### PR TITLE
feat(async): cv parsing jobs migration and alembic registry

### DIFF
--- a/apps/backend/alembic/env.py
+++ b/apps/backend/alembic/env.py
@@ -11,7 +11,12 @@ from alembic import context
 from hrm_backend.audit.models.event import AuditEvent  # noqa: F401
 from hrm_backend.auth.models.employee_registration_key import EmployeeRegistrationKey  # noqa: F401
 from hrm_backend.auth.models.staff_account import StaffAccount  # noqa: F401
+from hrm_backend.candidates.models.document import CandidateDocument  # noqa: F401
+from hrm_backend.candidates.models.parsing_job import CVParsingJob  # noqa: F401
+from hrm_backend.candidates.models.profile import CandidateProfile  # noqa: F401
 from hrm_backend.core.models.base import Base
+from hrm_backend.vacancies.models.pipeline_transition import PipelineTransition  # noqa: F401
+from hrm_backend.vacancies.models.vacancy import Vacancy  # noqa: F401
 
 config = context.config
 

--- a/apps/backend/alembic/versions/20260304_000006_cv_parsing_jobs.py
+++ b/apps/backend/alembic/versions/20260304_000006_cv_parsing_jobs.py
@@ -1,0 +1,69 @@
+"""create cv parsing jobs table
+
+Revision ID: 20260304000006
+Revises: 20260304000005
+Create Date: 2026-03-04 16:30:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260304000006"
+down_revision = "20260304000005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create async CV parsing job table with lifecycle indexes."""
+    op.create_table(
+        "cv_parsing_jobs",
+        sa.Column("job_id", sa.String(length=36), nullable=False),
+        sa.Column("candidate_id", sa.String(length=36), nullable=False),
+        sa.Column("document_id", sa.String(length=36), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("attempt_count", sa.Integer(), nullable=False),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("queued_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["candidate_id"],
+            ["candidate_profiles.candidate_id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["document_id"],
+            ["candidate_documents.document_id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("job_id"),
+    )
+    op.create_index("ix_cv_parsing_jobs_status", "cv_parsing_jobs", ["status"], unique=False)
+    op.create_index("ix_cv_parsing_jobs_queued_at", "cv_parsing_jobs", ["queued_at"], unique=False)
+    op.create_index(
+        "ix_cv_parsing_jobs_candidate_id",
+        "cv_parsing_jobs",
+        ["candidate_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_cv_parsing_jobs_document_id",
+        "cv_parsing_jobs",
+        ["document_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop async CV parsing job table and supporting indexes."""
+    op.drop_index("ix_cv_parsing_jobs_document_id", table_name="cv_parsing_jobs")
+    op.drop_index("ix_cv_parsing_jobs_candidate_id", table_name="cv_parsing_jobs")
+    op.drop_index("ix_cv_parsing_jobs_queued_at", table_name="cv_parsing_jobs")
+    op.drop_index("ix_cv_parsing_jobs_status", table_name="cv_parsing_jobs")
+    op.drop_table("cv_parsing_jobs")


### PR DESCRIPTION
## Scope\n- add cv_parsing_jobs migration as the next revision in chain\n- register recruitment models in Alembic metadata\n\n## Goal\n- close async CV parsing lifecycle storage contract\n- keep migration chain linear for sequential PR merge\n\n## Verification\n- ./scripts/check-docs-structure.sh\n- uv run --project apps/backend ruff check .\n- uv run --project apps/backend pytest -q\n- docker compose run --rm frontend npm run lint\n- docker compose run --rm frontend npm run test -- --run