### PR TITLE
PR-C: Normalize remaining API ID contracts to UUID

### DIFF
--- a/apps/backend/src/hrm_backend/candidates/routers/v1.py
+++ b/apps/backend/src/hrm_backend/candidates/routers/v1.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from io import BytesIO
 from typing import Annotated
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
 from fastapi.responses import StreamingResponse
@@ -59,7 +60,7 @@ def create_candidate_profile(
 
 @router.get("/{candidate_id}", response_model=CandidateResponse)
 def get_candidate_profile(
-    candidate_id: str,
+    candidate_id: UUID,
     request: Request,
     _: CandidateReadRole,
     auth_context: CurrentAuthContext,
@@ -75,7 +76,7 @@ def get_candidate_profile(
 
 @router.patch("/{candidate_id}", response_model=CandidateResponse)
 def patch_candidate_profile(
-    candidate_id: str,
+    candidate_id: UUID,
     payload: CandidateUpdateRequest,
     request: Request,
     _: CandidateUpdateRole,
@@ -104,7 +105,7 @@ def list_candidate_profiles(
 
 @router.post("/{candidate_id}/cv", response_model=CandidateCVUploadResponse)
 async def upload_candidate_cv(
-    candidate_id: str,
+    candidate_id: UUID,
     request: Request,
     checksum_sha256: Annotated[str, Form(min_length=64, max_length=64)],
     file: Annotated[UploadFile, File(...)],
@@ -124,7 +125,7 @@ async def upload_candidate_cv(
 
 @router.get("/{candidate_id}/cv")
 def download_candidate_cv(
-    candidate_id: str,
+    candidate_id: UUID,
     request: Request,
     _: CandidateCVReadRole,
     auth_context: CurrentAuthContext,
@@ -143,7 +144,7 @@ def download_candidate_cv(
 
 @router.get("/{candidate_id}/cv/parsing-status", response_model=CVParsingStatusResponse)
 def get_candidate_cv_parsing_status(
-    candidate_id: str,
+    candidate_id: UUID,
     request: Request,
     _: CandidateCVStatusRole,
     auth_context: CurrentAuthContext,

--- a/apps/backend/src/hrm_backend/candidates/schemas/cv.py
+++ b/apps/backend/src/hrm_backend/candidates/schemas/cv.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from uuid import UUID
 
 from pydantic import BaseModel
 
@@ -10,8 +11,8 @@ from pydantic import BaseModel
 class CandidateCVUploadResponse(BaseModel):
     """Metadata payload returned after successful CV upload."""
 
-    document_id: str
-    candidate_id: str
+    document_id: UUID
+    candidate_id: UUID
     filename: str
     mime_type: str
     size_bytes: int

--- a/apps/backend/src/hrm_backend/candidates/schemas/parsing.py
+++ b/apps/backend/src/hrm_backend/candidates/schemas/parsing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Literal
+from uuid import UUID
 
 from pydantic import BaseModel
 
@@ -13,9 +14,9 @@ CVParsingStatus = Literal["queued", "running", "succeeded", "failed"]
 class CVParsingStatusResponse(BaseModel):
     """Current parsing job status for candidate CV."""
 
-    candidate_id: str
-    document_id: str
-    job_id: str
+    candidate_id: UUID
+    document_id: UUID
+    job_id: UUID
     status: CVParsingStatus
     attempt_count: int
     last_error: str | None

--- a/apps/backend/src/hrm_backend/candidates/schemas/profile.py
+++ b/apps/backend/src/hrm_backend/candidates/schemas/profile.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Any
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -71,7 +72,7 @@ class CandidateUpdateRequest(BaseModel):
 class CandidateResponse(BaseModel):
     """Candidate profile API representation."""
 
-    candidate_id: str
+    candidate_id: UUID
     owner_subject_id: str
     first_name: str
     last_name: str

--- a/apps/backend/src/hrm_backend/candidates/services/candidate_service.py
+++ b/apps/backend/src/hrm_backend/candidates/services/candidate_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from fastapi import HTTPException, Request, UploadFile, status
 
@@ -104,7 +104,7 @@ class CandidateService:
     def get_profile(
         self,
         *,
-        candidate_id: str,
+        candidate_id: UUID,
         auth_context: AuthContext,
         request: Request,
     ) -> CandidateResponse:
@@ -167,7 +167,7 @@ class CandidateService:
     def update_profile(
         self,
         *,
-        candidate_id: str,
+        candidate_id: UUID,
         payload: CandidateUpdateRequest,
         auth_context: AuthContext,
         request: Request,
@@ -206,7 +206,7 @@ class CandidateService:
     async def upload_cv(
         self,
         *,
-        candidate_id: str,
+        candidate_id: UUID,
         file: UploadFile,
         checksum_sha256: str,
         auth_context: AuthContext,
@@ -231,6 +231,7 @@ class CandidateService:
             request=request,
             action="candidate_cv:upload",
         )
+        candidate_id_str = str(candidate_id)
         payload = await file.read()
         validated = validate_cv_payload(
             filename=file.filename or "cv",
@@ -241,7 +242,9 @@ class CandidateService:
             max_size_bytes=self._settings.cv_max_size_bytes,
         )
 
-        object_key = f"candidates/{candidate_id}/cv/{uuid4().hex}-{(file.filename or 'cv').strip()}"
+        object_key = (
+            f"candidates/{candidate_id_str}/cv/{uuid4().hex}-{(file.filename or 'cv').strip()}"
+        )
         self._storage.put_object(
             object_key=object_key,
             data=validated.content,
@@ -249,9 +252,9 @@ class CandidateService:
             enable_sse=self._settings.object_storage_sse_enabled,
         )
 
-        self._document_dao.deactivate_active_documents(candidate_id)
+        self._document_dao.deactivate_active_documents(candidate_id_str)
         doc = self._document_dao.create_document(
-            candidate_id=candidate_id,
+            candidate_id=candidate_id_str,
             object_key=object_key,
             filename=file.filename or "cv",
             mime_type=validated.mime_type,
@@ -260,7 +263,7 @@ class CandidateService:
             is_active=True,
         )
         parsing_job = self._parsing_job_dao.create_queued_job(
-            candidate_id=candidate_id,
+            candidate_id=candidate_id_str,
             document_id=doc.document_id,
         )
         enqueue_cv_parsing(job_id=parsing_job.job_id)
@@ -277,8 +280,8 @@ class CandidateService:
         )
 
         return CandidateCVUploadResponse(
-            document_id=doc.document_id,
-            candidate_id=doc.candidate_id,
+            document_id=UUID(doc.document_id),
+            candidate_id=UUID(doc.candidate_id),
             filename=doc.filename,
             mime_type=doc.mime_type,
             size_bytes=doc.size_bytes,
@@ -289,7 +292,7 @@ class CandidateService:
     def download_cv(
         self,
         *,
-        candidate_id: str,
+        candidate_id: UUID,
         auth_context: AuthContext,
         request: Request,
     ) -> CandidateCVDownloadPayload:
@@ -332,7 +335,7 @@ class CandidateService:
     def get_parsing_status(
         self,
         *,
-        candidate_id: str,
+        candidate_id: UUID,
         auth_context: AuthContext,
         request: Request,
     ) -> CVParsingStatusResponse:
@@ -365,9 +368,9 @@ class CandidateService:
             resource_id=job.job_id,
         )
         return CVParsingStatusResponse(
-            candidate_id=job.candidate_id,
-            document_id=job.document_id,
-            job_id=job.job_id,
+            candidate_id=UUID(job.candidate_id),
+            document_id=UUID(job.document_id),
+            job_id=UUID(job.job_id),
             status=job.status,  # type: ignore[arg-type]
             attempt_count=job.attempt_count,
             last_error=job.last_error,
@@ -393,7 +396,7 @@ class CandidateService:
             return requested_owner.strip()
         return str(auth_context.subject_id)
 
-    def _get_profile_or_404(self, candidate_id: str) -> CandidateProfile:
+    def _get_profile_or_404(self, candidate_id: UUID) -> CandidateProfile:
         """Load profile or raise 404.
 
         Args:
@@ -402,12 +405,12 @@ class CandidateService:
         Returns:
             CandidateProfile: Loaded profile entity.
         """
-        entity = self._profile_dao.get_by_id(candidate_id)
+        entity = self._profile_dao.get_by_id(str(candidate_id))
         if entity is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Candidate not found")
         return entity
 
-    def _get_active_document_or_404(self, candidate_id: str) -> CandidateDocument:
+    def _get_active_document_or_404(self, candidate_id: UUID) -> CandidateDocument:
         """Load active candidate CV row or raise 404.
 
         Args:
@@ -416,7 +419,7 @@ class CandidateService:
         Returns:
             CandidateDocument: Active CV metadata row.
         """
-        entity = self._document_dao.get_active_document(candidate_id)
+        entity = self._document_dao.get_active_document(str(candidate_id))
         if entity is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -424,7 +427,7 @@ class CandidateService:
             )
         return entity
 
-    def _get_latest_job_or_404(self, candidate_id: str) -> CVParsingJob:
+    def _get_latest_job_or_404(self, candidate_id: UUID) -> CVParsingJob:
         """Load latest parsing job row or raise 404.
 
         Args:
@@ -433,7 +436,7 @@ class CandidateService:
         Returns:
             CVParsingJob: Latest parsing job entity.
         """
-        job = self._parsing_job_dao.get_latest_by_candidate(candidate_id)
+        job = self._parsing_job_dao.get_latest_by_candidate(str(candidate_id))
         if job is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -512,7 +515,7 @@ def _to_candidate_response(entity: CandidateProfile) -> CandidateResponse:
         CandidateResponse: API response payload.
     """
     return CandidateResponse(
-        candidate_id=entity.candidate_id,
+        candidate_id=UUID(entity.candidate_id),
         owner_subject_id=entity.owner_subject_id,
         first_name=entity.first_name,
         last_name=entity.last_name,

--- a/apps/backend/src/hrm_backend/vacancies/routers/v1.py
+++ b/apps/backend/src/hrm_backend/vacancies/routers/v1.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Annotated
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
 
@@ -65,7 +66,7 @@ def list_vacancies(
 
 @router.get("/api/v1/vacancies/{vacancy_id}", response_model=VacancyResponse)
 def get_vacancy(
-    vacancy_id: str,
+    vacancy_id: UUID,
     request: Request,
     _: VacancyReadRole,
     auth_context: CurrentAuthContext,
@@ -77,7 +78,7 @@ def get_vacancy(
 
 @router.patch("/api/v1/vacancies/{vacancy_id}", response_model=VacancyResponse)
 def patch_vacancy(
-    vacancy_id: str,
+    vacancy_id: UUID,
     payload: VacancyUpdateRequest,
     request: Request,
     _: VacancyUpdateRole,
@@ -134,7 +135,7 @@ def create_pipeline_transition(
     },
 )
 async def apply_to_vacancy_public(
-    vacancy_id: str,
+    vacancy_id: UUID,
     request: Request,
     first_name: Annotated[str, Form(min_length=1, max_length=128)],
     last_name: Annotated[str, Form(min_length=1, max_length=128)],

--- a/apps/backend/src/hrm_backend/vacancies/schemas/pipeline.py
+++ b/apps/backend/src/hrm_backend/vacancies/schemas/pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Literal
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -23,8 +24,8 @@ class PipelineTransitionCreateRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    vacancy_id: str = Field(min_length=1, max_length=36)
-    candidate_id: str = Field(min_length=1, max_length=36)
+    vacancy_id: UUID
+    candidate_id: UUID
     to_stage: PipelineStage
     reason: str | None = Field(default=None, max_length=2048)
 
@@ -32,9 +33,9 @@ class PipelineTransitionCreateRequest(BaseModel):
 class PipelineTransitionResponse(BaseModel):
     """Pipeline transition API representation."""
 
-    transition_id: str
-    vacancy_id: str
-    candidate_id: str
+    transition_id: UUID
+    vacancy_id: UUID
+    candidate_id: UUID
     from_stage: PipelineStage | None
     to_stage: PipelineStage
     reason: str | None

--- a/apps/backend/src/hrm_backend/vacancies/schemas/vacancy.py
+++ b/apps/backend/src/hrm_backend/vacancies/schemas/vacancy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -32,7 +33,7 @@ class VacancyUpdateRequest(BaseModel):
 class VacancyResponse(BaseModel):
     """Vacancy API representation."""
 
-    vacancy_id: str
+    vacancy_id: UUID
     title: str
     description: str
     department: str

--- a/apps/backend/src/hrm_backend/vacancies/services/application_service.py
+++ b/apps/backend/src/hrm_backend/vacancies/services/application_service.py
@@ -73,7 +73,7 @@ class VacancyApplicationService:
     async def apply_public(
         self,
         *,
-        vacancy_id: str,
+        vacancy_id: UUID,
         first_name: str,
         last_name: str,
         email: str,
@@ -207,7 +207,7 @@ class VacancyApplicationService:
                 vacancy_id=vacancy_id_str,
             )
             return PublicVacancyApplicationResponse(
-                vacancy_id=UUID(vacancy_id),
+                vacancy_id=vacancy_id,
                 candidate_id=UUID(candidate.candidate_id),
                 document_id=UUID(document.document_id),
                 parsing_job_id=UUID(parsing_job.job_id),

--- a/apps/backend/src/hrm_backend/vacancies/services/vacancy_service.py
+++ b/apps/backend/src/hrm_backend/vacancies/services/vacancy_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from uuid import UUID
+
 from fastapi import HTTPException, Request, status
 
 from hrm_backend.audit.services.audit_service import AuditService, actor_from_auth_context
@@ -89,12 +91,12 @@ class VacancyService:
     def get_vacancy(
         self,
         *,
-        vacancy_id: str,
+        vacancy_id: UUID,
         auth_context: AuthContext,
         request: Request,
     ) -> VacancyResponse:
         """Load one vacancy or raise 404."""
-        entity = self._vacancy_dao.get_by_id(vacancy_id)
+        entity = self._vacancy_dao.get_by_id(str(vacancy_id))
         if entity is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Vacancy not found")
 
@@ -113,13 +115,13 @@ class VacancyService:
     def update_vacancy(
         self,
         *,
-        vacancy_id: str,
+        vacancy_id: UUID,
         payload: VacancyUpdateRequest,
         auth_context: AuthContext,
         request: Request,
     ) -> VacancyResponse:
         """Patch vacancy row and emit audit event."""
-        entity = self._vacancy_dao.get_by_id(vacancy_id)
+        entity = self._vacancy_dao.get_by_id(str(vacancy_id))
         if entity is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Vacancy not found")
         updated = self._vacancy_dao.update_vacancy(entity=entity, payload=payload)
@@ -143,17 +145,20 @@ class VacancyService:
         request: Request,
     ) -> PipelineTransitionResponse:
         """Append candidate pipeline transition if allowed by canonical matrix."""
-        vacancy = self._vacancy_dao.get_by_id(payload.vacancy_id)
+        vacancy_id = str(payload.vacancy_id)
+        candidate_id = str(payload.candidate_id)
+
+        vacancy = self._vacancy_dao.get_by_id(vacancy_id)
         if vacancy is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Vacancy not found")
 
-        candidate = self._candidate_profile_dao.get_by_id(payload.candidate_id)
+        candidate = self._candidate_profile_dao.get_by_id(candidate_id)
         if candidate is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Candidate not found")
 
         previous = self._transition_dao.get_last_transition(
-            vacancy_id=payload.vacancy_id,
-            candidate_id=payload.candidate_id,
+            vacancy_id=vacancy_id,
+            candidate_id=candidate_id,
         )
         from_stage = None if previous is None else previous.to_stage
         if not is_transition_allowed(from_stage=from_stage, to_stage=payload.to_stage):
@@ -166,8 +171,8 @@ class VacancyService:
 
         actor_sub, actor_role = actor_from_auth_context(auth_context)
         transition = self._transition_dao.create_transition(
-            vacancy_id=payload.vacancy_id,
-            candidate_id=payload.candidate_id,
+            vacancy_id=vacancy_id,
+            candidate_id=candidate_id,
             from_stage=from_stage,
             to_stage=payload.to_stage,
             reason=payload.reason,
@@ -185,9 +190,9 @@ class VacancyService:
         )
 
         return PipelineTransitionResponse(
-            transition_id=transition.transition_id,
-            vacancy_id=transition.vacancy_id,
-            candidate_id=transition.candidate_id,
+            transition_id=UUID(transition.transition_id),
+            vacancy_id=UUID(transition.vacancy_id),
+            candidate_id=UUID(transition.candidate_id),
             from_stage=transition.from_stage,  # type: ignore[arg-type]
             to_stage=transition.to_stage,  # type: ignore[arg-type]
             reason=transition.reason,
@@ -207,7 +212,7 @@ def _to_vacancy_response(entity) -> VacancyResponse:
         VacancyResponse: API payload.
     """
     return VacancyResponse(
-        vacancy_id=entity.vacancy_id,
+        vacancy_id=UUID(entity.vacancy_id),
         title=entity.title,
         description=entity.description,
         department=entity.department,

--- a/apps/backend/tests/integration/candidates/test_candidate_api.py
+++ b/apps/backend/tests/integration/candidates/test_candidate_api.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
-from uuid import uuid4
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 import pytest
-from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 
@@ -18,6 +18,8 @@ from hrm_backend.candidates.dependencies.candidates import get_candidate_storage
 from hrm_backend.core.models.base import Base
 from hrm_backend.main import app
 from hrm_backend.settings import AppSettings, get_settings
+
+pytestmark = pytest.mark.anyio
 
 
 class InMemoryCandidateStorage:
@@ -105,63 +107,76 @@ def _load_events(database_url: str) -> list[AuditEvent]:
         engine.dispose()
 
 
-def test_candidate_crud_and_ownership_deny_are_enforced(configured_app) -> None:
+@pytest.fixture()
+async def api_client(configured_app) -> AsyncClient:
+    """Provide async API client for candidate integration tests."""
+    configured, *_ = configured_app
+    async with AsyncClient(
+        transport=ASGITransport(app=configured),
+        base_url="http://testserver",
+    ) as client:
+        yield client
+
+
+async def test_candidate_crud_and_ownership_deny_are_enforced(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
     """Verify candidate CRUD with RBAC deny trace for non-privileged staff role."""
-    configured, context_holder, _, database_url = configured_app
+    _, context_holder, _, database_url = configured_app
 
-    with TestClient(configured) as client:
-        create_response = client.post(
-            "/api/v1/candidates",
-            json={
-                "owner_subject_id": "another-owner",
-                "first_name": "Alice",
-                "last_name": "Doe",
-                "email": "Alice@example.com",
-                "phone": "+375291112233",
-                "location": "Minsk",
-                "current_title": "Backend Engineer",
-                "extra_data": {"stack": "python"},
-            },
-        )
-        assert create_response.status_code == 200
-        payload = create_response.json()
-        candidate_id = payload["candidate_id"]
-        assert payload["owner_subject_id"] == "another-owner"
-        assert payload["email"] == "alice@example.com"
+    create_response = await api_client.post(
+        "/api/v1/candidates",
+        json={
+            "owner_subject_id": "another-owner",
+            "first_name": "Alice",
+            "last_name": "Doe",
+            "email": "Alice@example.com",
+            "phone": "+375291112233",
+            "location": "Minsk",
+            "current_title": "Backend Engineer",
+            "extra_data": {"stack": "python"},
+        },
+    )
+    assert create_response.status_code == 200
+    payload = create_response.json()
+    candidate_id = payload["candidate_id"]
+    assert payload["owner_subject_id"] == "another-owner"
+    assert payload["email"] == "alice@example.com"
 
-        get_response = client.get(f"/api/v1/candidates/{candidate_id}")
-        assert get_response.status_code == 200
+    get_response = await api_client.get(f"/api/v1/candidates/{candidate_id}")
+    assert get_response.status_code == 200
 
-        patch_response = client.patch(
-            f"/api/v1/candidates/{candidate_id}",
-            json={"current_title": "Senior Backend Engineer"},
-        )
-        assert patch_response.status_code == 200
-        assert patch_response.json()["current_title"] == "Senior Backend Engineer"
+    patch_response = await api_client.patch(
+        f"/api/v1/candidates/{candidate_id}",
+        json={"current_title": "Senior Backend Engineer"},
+    )
+    assert patch_response.status_code == 200
+    assert patch_response.json()["current_title"] == "Senior Backend Engineer"
 
-        context_holder["context"] = AuthContext(
-            subject_id=uuid4(),
-            role="manager",
-            session_id=uuid4(),
-            token_id=uuid4(),
-            expires_at=9999999999,
-        )
-        forbidden_get = client.get(f"/api/v1/candidates/{candidate_id}")
-        assert forbidden_get.status_code == 403
+    context_holder["context"] = AuthContext(
+        subject_id=uuid5(NAMESPACE_URL, "manager-ctx"),
+        role="manager",
+        session_id=uuid4(),
+        token_id=uuid4(),
+        expires_at=9999999999,
+    )
+    forbidden_get = await api_client.get(f"/api/v1/candidates/{candidate_id}")
+    assert forbidden_get.status_code == 403
 
-        forbidden_list = client.get("/api/v1/candidates")
-        assert forbidden_list.status_code == 403
+    forbidden_list = await api_client.get("/api/v1/candidates")
+    assert forbidden_list.status_code == 403
 
-        context_holder["context"] = AuthContext(
-            subject_id=uuid4(),
-            role="hr",
-            session_id=uuid4(),
-            token_id=uuid4(),
-            expires_at=9999999999,
-        )
-        list_response = client.get("/api/v1/candidates")
-        assert list_response.status_code == 200
-        assert len(list_response.json()["items"]) == 1
+    context_holder["context"] = AuthContext(
+        subject_id=uuid4(),
+        role="hr",
+        session_id=uuid4(),
+        token_id=uuid4(),
+        expires_at=9999999999,
+    )
+    list_response = await api_client.get("/api/v1/candidates")
+    assert list_response.status_code == 200
+    assert len(list_response.json()["items"]) == 1
 
     events = _load_events(database_url)
     permission_denials = [
@@ -174,73 +189,97 @@ def test_candidate_crud_and_ownership_deny_are_enforced(configured_app) -> None:
     assert "has no permission" in (permission_denials[0].reason or "")
 
 
-def test_cv_upload_download_status_and_validation_failures(configured_app) -> None:
+async def test_cv_upload_download_status_and_validation_failures(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
     """Verify CV upload/download/status and validation error contracts."""
-    configured, context_holder, _, _ = configured_app
+    _, context_holder, _, _ = configured_app
 
-    with TestClient(configured) as client:
-        create_response = client.post(
-            "/api/v1/candidates",
-            json={
-                "first_name": "Bob",
-                "last_name": "Miller",
-                "email": "bob@example.com",
-                "extra_data": {},
-            },
-        )
-        candidate_id = create_response.json()["candidate_id"]
+    create_response = await api_client.post(
+        "/api/v1/candidates",
+        json={
+            "first_name": "Bob",
+            "last_name": "Miller",
+            "email": "bob@example.com",
+            "extra_data": {},
+        },
+    )
+    candidate_id = create_response.json()["candidate_id"]
 
-        valid_content = b"pdf-content"
-        valid_checksum = hashlib.sha256(valid_content).hexdigest()
-        upload_response = client.post(
-            f"/api/v1/candidates/{candidate_id}/cv",
-            data={"checksum_sha256": valid_checksum},
-            files={"file": ("cv.pdf", valid_content, "application/pdf")},
-        )
-        assert upload_response.status_code == 200
-        upload_payload = upload_response.json()
-        assert upload_payload["size_bytes"] == len(valid_content)
+    valid_content = b"pdf-content"
+    valid_checksum = hashlib.sha256(valid_content).hexdigest()
+    upload_response = await api_client.post(
+        f"/api/v1/candidates/{candidate_id}/cv",
+        data={"checksum_sha256": valid_checksum},
+        files={"file": ("cv.pdf", valid_content, "application/pdf")},
+    )
+    assert upload_response.status_code == 200
+    upload_payload = upload_response.json()
+    assert upload_payload["size_bytes"] == len(valid_content)
 
-        download_response = client.get(f"/api/v1/candidates/{candidate_id}/cv")
-        assert download_response.status_code == 200
-        assert download_response.content == valid_content
-        assert "attachment; filename=\"cv.pdf\"" in download_response.headers["content-disposition"]
+    download_response = await api_client.get(f"/api/v1/candidates/{candidate_id}/cv")
+    assert download_response.status_code == 200
+    assert download_response.content == valid_content
+    assert "attachment; filename=\"cv.pdf\"" in download_response.headers["content-disposition"]
 
-        status_response = client.get(f"/api/v1/candidates/{candidate_id}/cv/parsing-status")
-        assert status_response.status_code == 200
-        assert status_response.json()["status"] == "queued"
+    status_response = await api_client.get(f"/api/v1/candidates/{candidate_id}/cv/parsing-status")
+    assert status_response.status_code == 200
+    assert status_response.json()["status"] == "queued"
 
-        bad_mime_content = b"plain-text"
-        bad_mime_checksum = hashlib.sha256(bad_mime_content).hexdigest()
-        bad_mime_response = client.post(
-            f"/api/v1/candidates/{candidate_id}/cv",
-            data={"checksum_sha256": bad_mime_checksum},
-            files={"file": ("cv.txt", bad_mime_content, "text/plain")},
-        )
-        assert bad_mime_response.status_code == 415
+    bad_mime_content = b"plain-text"
+    bad_mime_checksum = hashlib.sha256(bad_mime_content).hexdigest()
+    bad_mime_response = await api_client.post(
+        f"/api/v1/candidates/{candidate_id}/cv",
+        data={"checksum_sha256": bad_mime_checksum},
+        files={"file": ("cv.txt", bad_mime_content, "text/plain")},
+    )
+    assert bad_mime_response.status_code == 415
 
-        bad_checksum_response = client.post(
-            f"/api/v1/candidates/{candidate_id}/cv",
-            data={"checksum_sha256": "0" * 64},
-            files={"file": ("cv.pdf", valid_content, "application/pdf")},
-        )
-        assert bad_checksum_response.status_code == 422
+    bad_checksum_response = await api_client.post(
+        f"/api/v1/candidates/{candidate_id}/cv",
+        data={"checksum_sha256": "0" * 64},
+        files={"file": ("cv.pdf", valid_content, "application/pdf")},
+    )
+    assert bad_checksum_response.status_code == 422
 
-        oversized_content = b"x" * 33
-        oversized_checksum = hashlib.sha256(oversized_content).hexdigest()
-        oversized_response = client.post(
-            f"/api/v1/candidates/{candidate_id}/cv",
-            data={"checksum_sha256": oversized_checksum},
-            files={"file": ("cv.pdf", oversized_content, "application/pdf")},
-        )
-        assert oversized_response.status_code == 413
+    oversized_content = b"x" * 33
+    oversized_checksum = hashlib.sha256(oversized_content).hexdigest()
+    oversized_response = await api_client.post(
+        f"/api/v1/candidates/{candidate_id}/cv",
+        data={"checksum_sha256": oversized_checksum},
+        files={"file": ("cv.pdf", oversized_content, "application/pdf")},
+    )
+    assert oversized_response.status_code == 413
 
-        context_holder["context"] = AuthContext(
-            subject_id=uuid4(),
-            role="manager",
-            session_id=uuid4(),
-            token_id=uuid4(),
-            expires_at=9999999999,
-        )
-        denied_status = client.get(f"/api/v1/candidates/{candidate_id}/cv/parsing-status")
-        assert denied_status.status_code == 403
+    context_holder["context"] = AuthContext(
+        subject_id=uuid4(),
+        role="manager",
+        session_id=uuid4(),
+        token_id=uuid4(),
+        expires_at=9999999999,
+    )
+    denied_status = await api_client.get(f"/api/v1/candidates/{candidate_id}/cv/parsing-status")
+    assert denied_status.status_code == 403
+
+
+async def test_candidate_uuid_boundaries_reject_invalid_ids(
+    api_client: AsyncClient,
+) -> None:
+    """Verify candidate endpoints reject non-UUID path identifiers with 422."""
+    invalid_id = "candidate-not-uuid"
+
+    get_response = await api_client.get(f"/api/v1/candidates/{invalid_id}")
+    assert get_response.status_code == 422
+
+    content = b"uuid-boundary-cv"
+    checksum = hashlib.sha256(content).hexdigest()
+    upload_response = await api_client.post(
+        f"/api/v1/candidates/{invalid_id}/cv",
+        data={"checksum_sha256": checksum},
+        files={"file": ("cv.pdf", content, "application/pdf")},
+    )
+    assert upload_response.status_code == 422
+
+    status_response = await api_client.get(f"/api/v1/candidates/{invalid_id}/cv/parsing-status")
+    assert status_response.status_code == 422

--- a/apps/backend/tests/integration/candidates/test_cv_parsing_jobs.py
+++ b/apps/backend/tests/integration/candidates/test_cv_parsing_jobs.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
-from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
@@ -22,6 +22,8 @@ from hrm_backend.candidates.services.cv_parsing_worker_service import CVParsingW
 from hrm_backend.core.models.base import Base
 from hrm_backend.main import app
 from hrm_backend.settings import AppSettings, get_settings
+
+pytestmark = pytest.mark.anyio
 
 
 class InMemoryCandidateStorage:
@@ -117,68 +119,82 @@ def _run_worker_once(
         engine.dispose()
 
 
-def test_parsing_job_success_and_status_tracking(configured_app) -> None:
+@pytest.fixture()
+async def api_client(configured_app) -> AsyncClient:
+    """Provide async API client for parsing integration tests."""
+    configured, *_ = configured_app
+    async with AsyncClient(
+        transport=ASGITransport(app=configured),
+        base_url="http://testserver",
+    ) as client:
+        yield client
+
+
+async def test_parsing_job_success_and_status_tracking(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
     """Verify queued job moves to succeeded state after worker iteration."""
-    configured, settings, _, storage, database_url = configured_app
+    _, settings, _, storage, database_url = configured_app
 
-    with TestClient(configured) as client:
-        candidate_response = client.post(
-            "/api/v1/candidates",
-            json={
-                "first_name": "Nina",
-                "last_name": "Stone",
-                "email": "nina@example.com",
-                "extra_data": {},
-            },
-        )
-        candidate_id = candidate_response.json()["candidate_id"]
+    candidate_response = await api_client.post(
+        "/api/v1/candidates",
+        json={
+            "first_name": "Nina",
+            "last_name": "Stone",
+            "email": "nina@example.com",
+            "extra_data": {},
+        },
+    )
+    candidate_id = candidate_response.json()["candidate_id"]
 
-        content = b"normal-parse-content"
-        checksum = hashlib.sha256(content).hexdigest()
-        upload_response = client.post(
-            f"/api/v1/candidates/{candidate_id}/cv",
-            data={"checksum_sha256": checksum},
-            files={"file": ("cv.pdf", content, "application/pdf")},
-        )
-        assert upload_response.status_code == 200
+    content = b"normal-parse-content"
+    checksum = hashlib.sha256(content).hexdigest()
+    upload_response = await api_client.post(
+        f"/api/v1/candidates/{candidate_id}/cv",
+        data={"checksum_sha256": checksum},
+        files={"file": ("cv.pdf", content, "application/pdf")},
+    )
+    assert upload_response.status_code == 200
 
-        pre_status = client.get(f"/api/v1/candidates/{candidate_id}/cv/parsing-status")
-        assert pre_status.status_code == 200
-        assert pre_status.json()["status"] == "queued"
+    pre_status = await api_client.get(f"/api/v1/candidates/{candidate_id}/cv/parsing-status")
+    assert pre_status.status_code == 200
+    assert pre_status.json()["status"] == "queued"
 
     first_worker_result = _run_worker_once(database_url, settings, storage)
     assert first_worker_result == "succeeded"
 
-    with TestClient(configured) as client:
-        post_status = client.get(f"/api/v1/candidates/{candidate_id}/cv/parsing-status")
-        assert post_status.status_code == 200
-        assert post_status.json()["status"] == "succeeded"
+    post_status = await api_client.get(f"/api/v1/candidates/{candidate_id}/cv/parsing-status")
+    assert post_status.status_code == 200
+    assert post_status.json()["status"] == "succeeded"
 
 
-def test_parsing_job_failure_path_and_retry_limit(configured_app) -> None:
+async def test_parsing_job_failure_path_and_retry_limit(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
     """Verify failure path retries up to configured limit and then stops."""
-    configured, settings, _, storage, database_url = configured_app
+    _, settings, _, storage, database_url = configured_app
 
-    with TestClient(configured) as client:
-        candidate_response = client.post(
-            "/api/v1/candidates",
-            json={
-                "first_name": "Tom",
-                "last_name": "Green",
-                "email": "tom@example.com",
-                "extra_data": {},
-            },
-        )
-        candidate_id = candidate_response.json()["candidate_id"]
+    candidate_response = await api_client.post(
+        "/api/v1/candidates",
+        json={
+            "first_name": "Tom",
+            "last_name": "Green",
+            "email": "tom@example.com",
+            "extra_data": {},
+        },
+    )
+    candidate_id = candidate_response.json()["candidate_id"]
 
-        content = b"FAIL_PARSE deterministic-failure"
-        checksum = hashlib.sha256(content).hexdigest()
-        upload_response = client.post(
-            f"/api/v1/candidates/{candidate_id}/cv",
-            data={"checksum_sha256": checksum},
-            files={"file": ("cv.pdf", content, "application/pdf")},
-        )
-        assert upload_response.status_code == 200
+    content = b"FAIL_PARSE deterministic-failure"
+    checksum = hashlib.sha256(content).hexdigest()
+    upload_response = await api_client.post(
+        f"/api/v1/candidates/{candidate_id}/cv",
+        data={"checksum_sha256": checksum},
+        files={"file": ("cv.pdf", content, "application/pdf")},
+    )
+    assert upload_response.status_code == 200
 
     first_worker_result = _run_worker_once(database_url, settings, storage)
     second_worker_result = _run_worker_once(database_url, settings, storage)
@@ -188,10 +204,9 @@ def test_parsing_job_failure_path_and_retry_limit(configured_app) -> None:
     assert second_worker_result == "failed"
     assert third_worker_result == "idle"
 
-    with TestClient(configured) as client:
-        status_response = client.get(f"/api/v1/candidates/{candidate_id}/cv/parsing-status")
-        assert status_response.status_code == 200
-        payload = status_response.json()
-        assert payload["status"] == "failed"
-        assert payload["attempt_count"] == 2
-        assert payload["last_error"] is not None
+    status_response = await api_client.get(f"/api/v1/candidates/{candidate_id}/cv/parsing-status")
+    assert status_response.status_code == 200
+    payload = status_response.json()
+    assert payload["status"] == "failed"
+    assert payload["attempt_count"] == 2
+    assert payload["last_error"] is not None

--- a/apps/backend/tests/integration/vacancies/test_vacancy_pipeline_api.py
+++ b/apps/backend/tests/integration/vacancies/test_vacancy_pipeline_api.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
-from uuid import uuid4
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 import pytest
-from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 
@@ -17,6 +18,8 @@ from hrm_backend.candidates.models.profile import CandidateProfile
 from hrm_backend.core.models.base import Base
 from hrm_backend.main import app
 from hrm_backend.settings import AppSettings, get_settings
+
+pytestmark = pytest.mark.anyio
 
 
 @pytest.fixture()
@@ -54,10 +57,12 @@ def configured_app(sqlite_database_url: str):
 
     engine = create_engine(sqlite_database_url, future=True)
     Base.metadata.create_all(engine)
+    candidate_1_id = str(uuid5(NAMESPACE_URL, "candidate-1"))
+    candidate_2_id = str(uuid5(NAMESPACE_URL, "candidate-2"))
     with Session(engine) as session:
         session.add(
             CandidateProfile(
-                candidate_id="cand-1",
+                candidate_id=candidate_1_id,
                 owner_subject_id="candidate-1",
                 first_name="A",
                 last_name="B",
@@ -70,7 +75,7 @@ def configured_app(sqlite_database_url: str):
         )
         session.add(
             CandidateProfile(
-                candidate_id="cand-2",
+                candidate_id=candidate_2_id,
                 owner_subject_id="candidate-2",
                 first_name="C",
                 last_name="D",
@@ -84,7 +89,7 @@ def configured_app(sqlite_database_url: str):
         session.commit()
 
     try:
-        yield app, context_holder, sqlite_database_url
+        yield app, context_holder, sqlite_database_url, candidate_1_id, candidate_2_id
     finally:
         app.dependency_overrides.pop(get_settings, None)
         app.dependency_overrides.pop(get_current_auth_context, None)
@@ -105,103 +110,118 @@ def _load_events(database_url: str) -> list[AuditEvent]:
         engine.dispose()
 
 
-def test_vacancy_crud_and_pipeline_transitions(configured_app) -> None:
+@pytest.fixture()
+async def api_client(configured_app) -> AsyncClient:
+    """Provide async API client for vacancy integration tests."""
+    configured, *_ = configured_app
+    async with AsyncClient(
+        transport=ASGITransport(app=configured),
+        base_url="http://testserver",
+    ) as client:
+        yield client
+
+
+async def test_vacancy_crud_and_pipeline_transitions(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
     """Verify vacancy CRUD and canonical pipeline transitions."""
-    configured, _, _ = configured_app
+    _, _, _, candidate_1_id, candidate_2_id = configured_app
 
-    with TestClient(configured) as client:
-        create_response = client.post(
-            "/api/v1/vacancies",
-            json={
-                "title": "ML Engineer",
-                "description": "Build matching services",
-                "department": "Engineering",
-                "status": "open",
-            },
-        )
-        assert create_response.status_code == 200
-        vacancy_id = create_response.json()["vacancy_id"]
+    create_response = await api_client.post(
+        "/api/v1/vacancies",
+        json={
+            "title": "ML Engineer",
+            "description": "Build matching services",
+            "department": "Engineering",
+            "status": "open",
+        },
+    )
+    assert create_response.status_code == 200
+    vacancy_id = create_response.json()["vacancy_id"]
 
-        list_response = client.get("/api/v1/vacancies")
-        assert list_response.status_code == 200
-        assert len(list_response.json()["items"]) == 1
+    list_response = await api_client.get("/api/v1/vacancies")
+    assert list_response.status_code == 200
+    assert len(list_response.json()["items"]) == 1
 
-        get_response = client.get(f"/api/v1/vacancies/{vacancy_id}")
-        assert get_response.status_code == 200
+    get_response = await api_client.get(f"/api/v1/vacancies/{vacancy_id}")
+    assert get_response.status_code == 200
 
-        patch_response = client.patch(
-            f"/api/v1/vacancies/{vacancy_id}",
-            json={"status": "active"},
-        )
-        assert patch_response.status_code == 200
-        assert patch_response.json()["status"] == "active"
+    patch_response = await api_client.patch(
+        f"/api/v1/vacancies/{vacancy_id}",
+        json={"status": "active"},
+    )
+    assert patch_response.status_code == 200
+    assert patch_response.json()["status"] == "active"
 
-        stages = [
-            "applied",
-            "screening",
-            "shortlist",
-            "interview",
-            "offer",
-            "hired",
-        ]
-        for stage in stages:
-            transition = client.post(
-                "/api/v1/pipeline/transitions",
-                json={
-                    "vacancy_id": vacancy_id,
-                    "candidate_id": "cand-1",
-                    "to_stage": stage,
-                    "reason": "progress",
-                },
-            )
-            assert transition.status_code == 200
-
-        invalid_transition = client.post(
+    stages = [
+        "applied",
+        "screening",
+        "shortlist",
+        "interview",
+        "offer",
+        "hired",
+    ]
+    for stage in stages:
+        transition = await api_client.post(
             "/api/v1/pipeline/transitions",
             json={
                 "vacancy_id": vacancy_id,
-                "candidate_id": "cand-2",
-                "to_stage": "offer",
-                "reason": "skip",
+                "candidate_id": candidate_1_id,
+                "to_stage": stage,
+                "reason": "progress",
             },
         )
-        assert invalid_transition.status_code == 422
-        assert "not allowed" in invalid_transition.json()["detail"]
+        assert transition.status_code == 200
+
+    invalid_transition = await api_client.post(
+        "/api/v1/pipeline/transitions",
+        json={
+            "vacancy_id": vacancy_id,
+            "candidate_id": candidate_2_id,
+            "to_stage": "offer",
+            "reason": "skip",
+        },
+    )
+    assert invalid_transition.status_code == 422
+    assert "not allowed" in invalid_transition.json()["detail"]
 
 
-def test_pipeline_transition_rbac_deny_is_audited(configured_app) -> None:
+async def test_pipeline_transition_rbac_deny_is_audited(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
     """Verify pipeline transition deny path records RBAC audit event."""
-    configured, context_holder, database_url = configured_app
+    _, context_holder, database_url, candidate_1_id, _ = configured_app
 
-    with TestClient(configured) as client:
-        create_response = client.post(
-            "/api/v1/vacancies",
-            json={
-                "title": "Data Engineer",
-                "description": "Build ETL",
-                "department": "Data",
-                "status": "open",
-            },
-        )
-        vacancy_id = create_response.json()["vacancy_id"]
+    create_response = await api_client.post(
+        "/api/v1/vacancies",
+        json={
+            "title": "Data Engineer",
+            "description": "Build ETL",
+            "department": "Data",
+            "status": "open",
+        },
+    )
+    vacancy_id = create_response.json()["vacancy_id"]
 
-        context_holder["context"] = AuthContext(
-            subject_id=uuid4(),
-            role="manager",
-            session_id=uuid4(),
-            token_id=uuid4(),
-            expires_at=9999999999,
-        )
-        denied_response = client.post(
-            "/api/v1/pipeline/transitions",
-            json={
-                "vacancy_id": vacancy_id,
-                "candidate_id": "cand-1",
-                "to_stage": "applied",
-                "reason": "self-move",
-            },
-        )
-        assert denied_response.status_code == 403
+    context_holder["context"] = AuthContext(
+        subject_id=uuid4(),
+        role="manager",
+        session_id=uuid4(),
+        token_id=uuid4(),
+        expires_at=9999999999,
+    )
+    denied_response = await api_client.post(
+        "/api/v1/pipeline/transitions",
+        json={
+            "vacancy_id": vacancy_id,
+            "candidate_id": candidate_1_id,
+            "to_stage": "applied",
+            "reason": "self-move",
+        },
+    )
+    assert denied_response.status_code == 403
 
     events = _load_events(database_url)
     denied_events = [
@@ -211,3 +231,111 @@ def test_pipeline_transition_rbac_deny_is_audited(configured_app) -> None:
     ]
     assert len(denied_events) >= 1
     assert denied_events[-1].actor_role == "manager"
+
+
+async def test_vacancy_and_pipeline_uuid_boundaries_reject_invalid_ids(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
+    """Verify vacancy and pipeline endpoints reject non-UUID identifiers with 422."""
+    _, _, _, candidate_1_id, _ = configured_app
+    invalid_vacancy_id = "vacancy-not-uuid"
+
+    get_response = await api_client.get(f"/api/v1/vacancies/{invalid_vacancy_id}")
+    assert get_response.status_code == 422
+
+    patch_response = await api_client.patch(
+        f"/api/v1/vacancies/{invalid_vacancy_id}",
+        json={"status": "open"},
+    )
+    assert patch_response.status_code == 422
+
+    content = b"public-apply-boundary"
+    checksum = hashlib.sha256(content).hexdigest()
+    apply_response = await api_client.post(
+        f"/api/v1/vacancies/{invalid_vacancy_id}/applications",
+        data={
+            "first_name": "Boundary",
+            "last_name": "Case",
+            "email": "boundary@example.com",
+            "phone": "+375291112233",
+            "checksum_sha256": checksum,
+        },
+        files={"file": ("cv.pdf", content, "application/pdf")},
+    )
+    assert apply_response.status_code == 422
+
+    invalid_vacancy_transition = await api_client.post(
+        "/api/v1/pipeline/transitions",
+        json={
+            "vacancy_id": invalid_vacancy_id,
+            "candidate_id": candidate_1_id,
+            "to_stage": "applied",
+            "reason": "invalid-vacancy-id",
+        },
+    )
+    assert invalid_vacancy_transition.status_code == 422
+
+    create_response = await api_client.post(
+        "/api/v1/vacancies",
+        json={
+            "title": "UUID Boundary Vacancy",
+            "description": "Boundary checks",
+            "department": "QA",
+            "status": "open",
+        },
+    )
+    assert create_response.status_code == 200
+    vacancy_id = create_response.json()["vacancy_id"]
+
+    invalid_candidate_transition = await api_client.post(
+        "/api/v1/pipeline/transitions",
+        json={
+            "vacancy_id": vacancy_id,
+            "candidate_id": "candidate-not-uuid",
+            "to_stage": "applied",
+            "reason": "invalid-candidate-id",
+        },
+    )
+    assert invalid_candidate_transition.status_code == 422
+
+
+async def test_openapi_exposes_uuid_format_for_normalized_id_contracts(
+    api_client: AsyncClient,
+) -> None:
+    """Verify OpenAPI reflects UUID typing for normalized API identifiers."""
+    response = await api_client.get("/openapi.json")
+    assert response.status_code == 200
+    spec = response.json()
+
+    schemas = spec["components"]["schemas"]
+    assert schemas["CandidateResponse"]["properties"]["candidate_id"]["format"] == "uuid"
+    assert schemas["CVParsingStatusResponse"]["properties"]["candidate_id"]["format"] == "uuid"
+    assert schemas["CVParsingStatusResponse"]["properties"]["document_id"]["format"] == "uuid"
+    assert schemas["CVParsingStatusResponse"]["properties"]["job_id"]["format"] == "uuid"
+    assert schemas["VacancyResponse"]["properties"]["vacancy_id"]["format"] == "uuid"
+    assert (
+        schemas["PipelineTransitionCreateRequest"]["properties"]["vacancy_id"]["format"] == "uuid"
+    )
+    assert (
+        schemas["PipelineTransitionCreateRequest"]["properties"]["candidate_id"]["format"]
+        == "uuid"
+    )
+    assert (
+        schemas["PipelineTransitionResponse"]["properties"]["transition_id"]["format"] == "uuid"
+    )
+
+    vacancy_get_parameters = spec["paths"]["/api/v1/vacancies/{vacancy_id}"]["get"]["parameters"]
+    candidate_get_parameters = spec["paths"]["/api/v1/candidates/{candidate_id}"]["get"][
+        "parameters"
+    ]
+    assert any(
+        parameter["name"] == "vacancy_id"
+        and parameter["schema"].get("format") == "uuid"
+        for parameter in vacancy_get_parameters
+    )
+    assert any(
+        parameter["name"] == "candidate_id"
+        and parameter["schema"].get("format") == "uuid"
+        for parameter in candidate_get_parameters
+    )

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -22,6 +22,7 @@ Use this log for decisions that change interfaces, data models, deployment topol
 | ADR-0015 | 2026-03-04 | accepted | Use Celery as execution engine for CV parsing with DB job table as source of truth | architect + backend-engineer | async runtime, operations, reliability |
 | ADR-0016 | 2026-03-04 | accepted | Remove legacy auth login payload and temporary settings compatibility shims | architect + backend-engineer | auth API contract, backend shared config imports |
 | ADR-0017 | 2026-03-05 | accepted | Add layered anti-abuse controls for public vacancy application endpoint | architect + backend-engineer | recruitment API, observability, operations |
+| ADR-0018 | 2026-03-05 | accepted | Normalize API ID contracts to UUID at boundary level | architect + backend-engineer | candidate/vacancy/pipeline contracts, OpenAPI |
 
 ## ADR-0001
 - Context: Project is at bootstrap stage and lacks durable knowledge artifacts.
@@ -245,3 +246,14 @@ Use this log for decisions that change interfaces, data models, deployment topol
   - Public apply path gains deterministic abuse controls and clearer diagnostics.
   - Endpoint contract now includes `409/429` paths and rate-limit headers.
   - Operations must monitor blocked-rate anomalies and maintain Redis availability.
+
+## ADR-0018
+- Context: Remaining API contracts still represented entity identifiers as plain strings, which allowed non-UUID payloads on boundary paths and produced inconsistent OpenAPI typing.
+- Decision:
+  - Normalize candidate/vacancy/pipeline/CV-status API schemas and route boundaries to UUID types.
+  - Accept UUID in path/body contracts and return `422` for invalid non-UUID identifiers.
+  - Keep storage layer unchanged (string UUID columns) and convert UUID -> string only at DAO/model boundary.
+- Consequences:
+  - OpenAPI now exposes uniform `format: uuid` for normalized ID fields.
+  - Contract validation becomes stricter for clients still sending legacy non-UUID values.
+  - Service signatures become type-safe without forcing DB storage migration in this phase.

--- a/docs/testing/strategy.md
+++ b/docs/testing/strategy.md
@@ -96,6 +96,7 @@ apps/backend/tests/
 | Capability | Unit Coverage | Integration Coverage | Required Evidence |
 | --- | --- | --- | --- |
 | Candidate profile schema and ownership guards | `tests/unit/candidates/test_cv_validation.py` + role checks in `tests/unit/rbac/test_rbac.py` | `tests/integration/candidates/test_candidate_api.py` | `uv run --project apps/backend pytest -q` |
+| UUID boundary validation for candidate/vacancy/pipeline contracts | Candidate/vacancy schema parsing via unit-level model validation | `tests/integration/candidates/test_candidate_api.py` + `tests/integration/vacancies/test_vacancy_pipeline_api.py` (invalid UUID -> `422`) | OpenAPI IDs expose `format: uuid` and boundary negatives are covered |
 | CV upload validation (mime/size/checksum) | `tests/unit/candidates/test_cv_validation.py` | `test_cv_upload_download_status_and_validation_failures` | Validation negative paths return `415/422/413` |
 | Public vacancy apply flow (anonymous) | `tests/unit/vacancies/test_pipeline_validator.py` + candidate validation units | `tests/integration/vacancies/test_vacancy_pipeline_api.py` | Apply creates candidate/doc/transition/parsing job |
 | Vacancy lifecycle and canonical pipeline transitions | `tests/unit/vacancies/test_pipeline_validator.py` | `tests/integration/vacancies/test_vacancy_pipeline_api.py` | Valid chain passes, invalid chain returns `422` |


### PR DESCRIPTION
## Scope\n- Normalize remaining API boundary contracts to UUID types across candidates, vacancies, pipeline and CV status\n- Keep storage boundary as string UUID where persistence layer still expects string\n- Remove legacy non-UUID fixtures and add invalid UUID 422 negative coverage\n- Ensure OpenAPI reflects uuid format for ID fields/params\n\n## Verification\n- ./scripts/check-docs-structure.sh\n- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend ruff check apps/backend/src apps/backend/tests apps/backend/alembic\n- uv run --project apps/backend pytest -q apps/backend/tests/integration/candidates apps/backend/tests/integration/vacancies apps/backend/tests/integration/cv_jobs\n- OpenAPI UUID format checks in integration suite\n\n## API impact\n- Invalid non-UUID IDs now return 422 on normalized boundaries\n\n## Notes\n- This PR is based on PR-B and precedes OpenAPI freeze stage.