### PR TITLE
PR-B: Stabilize integration harness and harden public apply

### DIFF
--- a/apps/backend/src/hrm_backend/candidates/services/__init__.py
+++ b/apps/backend/src/hrm_backend/candidates/services/__init__.py
@@ -1,6 +1,30 @@
-"""Business services for candidate domain."""
+"""Candidate service exports with lazy imports to avoid circular dependencies.
 
-from hrm_backend.candidates.services.candidate_service import CandidateService
-from hrm_backend.candidates.services.cv_parsing_worker_service import CVParsingWorkerService
+This package exposes the public candidate-domain services while delaying heavy imports
+until consumers actually request the symbols.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from hrm_backend.candidates.services.candidate_service import CandidateService
+    from hrm_backend.candidates.services.cv_parsing_worker_service import CVParsingWorkerService
 
 __all__ = ["CandidateService", "CVParsingWorkerService"]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve public service symbols lazily on first access."""
+    if name == "CandidateService":
+        from hrm_backend.candidates.services.candidate_service import CandidateService
+
+        return CandidateService
+    if name == "CVParsingWorkerService":
+        from hrm_backend.candidates.services.cv_parsing_worker_service import (
+            CVParsingWorkerService,
+        )
+
+        return CVParsingWorkerService
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/apps/backend/src/hrm_backend/settings.py
+++ b/apps/backend/src/hrm_backend/settings.py
@@ -36,6 +36,18 @@ class AppSettings(BaseSettings):
         object_storage_sse_enabled: Whether uploads use SSE-S3 headers.
         cv_parsing_max_attempts: Maximum worker retries for CV parsing.
         employee_key_ttl_seconds: Default ttl for one-time employee registration keys.
+        public_apply_rate_limit_redis_prefix: Redis key prefix for public apply rate limits.
+        public_apply_rate_limit_ip: Rate limit threshold for IP bucket.
+        public_apply_rate_limit_ip_window_seconds: Time window for IP bucket.
+        public_apply_rate_limit_ip_vacancy: Rate limit threshold for IP+vacancy bucket.
+        public_apply_rate_limit_ip_vacancy_window_seconds: Time window for IP+vacancy bucket.
+        public_apply_rate_limit_email_vacancy: Rate limit threshold for email+vacancy bucket.
+        public_apply_rate_limit_email_vacancy_window_seconds: Time window for email+vacancy bucket.
+        public_apply_dedup_window_seconds:
+            Deduplication window for vacancy+checksum anti-spam check.
+        public_apply_email_cooldown_seconds: Cooldown between submissions by one email per vacancy.
+        public_apply_blocked_alert_threshold_per_minute:
+            Anomaly threshold for blocked submissions per minute.
         celery_broker_url: Celery broker URL.
         celery_result_backend: Celery result backend URL.
         celery_task_default_queue: Default Celery queue name.
@@ -92,6 +104,51 @@ class AppSettings(BaseSettings):
         env="EMPLOYEE_KEY_TTL_SECONDS",
         gt=0,
     )
+    public_apply_rate_limit_redis_prefix: str = Field(
+        default="vacancy:apply_public:rl",
+        env="PUBLIC_APPLY_RATE_LIMIT_REDIS_PREFIX",
+    )
+    public_apply_rate_limit_ip: int = Field(default=10, env="PUBLIC_APPLY_RATE_LIMIT_IP", gt=0)
+    public_apply_rate_limit_ip_window_seconds: int = Field(
+        default=15 * 60,
+        env="PUBLIC_APPLY_RATE_LIMIT_IP_WINDOW_SECONDS",
+        gt=0,
+    )
+    public_apply_rate_limit_ip_vacancy: int = Field(
+        default=5,
+        env="PUBLIC_APPLY_RATE_LIMIT_IP_VACANCY",
+        gt=0,
+    )
+    public_apply_rate_limit_ip_vacancy_window_seconds: int = Field(
+        default=15 * 60,
+        env="PUBLIC_APPLY_RATE_LIMIT_IP_VACANCY_WINDOW_SECONDS",
+        gt=0,
+    )
+    public_apply_rate_limit_email_vacancy: int = Field(
+        default=8,
+        env="PUBLIC_APPLY_RATE_LIMIT_EMAIL_VACANCY",
+        gt=0,
+    )
+    public_apply_rate_limit_email_vacancy_window_seconds: int = Field(
+        default=24 * 60 * 60,
+        env="PUBLIC_APPLY_RATE_LIMIT_EMAIL_VACANCY_WINDOW_SECONDS",
+        gt=0,
+    )
+    public_apply_dedup_window_seconds: int = Field(
+        default=24 * 60 * 60,
+        env="PUBLIC_APPLY_DEDUP_WINDOW_SECONDS",
+        ge=0,
+    )
+    public_apply_email_cooldown_seconds: int = Field(
+        default=60,
+        env="PUBLIC_APPLY_EMAIL_COOLDOWN_SECONDS",
+        ge=0,
+    )
+    public_apply_blocked_alert_threshold_per_minute: int = Field(
+        default=30,
+        env="PUBLIC_APPLY_BLOCKED_ALERT_THRESHOLD_PER_MINUTE",
+        gt=0,
+    )
     celery_broker_url: str = Field(default="redis://redis:6379/0", env="CELERY_BROKER_URL")
     celery_result_backend: str = Field(default="redis://redis:6379/0", env="CELERY_RESULT_BACKEND")
     celery_task_default_queue: str = Field(default="cv_parsing", env="CELERY_TASK_DEFAULT_QUEUE")
@@ -113,6 +170,7 @@ class AppSettings(BaseSettings):
         "jwt_secret",
         "jwt_algorithm",
         "redis_prefix",
+        "public_apply_rate_limit_redis_prefix",
         "celery_broker_url",
         "celery_result_backend",
         "celery_task_default_queue",

--- a/apps/backend/src/hrm_backend/vacancies/dao/__init__.py
+++ b/apps/backend/src/hrm_backend/vacancies/dao/__init__.py
@@ -1,6 +1,7 @@
 """Data-access objects for vacancy domain."""
 
 from hrm_backend.vacancies.dao.pipeline_transition_dao import PipelineTransitionDAO
+from hrm_backend.vacancies.dao.public_apply_guard_dao import PublicApplyGuardDAO
 from hrm_backend.vacancies.dao.vacancy_dao import VacancyDAO
 
-__all__ = ["VacancyDAO", "PipelineTransitionDAO"]
+__all__ = ["VacancyDAO", "PipelineTransitionDAO", "PublicApplyGuardDAO"]

--- a/apps/backend/src/hrm_backend/vacancies/dao/public_apply_guard_dao.py
+++ b/apps/backend/src/hrm_backend/vacancies/dao/public_apply_guard_dao.py
@@ -1,0 +1,96 @@
+"""Database guard queries used by public vacancy application anti-spam policy."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from hrm_backend.candidates.models.document import CandidateDocument
+from hrm_backend.candidates.models.profile import CandidateProfile
+from hrm_backend.vacancies.models.pipeline_transition import PipelineTransition
+
+
+class PublicApplyGuardDAO:
+    """Read-only DAO with anti-spam lookup helpers for public applications."""
+
+    def __init__(self, session: Session) -> None:
+        """Initialize DAO with active SQLAlchemy session.
+
+        Args:
+            session: Active SQLAlchemy session.
+        """
+        self._session = session
+
+    def has_recent_submission_for_email(
+        self,
+        *,
+        vacancy_id: str,
+        email: str,
+        window_seconds: int,
+    ) -> bool:
+        """Check whether email already applied to vacancy in recent time window.
+
+        Args:
+            vacancy_id: Vacancy identifier.
+            email: Normalized candidate email.
+            window_seconds: Cooldown window in seconds.
+
+        Returns:
+            bool: ``True`` when a recent public application exists.
+        """
+        if window_seconds <= 0:
+            return False
+
+        threshold = datetime.now(UTC) - timedelta(seconds=window_seconds)
+        stmt = (
+            select(PipelineTransition.transition_id)
+            .join(
+                CandidateProfile,
+                CandidateProfile.candidate_id == PipelineTransition.candidate_id,
+            )
+            .where(PipelineTransition.vacancy_id == vacancy_id)
+            .where(PipelineTransition.to_stage == "applied")
+            .where(PipelineTransition.reason == "public_application")
+            .where(CandidateProfile.email == email)
+            .where(PipelineTransition.transitioned_at >= threshold)
+            .limit(1)
+        )
+        return self._session.execute(stmt).scalar_one_or_none() is not None
+
+    def has_recent_submission_for_checksum(
+        self,
+        *,
+        vacancy_id: str,
+        checksum_sha256: str,
+        window_seconds: int,
+    ) -> bool:
+        """Check whether checksum was already submitted to the same vacancy recently.
+
+        Args:
+            vacancy_id: Vacancy identifier.
+            checksum_sha256: SHA-256 document checksum.
+            window_seconds: Deduplication window in seconds.
+
+        Returns:
+            bool: ``True`` when duplicate submission is detected.
+        """
+        if window_seconds <= 0:
+            return False
+
+        threshold = datetime.now(UTC) - timedelta(seconds=window_seconds)
+        stmt = (
+            select(PipelineTransition.transition_id)
+            .join(
+                CandidateDocument,
+                CandidateDocument.candidate_id == PipelineTransition.candidate_id,
+            )
+            .where(PipelineTransition.vacancy_id == vacancy_id)
+            .where(PipelineTransition.to_stage == "applied")
+            .where(PipelineTransition.reason == "public_application")
+            .where(CandidateDocument.checksum_sha256 == checksum_sha256)
+            .where(PipelineTransition.transitioned_at >= threshold)
+            .limit(1)
+        )
+        return self._session.execute(stmt).scalar_one_or_none() is not None

--- a/apps/backend/src/hrm_backend/vacancies/dependencies/vacancies.py
+++ b/apps/backend/src/hrm_backend/vacancies/dependencies/vacancies.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import Depends
+from redis import Redis
 from sqlalchemy.orm import Session
 
 from hrm_backend.audit.dependencies.audit import get_audit_service
 from hrm_backend.audit.services.audit_service import AuditService
+from hrm_backend.auth.infra.redis import get_redis_client
 from hrm_backend.candidates.dependencies.candidates import get_candidate_storage
 from hrm_backend.candidates.infra.minio import CandidateStorage
 from hrm_backend.candidates.infra.postgres import (
@@ -18,14 +20,18 @@ from hrm_backend.candidates.infra.postgres import (
 )
 from hrm_backend.core.db.session import get_db_session
 from hrm_backend.settings import AppSettings, get_settings
+from hrm_backend.vacancies.dao.public_apply_guard_dao import PublicApplyGuardDAO
 from hrm_backend.vacancies.infra.postgres import PipelineTransitionDAO, VacancyDAO
 from hrm_backend.vacancies.services.application_service import VacancyApplicationService
+from hrm_backend.vacancies.services.public_apply_policy import PublicApplyPolicyService
+from hrm_backend.vacancies.services.public_apply_rate_limiter import PublicApplyRateLimiter
 from hrm_backend.vacancies.services.vacancy_service import VacancyService
 
 SessionDependency = Annotated[Session, Depends(get_db_session)]
 AuditDependency = Annotated[AuditService, Depends(get_audit_service)]
 SettingsDependency = Annotated[AppSettings, Depends(get_settings)]
 CandidateStorageDependency = Annotated[CandidateStorage, Depends(get_candidate_storage)]
+RedisClientDependency = Annotated[Redis, Depends(get_redis_client)]
 
 
 def get_vacancy_service(
@@ -49,11 +55,47 @@ def get_vacancy_service(
     )
 
 
+def get_public_apply_guard_dao(session: SessionDependency) -> PublicApplyGuardDAO:
+    """Build read-only anti-spam guard DAO for public apply policy."""
+    return PublicApplyGuardDAO(session=session)
+
+
+def get_public_apply_rate_limiter(
+    settings: SettingsDependency,
+    redis_client: RedisClientDependency,
+) -> PublicApplyRateLimiter:
+    """Build Redis-backed rate limiter for public apply endpoint."""
+    return PublicApplyRateLimiter(
+        redis_client=redis_client,
+        key_prefix=settings.public_apply_rate_limit_redis_prefix,
+        ip_limit=settings.public_apply_rate_limit_ip,
+        ip_window_seconds=settings.public_apply_rate_limit_ip_window_seconds,
+        ip_vacancy_limit=settings.public_apply_rate_limit_ip_vacancy,
+        ip_vacancy_window_seconds=settings.public_apply_rate_limit_ip_vacancy_window_seconds,
+        email_vacancy_limit=settings.public_apply_rate_limit_email_vacancy,
+        email_vacancy_window_seconds=settings.public_apply_rate_limit_email_vacancy_window_seconds,
+    )
+
+
+def get_public_apply_policy_service(
+    settings: SettingsDependency,
+    guard_dao: Annotated[PublicApplyGuardDAO, Depends(get_public_apply_guard_dao)],
+) -> PublicApplyPolicyService:
+    """Build anti-spam policy service for public apply endpoint."""
+    return PublicApplyPolicyService(
+        guard_dao=guard_dao,
+        email_cooldown_seconds=settings.public_apply_email_cooldown_seconds,
+        dedup_window_seconds=settings.public_apply_dedup_window_seconds,
+    )
+
+
 def get_vacancy_application_service(
     settings: SettingsDependency,
     session: SessionDependency,
     storage: CandidateStorageDependency,
     audit_service: AuditDependency,
+    rate_limiter: Annotated[PublicApplyRateLimiter, Depends(get_public_apply_rate_limiter)],
+    policy_service: Annotated[PublicApplyPolicyService, Depends(get_public_apply_policy_service)],
 ) -> VacancyApplicationService:
     """Build public vacancy application service dependency."""
     return VacancyApplicationService(
@@ -65,4 +107,6 @@ def get_vacancy_application_service(
         transition_dao=PipelineTransitionDAO(session=session),
         storage=storage,
         audit_service=audit_service,
+        rate_limiter=rate_limiter,
+        policy_service=policy_service,
     )

--- a/apps/backend/src/hrm_backend/vacancies/monitoring/__init__.py
+++ b/apps/backend/src/hrm_backend/vacancies/monitoring/__init__.py
@@ -1,0 +1,13 @@
+"""Monitoring helpers for vacancy-domain runtime signals."""
+
+from hrm_backend.vacancies.monitoring.public_apply import (
+    record_public_apply_blocked,
+    record_public_apply_success,
+    snapshot_public_apply_metrics,
+)
+
+__all__ = [
+    "record_public_apply_success",
+    "record_public_apply_blocked",
+    "snapshot_public_apply_metrics",
+]

--- a/apps/backend/src/hrm_backend/vacancies/monitoring/public_apply.py
+++ b/apps/backend/src/hrm_backend/vacancies/monitoring/public_apply.py
@@ -1,0 +1,95 @@
+"""In-process counters and structured logs for public apply anti-abuse monitoring."""
+
+from __future__ import annotations
+
+from collections import Counter, deque
+from collections.abc import Mapping
+from json import dumps
+from logging import getLogger
+from threading import Lock
+from time import time
+
+from hrm_backend.vacancies.schemas.application import PublicApplyReasonCode
+
+_logger = getLogger(__name__)
+_lock = Lock()
+_counters: Counter[str] = Counter()
+_blocked_timestamps: deque[float] = deque()
+
+
+def record_public_apply_success(
+    *,
+    correlation_id: str | None,
+    vacancy_id: str,
+) -> None:
+    """Record successful public apply request metrics and structured log."""
+    with _lock:
+        _counters["success"] += 1
+
+    _logger.info(
+        dumps(
+            {
+                "event": "vacancy_apply_public",
+                "result": "success",
+                "vacancy_id": vacancy_id,
+                "correlation_id": correlation_id,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def record_public_apply_blocked(
+    *,
+    correlation_id: str | None,
+    vacancy_id: str,
+    reason_code: PublicApplyReasonCode,
+    blocked_alert_threshold_per_minute: int,
+) -> None:
+    """Record blocked request metrics, structured log, and anomaly warning signal."""
+    now = time()
+    with _lock:
+        _counters["blocked_total"] += 1
+        _counters[f"blocked:{reason_code}"] += 1
+        _blocked_timestamps.append(now)
+        while _blocked_timestamps and (now - _blocked_timestamps[0]) > 60:
+            _blocked_timestamps.popleft()
+        blocked_per_minute = len(_blocked_timestamps)
+
+    _logger.info(
+        dumps(
+            {
+                "event": "vacancy_apply_public",
+                "result": "blocked",
+                "reason_code": reason_code,
+                "vacancy_id": vacancy_id,
+                "correlation_id": correlation_id,
+                "blocked_per_minute": blocked_per_minute,
+            },
+            sort_keys=True,
+        )
+    )
+
+    if blocked_alert_threshold_per_minute <= 0:
+        return
+    if blocked_per_minute < blocked_alert_threshold_per_minute:
+        return
+
+    _logger.warning(
+        dumps(
+            {
+                "event": "vacancy_apply_public_blocked_anomaly",
+                "blocked_per_minute": blocked_per_minute,
+                "threshold_per_minute": blocked_alert_threshold_per_minute,
+                "correlation_id": correlation_id,
+                "vacancy_id": vacancy_id,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def snapshot_public_apply_metrics() -> Mapping[str, int]:
+    """Return in-process counters snapshot (used by tests and diagnostics)."""
+    with _lock:
+        return dict(_counters)

--- a/apps/backend/src/hrm_backend/vacancies/routers/v1.py
+++ b/apps/backend/src/hrm_backend/vacancies/routers/v1.py
@@ -108,6 +108,30 @@ def create_pipeline_transition(
 @router.post(
     "/api/v1/vacancies/{vacancy_id}/applications",
     response_model=PublicVacancyApplicationResponse,
+    responses={
+        409: {"description": "Duplicate submission or active cooldown"},
+        429: {
+            "description": "Too many requests",
+            "headers": {
+                "Retry-After": {
+                    "description": "Seconds before next retry",
+                    "schema": {"type": "string"},
+                },
+                "X-RateLimit-Limit": {
+                    "description": "Bucket limit",
+                    "schema": {"type": "string"},
+                },
+                "X-RateLimit-Remaining": {
+                    "description": "Remaining requests in current window",
+                    "schema": {"type": "string"},
+                },
+                "X-RateLimit-Reset": {
+                    "description": "Unix epoch timestamp for limit reset",
+                    "schema": {"type": "string"},
+                },
+            },
+        },
+    },
 )
 async def apply_to_vacancy_public(
     vacancy_id: str,
@@ -122,6 +146,7 @@ async def apply_to_vacancy_public(
     location: Annotated[str | None, Form(max_length=256)] = None,
     current_title: Annotated[str | None, Form(max_length=256)] = None,
     extra_data: Annotated[str | None, Form()] = None,
+    website: Annotated[str | None, Form(max_length=256)] = None,
 ) -> PublicVacancyApplicationResponse:
     """Submit public candidate application with CV to target vacancy."""
     return await service.apply_public(
@@ -135,5 +160,6 @@ async def apply_to_vacancy_public(
         extra_data_raw=extra_data,
         file=file,
         checksum_sha256=checksum_sha256,
+        website=website,
         request=request,
     )

--- a/apps/backend/src/hrm_backend/vacancies/schemas/application.py
+++ b/apps/backend/src/hrm_backend/vacancies/schemas/application.py
@@ -3,9 +3,23 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Final, Literal
 from uuid import UUID
 
 from pydantic import BaseModel
+
+PublicApplyReasonCode = Literal[
+    "rate_limited",
+    "honeypot_triggered",
+    "duplicate_submission",
+    "cooldown_active",
+    "validation_failed",
+]
+PUBLIC_APPLY_REASON_RATE_LIMITED: Final[PublicApplyReasonCode] = "rate_limited"
+PUBLIC_APPLY_REASON_HONEYPOT_TRIGGERED: Final[PublicApplyReasonCode] = "honeypot_triggered"
+PUBLIC_APPLY_REASON_DUPLICATE_SUBMISSION: Final[PublicApplyReasonCode] = "duplicate_submission"
+PUBLIC_APPLY_REASON_COOLDOWN_ACTIVE: Final[PublicApplyReasonCode] = "cooldown_active"
+PUBLIC_APPLY_REASON_VALIDATION_FAILED: Final[PublicApplyReasonCode] = "validation_failed"
 
 
 class PublicVacancyApplicationResponse(BaseModel):

--- a/apps/backend/src/hrm_backend/vacancies/services/__init__.py
+++ b/apps/backend/src/hrm_backend/vacancies/services/__init__.py
@@ -1,6 +1,43 @@
-"""Business services for vacancy domain."""
+"""Vacancy service exports with lazy imports to prevent import cycles.
 
-from hrm_backend.vacancies.services.application_service import VacancyApplicationService
-from hrm_backend.vacancies.services.vacancy_service import VacancyService
+The package re-exports public service classes while keeping module initialization
+lightweight for unit and integration test collection.
+"""
 
-__all__ = ["VacancyService", "VacancyApplicationService"]
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from hrm_backend.vacancies.services.application_service import VacancyApplicationService
+    from hrm_backend.vacancies.services.public_apply_policy import PublicApplyPolicyService
+    from hrm_backend.vacancies.services.public_apply_rate_limiter import PublicApplyRateLimiter
+    from hrm_backend.vacancies.services.vacancy_service import VacancyService
+
+__all__ = [
+    "VacancyService",
+    "VacancyApplicationService",
+    "PublicApplyRateLimiter",
+    "PublicApplyPolicyService",
+]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve public vacancy service symbols lazily on first access."""
+    if name == "VacancyService":
+        from hrm_backend.vacancies.services.vacancy_service import VacancyService
+
+        return VacancyService
+    if name == "VacancyApplicationService":
+        from hrm_backend.vacancies.services.application_service import VacancyApplicationService
+
+        return VacancyApplicationService
+    if name == "PublicApplyRateLimiter":
+        from hrm_backend.vacancies.services.public_apply_rate_limiter import PublicApplyRateLimiter
+
+        return PublicApplyRateLimiter
+    if name == "PublicApplyPolicyService":
+        from hrm_backend.vacancies.services.public_apply_policy import PublicApplyPolicyService
+
+        return PublicApplyPolicyService
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/apps/backend/src/hrm_backend/vacancies/services/application_service.py
+++ b/apps/backend/src/hrm_backend/vacancies/services/application_service.py
@@ -6,8 +6,13 @@ from json import JSONDecodeError, loads
 from uuid import UUID, uuid4
 
 from fastapi import HTTPException, Request, UploadFile, status
+from redis.exceptions import RedisError
 
-from hrm_backend.audit.services.audit_service import AuditService
+from hrm_backend.audit.services.audit_service import (
+    AuditService,
+    get_client_ip,
+    get_request_id,
+)
 from hrm_backend.candidates.infra.celery.dispatch import enqueue_cv_parsing
 from hrm_backend.candidates.infra.minio import CandidateStorage
 from hrm_backend.candidates.infra.postgres import (
@@ -17,10 +22,22 @@ from hrm_backend.candidates.infra.postgres import (
 )
 from hrm_backend.candidates.schemas.profile import CandidateCreateRequest, CandidateUpdateRequest
 from hrm_backend.candidates.utils.cv import validate_cv_payload
+from hrm_backend.core.errors.http import service_unavailable
 from hrm_backend.settings import AppSettings
 from hrm_backend.vacancies.dao.pipeline_transition_dao import PipelineTransitionDAO
 from hrm_backend.vacancies.dao.vacancy_dao import VacancyDAO
-from hrm_backend.vacancies.schemas.application import PublicVacancyApplicationResponse
+from hrm_backend.vacancies.monitoring.public_apply import (
+    record_public_apply_blocked,
+    record_public_apply_success,
+)
+from hrm_backend.vacancies.schemas.application import (
+    PUBLIC_APPLY_REASON_DUPLICATE_SUBMISSION,
+    PUBLIC_APPLY_REASON_VALIDATION_FAILED,
+    PublicVacancyApplicationResponse,
+)
+from hrm_backend.vacancies.services.public_apply_exceptions import PublicApplyRejectedError
+from hrm_backend.vacancies.services.public_apply_policy import PublicApplyPolicyService
+from hrm_backend.vacancies.services.public_apply_rate_limiter import PublicApplyRateLimiter
 from hrm_backend.vacancies.utils.pipeline import is_transition_allowed
 
 
@@ -38,6 +55,8 @@ class VacancyApplicationService:
         transition_dao: PipelineTransitionDAO,
         storage: CandidateStorage,
         audit_service: AuditService,
+        rate_limiter: PublicApplyRateLimiter,
+        policy_service: PublicApplyPolicyService,
     ) -> None:
         """Initialize service dependencies."""
         self._settings = settings
@@ -48,6 +67,8 @@ class VacancyApplicationService:
         self._transition_dao = transition_dao
         self._storage = storage
         self._audit_service = audit_service
+        self._rate_limiter = rate_limiter
+        self._policy_service = policy_service
 
     async def apply_public(
         self,
@@ -62,11 +83,23 @@ class VacancyApplicationService:
         extra_data_raw: str | None,
         file: UploadFile,
         checksum_sha256: str,
+        website: str | None,
         request: Request,
     ) -> PublicVacancyApplicationResponse:
         """Create or update candidate profile and apply to vacancy with CV upload."""
+        vacancy_id_str = str(vacancy_id)
+        normalized_email = email.strip().lower()
+        correlation_id = get_request_id(request)
+        client_ip = get_client_ip(request)
         try:
-            vacancy = self._vacancy_dao.get_by_id(vacancy_id)
+            self._rate_limiter.enforce(
+                ip=client_ip,
+                vacancy_id=vacancy_id_str,
+                email=normalized_email,
+            )
+            self._policy_service.enforce_honeypot(website=website)
+
+            vacancy = self._vacancy_dao.get_by_id(vacancy_id_str)
             if vacancy is None:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
@@ -80,25 +113,10 @@ class VacancyApplicationService:
                 )
 
             extra_data = self._parse_extra_data(extra_data_raw)
-            candidate = self._upsert_candidate_profile(
-                first_name=first_name,
-                last_name=last_name,
-                email=email,
-                phone=phone,
-                location=location,
-                current_title=current_title,
-                extra_data=extra_data,
+            self._policy_service.enforce_email_cooldown(
+                vacancy_id=vacancy_id_str,
+                email=normalized_email,
             )
-
-            previous_transition = self._transition_dao.get_last_transition(
-                vacancy_id=vacancy_id,
-                candidate_id=candidate.candidate_id,
-            )
-            if previous_transition is not None:
-                raise HTTPException(
-                    status_code=status.HTTP_409_CONFLICT,
-                    detail="Candidate already applied to this vacancy",
-                )
 
             payload = await file.read()
             validated = validate_cv_payload(
@@ -109,6 +127,30 @@ class VacancyApplicationService:
                 allowed_mime_types=self._settings.cv_allowed_mime_types,
                 max_size_bytes=self._settings.cv_max_size_bytes,
             )
+            self._policy_service.enforce_checksum_dedup(
+                vacancy_id=vacancy_id_str,
+                checksum_sha256=validated.checksum_sha256,
+            )
+
+            candidate = self._upsert_candidate_profile(
+                first_name=first_name,
+                last_name=last_name,
+                email=normalized_email,
+                phone=phone,
+                location=location,
+                current_title=current_title,
+                extra_data=extra_data,
+            )
+            previous_transition = self._transition_dao.get_last_transition(
+                vacancy_id=vacancy_id_str,
+                candidate_id=candidate.candidate_id,
+            )
+            if previous_transition is not None:
+                raise PublicApplyRejectedError(
+                    reason_code=PUBLIC_APPLY_REASON_DUPLICATE_SUBMISSION,
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Candidate already applied to this vacancy",
+                )
 
             object_key = (
                 f"candidates/{candidate.candidate_id}/cv/"
@@ -144,7 +186,7 @@ class VacancyApplicationService:
                 )
 
             transition = self._transition_dao.create_transition(
-                vacancy_id=vacancy_id,
+                vacancy_id=vacancy_id_str,
                 candidate_id=candidate.candidate_id,
                 from_stage=None,
                 to_stage="applied",
@@ -160,6 +202,10 @@ class VacancyApplicationService:
                 request=request,
                 resource_id=transition.transition_id,
             )
+            record_public_apply_success(
+                correlation_id=correlation_id,
+                vacancy_id=vacancy_id_str,
+            )
             return PublicVacancyApplicationResponse(
                 vacancy_id=UUID(vacancy_id),
                 candidate_id=UUID(candidate.candidate_id),
@@ -168,13 +214,42 @@ class VacancyApplicationService:
                 transition_id=UUID(transition.transition_id),
                 applied_at=transition.transitioned_at,
             )
-        except HTTPException as exc:
+        except RedisError as exc:
+            raise service_unavailable(
+                "Public application protection is temporarily unavailable"
+            ) from exc
+        except PublicApplyRejectedError as exc:
             self._audit_service.record_api_event(
                 action="vacancy:apply_public",
                 resource_type="vacancy_application",
                 result="failure",
                 request=request,
-                reason=str(exc.detail),
+                reason=exc.reason_code,
+            )
+            record_public_apply_blocked(
+                correlation_id=correlation_id,
+                vacancy_id=vacancy_id_str,
+                reason_code=exc.reason_code,
+                blocked_alert_threshold_per_minute=(
+                    self._settings.public_apply_blocked_alert_threshold_per_minute
+                ),
+            )
+            raise
+        except HTTPException:
+            self._audit_service.record_api_event(
+                action="vacancy:apply_public",
+                resource_type="vacancy_application",
+                result="failure",
+                request=request,
+                reason=PUBLIC_APPLY_REASON_VALIDATION_FAILED,
+            )
+            record_public_apply_blocked(
+                correlation_id=correlation_id,
+                vacancy_id=vacancy_id_str,
+                reason_code=PUBLIC_APPLY_REASON_VALIDATION_FAILED,
+                blocked_alert_threshold_per_minute=(
+                    self._settings.public_apply_blocked_alert_threshold_per_minute
+                ),
             )
             raise
 
@@ -190,15 +265,14 @@ class VacancyApplicationService:
         extra_data: dict[str, object],
     ):
         """Create candidate profile if absent or refresh contact fields by email."""
-        normalized_email = email.strip().lower()
-        existing = self._profile_dao.get_by_email(normalized_email)
+        existing = self._profile_dao.get_by_email(email)
         if existing is None:
             return self._profile_dao.create_profile(
                 payload=CandidateCreateRequest(
                     owner_subject_id="public",
                     first_name=first_name,
                     last_name=last_name,
-                    email=normalized_email,
+                    email=email,
                     phone=phone,
                     location=location,
                     current_title=current_title,
@@ -212,7 +286,7 @@ class VacancyApplicationService:
             payload=CandidateUpdateRequest(
                 first_name=first_name,
                 last_name=last_name,
-                email=normalized_email,
+                email=email,
                 phone=phone,
                 location=location,
                 current_title=current_title,

--- a/apps/backend/src/hrm_backend/vacancies/services/public_apply_exceptions.py
+++ b/apps/backend/src/hrm_backend/vacancies/services/public_apply_exceptions.py
@@ -1,0 +1,34 @@
+"""Custom exception types for public vacancy application protection logic."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+from hrm_backend.vacancies.schemas.application import PublicApplyReasonCode
+
+
+class PublicApplyRejectedError(HTTPException):
+    """Structured rejection error for blocked public application requests.
+
+    Attributes:
+        reason_code: Stable machine-readable reason code used by audit and monitoring.
+    """
+
+    def __init__(
+        self,
+        *,
+        reason_code: PublicApplyReasonCode,
+        status_code: int,
+        detail: str,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        """Initialize structured public apply rejection.
+
+        Args:
+            reason_code: Stable rejection reason code.
+            status_code: HTTP response status code.
+            detail: Human-readable error detail.
+            headers: Optional HTTP headers for response.
+        """
+        super().__init__(status_code=status_code, detail=detail, headers=headers)
+        self.reason_code = reason_code

--- a/apps/backend/src/hrm_backend/vacancies/services/public_apply_policy.py
+++ b/apps/backend/src/hrm_backend/vacancies/services/public_apply_policy.py
@@ -1,0 +1,89 @@
+"""Anti-spam policy checks for the public vacancy application endpoint."""
+
+from __future__ import annotations
+
+from fastapi import status
+
+from hrm_backend.vacancies.dao.public_apply_guard_dao import PublicApplyGuardDAO
+from hrm_backend.vacancies.schemas.application import (
+    PUBLIC_APPLY_REASON_COOLDOWN_ACTIVE,
+    PUBLIC_APPLY_REASON_DUPLICATE_SUBMISSION,
+    PUBLIC_APPLY_REASON_HONEYPOT_TRIGGERED,
+)
+from hrm_backend.vacancies.services.public_apply_exceptions import PublicApplyRejectedError
+
+
+class PublicApplyPolicyService:
+    """Runs anti-spam guards before creating a public vacancy application."""
+
+    def __init__(
+        self,
+        *,
+        guard_dao: PublicApplyGuardDAO,
+        email_cooldown_seconds: int,
+        dedup_window_seconds: int,
+    ) -> None:
+        """Initialize policy dependencies and anti-spam windows.
+
+        Args:
+            guard_dao: DAO used for recent submission lookups.
+            email_cooldown_seconds: Cooldown window per email+vacancy pair.
+            dedup_window_seconds: Deduplication window per vacancy+checksum pair.
+        """
+        self._guard_dao = guard_dao
+        self._email_cooldown_seconds = email_cooldown_seconds
+        self._dedup_window_seconds = dedup_window_seconds
+
+    def enforce_honeypot(self, *, website: str | None) -> None:
+        """Reject request when honeypot field is filled."""
+        if website is None or not website.strip():
+            return
+
+        raise PublicApplyRejectedError(
+            reason_code=PUBLIC_APPLY_REASON_HONEYPOT_TRIGGERED,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Bot submission detected",
+        )
+
+    def enforce_email_cooldown(
+        self,
+        *,
+        vacancy_id: str,
+        email: str,
+    ) -> None:
+        """Reject request when recent application exists for email+vacancy pair."""
+        if not self._guard_dao.has_recent_submission_for_email(
+            vacancy_id=vacancy_id,
+            email=email,
+            window_seconds=self._email_cooldown_seconds,
+        ):
+            return
+
+        raise PublicApplyRejectedError(
+            reason_code=PUBLIC_APPLY_REASON_COOLDOWN_ACTIVE,
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Cooldown active for this email and vacancy. "
+                "Please wait before submitting again."
+            ),
+        )
+
+    def enforce_checksum_dedup(
+        self,
+        *,
+        vacancy_id: str,
+        checksum_sha256: str,
+    ) -> None:
+        """Reject request when checksum was already submitted to the same vacancy."""
+        if not self._guard_dao.has_recent_submission_for_checksum(
+            vacancy_id=vacancy_id,
+            checksum_sha256=checksum_sha256,
+            window_seconds=self._dedup_window_seconds,
+        ):
+            return
+
+        raise PublicApplyRejectedError(
+            reason_code=PUBLIC_APPLY_REASON_DUPLICATE_SUBMISSION,
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Duplicate submission detected for this vacancy",
+        )

--- a/apps/backend/src/hrm_backend/vacancies/services/public_apply_rate_limiter.py
+++ b/apps/backend/src/hrm_backend/vacancies/services/public_apply_rate_limiter.py
@@ -1,0 +1,155 @@
+"""Redis-backed rate limiter for the public vacancy application endpoint."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from time import time
+
+from fastapi import status
+from redis import Redis
+
+from hrm_backend.vacancies.schemas.application import PUBLIC_APPLY_REASON_RATE_LIMITED
+from hrm_backend.vacancies.services.public_apply_exceptions import PublicApplyRejectedError
+
+
+@dataclass(frozen=True)
+class _BucketResult:
+    """Internal result for one rate-limit bucket consumption attempt."""
+
+    count: int
+    ttl_seconds: int
+    limit: int
+    scope: str
+
+
+class PublicApplyRateLimiter:
+    """Rate limiter with independent limits for IP, IP+vacancy, and email+vacancy."""
+
+    def __init__(
+        self,
+        *,
+        redis_client: Redis,
+        key_prefix: str,
+        ip_limit: int,
+        ip_window_seconds: int,
+        ip_vacancy_limit: int,
+        ip_vacancy_window_seconds: int,
+        email_vacancy_limit: int,
+        email_vacancy_window_seconds: int,
+    ) -> None:
+        """Initialize limiter with Redis client and bucket thresholds.
+
+        Args:
+            redis_client: Redis client for atomic counter operations.
+            key_prefix: Key namespace prefix.
+            ip_limit: Max requests for one IP in configured window.
+            ip_window_seconds: Window size for IP limit.
+            ip_vacancy_limit: Max requests per IP+vacancy tuple in configured window.
+            ip_vacancy_window_seconds: Window size for IP+vacancy limit.
+            email_vacancy_limit: Max requests per email+vacancy tuple in configured window.
+            email_vacancy_window_seconds: Window size for email+vacancy limit.
+        """
+        self._redis = redis_client
+        self._key_prefix = key_prefix
+        self._ip_limit = ip_limit
+        self._ip_window_seconds = ip_window_seconds
+        self._ip_vacancy_limit = ip_vacancy_limit
+        self._ip_vacancy_window_seconds = ip_vacancy_window_seconds
+        self._email_vacancy_limit = email_vacancy_limit
+        self._email_vacancy_window_seconds = email_vacancy_window_seconds
+
+    def enforce(
+        self,
+        *,
+        ip: str | None,
+        vacancy_id: str,
+        email: str,
+    ) -> None:
+        """Consume all configured buckets and raise 429 on first exceeded limit.
+
+        Args:
+            ip: Client IP address.
+            vacancy_id: Vacancy identifier from path.
+            email: Candidate email from request payload.
+
+        Raises:
+            PublicApplyRejectedError: When any configured rate-limit bucket is exceeded.
+            RedisError: When Redis operation fails.
+        """
+        normalized_ip = (ip or "").strip() or "unknown"
+        normalized_vacancy_id = vacancy_id.strip()
+        normalized_email = email.strip().lower()
+        hashed_email = sha256(normalized_email.encode("utf-8")).hexdigest()
+
+        buckets = (
+            (
+                f"{self._key_prefix}:ip:{normalized_ip}",
+                self._ip_limit,
+                self._ip_window_seconds,
+                "ip",
+            ),
+            (
+                f"{self._key_prefix}:ip_vacancy:{normalized_ip}:{normalized_vacancy_id}",
+                self._ip_vacancy_limit,
+                self._ip_vacancy_window_seconds,
+                "ip+vacancy",
+            ),
+            (
+                f"{self._key_prefix}:email_vacancy:{hashed_email}:{normalized_vacancy_id}",
+                self._email_vacancy_limit,
+                self._email_vacancy_window_seconds,
+                "email+vacancy",
+            ),
+        )
+
+        for key, limit, window_seconds, scope in buckets:
+            result = self._consume_bucket(
+                key=key,
+                limit=limit,
+                window_seconds=window_seconds,
+                scope=scope,
+            )
+            if result.count <= result.limit:
+                continue
+
+            retry_after = max(result.ttl_seconds, 1)
+            reset_epoch = int(time()) + retry_after
+            headers = {
+                "Retry-After": str(retry_after),
+                "X-RateLimit-Limit": str(result.limit),
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": str(reset_epoch),
+            }
+            raise PublicApplyRejectedError(
+                reason_code=PUBLIC_APPLY_REASON_RATE_LIMITED,
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=f"Public application rate limit exceeded for scope '{result.scope}'",
+                headers=headers,
+            )
+
+    def _consume_bucket(
+        self,
+        *,
+        key: str,
+        limit: int,
+        window_seconds: int,
+        scope: str,
+    ) -> _BucketResult:
+        """Increment one Redis counter bucket and ensure TTL is set."""
+        count = int(self._redis.incr(key))
+        if count == 1:
+            self._redis.expire(key, window_seconds)
+            ttl_seconds = window_seconds
+        else:
+            ttl_seconds = int(self._redis.ttl(key))
+            if ttl_seconds <= 0:
+                self._redis.expire(key, window_seconds)
+                ttl_seconds = window_seconds
+
+        return _BucketResult(
+            count=count,
+            ttl_seconds=ttl_seconds,
+            limit=limit,
+            scope=scope,
+        )

--- a/apps/backend/tests/integration/conftest.py
+++ b/apps/backend/tests/integration/conftest.py
@@ -1,0 +1,68 @@
+"""Integration test harness configuration and runtime safety patches.
+
+This module centralizes integration-only pytest fixtures so API tests run with a
+deterministic ASGI in-process transport across CI and local environments.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Generator
+from functools import partial
+from typing import Any
+
+import anyio.to_thread
+import fastapi.concurrency
+import pytest
+import starlette.concurrency
+
+
+@pytest.fixture(scope="session")
+def anyio_backend() -> str:
+    """Pin AnyIO backend for integration tests.
+
+    Returns:
+        str: Backend name used by ``pytest-anyio`` parametrization.
+    """
+    return "asyncio"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def inline_threadpool_patch() -> Generator[None, None, None]:
+    """Patch threadpool helpers for deterministic in-process ASGI integration tests.
+
+    In this runtime environment AnyIO threadpool workers can deadlock in test
+    harnesses (``TestClient``/``ASGITransport``). Integration tests do not need
+    true threadpool execution, so we run these call sites inline to keep suites
+    deterministic and avoid hangs.
+    """
+
+    original_anyio_run_sync = anyio.to_thread.run_sync
+    original_starlette_run_in_threadpool = starlette.concurrency.run_in_threadpool
+    original_fastapi_run_in_threadpool = fastapi.concurrency.run_in_threadpool
+
+    async def _run_sync_inline(
+        func: Callable[..., Any],
+        /,
+        *args: Any,
+        **_: Any,
+    ) -> Any:
+        return func(*args)
+
+    async def _run_in_threadpool_inline(
+        func: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        if kwargs:
+            return partial(func, **kwargs)(*args)
+        return func(*args)
+
+    anyio.to_thread.run_sync = _run_sync_inline
+    starlette.concurrency.run_in_threadpool = _run_in_threadpool_inline
+    fastapi.concurrency.run_in_threadpool = _run_in_threadpool_inline
+    try:
+        yield
+    finally:
+        anyio.to_thread.run_sync = original_anyio_run_sync
+        starlette.concurrency.run_in_threadpool = original_starlette_run_in_threadpool
+        fastapi.concurrency.run_in_threadpool = original_fastapi_run_in_threadpool

--- a/apps/backend/tests/integration/security/test_audit_enforcement.py
+++ b/apps/backend/tests/integration/security/test_audit_enforcement.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
-from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 
@@ -19,6 +19,8 @@ from hrm_backend.core.models.base import Base
 from hrm_backend.main import app
 from hrm_backend.rbac import BackgroundAccessDeniedError, enforce_background_permission
 from hrm_backend.settings import AppSettings, get_settings
+
+pytestmark = pytest.mark.anyio
 
 
 @pytest.fixture()
@@ -78,70 +80,83 @@ def _load_events(database_url: str) -> list[AuditEvent]:
         engine.dispose()
 
 
-def test_api_permission_decisions_are_audited(configured_app) -> None:
+@pytest.fixture()
+async def api_client(configured_app) -> AsyncClient:
+    """Provide async API client for ASGI in-process integration requests."""
+    configured, _, _ = configured_app
+    async with AsyncClient(
+        transport=ASGITransport(app=configured),
+        base_url="http://testserver",
+    ) as client:
+        yield client
+
+
+async def test_api_permission_decisions_are_audited(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
     """Verify allowed/denied API permission checks persist audit events."""
-    configured, context_holder, database_url = configured_app
+    _, context_holder, database_url = configured_app
 
-    with TestClient(configured) as client:
-        context_holder["context"] = AuthContext(
-            subject_id=uuid4(),
-            role="hr",
-            session_id=uuid4(),
-            token_id=uuid4(),
-            expires_at=9999999999,
-        )
-        allow_response = client.post(
-            "/api/v1/vacancies",
-            headers={"X-Request-ID": "req-allow-1"},
-            json={
-                "title": "Backend Engineer",
-                "description": "Build recruitment platform modules",
-                "department": "Engineering",
-                "status": "open",
-            },
-        )
-        assert allow_response.status_code == 200
-        assert allow_response.headers.get("X-Request-ID") == "req-allow-1"
+    context_holder["context"] = AuthContext(
+        subject_id=uuid4(),
+        role="hr",
+        session_id=uuid4(),
+        token_id=uuid4(),
+        expires_at=9999999999,
+    )
+    allow_response = await api_client.post(
+        "/api/v1/vacancies",
+        headers={"X-Request-ID": "req-allow-1"},
+        json={
+            "title": "Backend Engineer",
+            "description": "Build recruitment platform modules",
+            "department": "Engineering",
+            "status": "open",
+        },
+    )
+    assert allow_response.status_code == 200
+    assert allow_response.headers.get("X-Request-ID") == "req-allow-1"
 
-        context_holder["context"] = AuthContext(
-            subject_id=uuid4(),
-            role="manager",
-            session_id=uuid4(),
-            token_id=uuid4(),
-            expires_at=9999999999,
-        )
-        deny_response = client.post(
-            "/api/v1/vacancies",
-            headers={"X-Request-ID": "req-deny-1"},
-            json={
-                "title": "Backend Engineer",
-                "description": "Build recruitment platform modules",
-                "department": "Engineering",
-                "status": "open",
-            },
-        )
-        assert deny_response.status_code == 403
-        assert deny_response.headers.get("X-Request-ID") == "req-deny-1"
+    context_holder["context"] = AuthContext(
+        subject_id=uuid4(),
+        role="manager",
+        session_id=uuid4(),
+        token_id=uuid4(),
+        expires_at=9999999999,
+    )
+    deny_response = await api_client.post(
+        "/api/v1/vacancies",
+        headers={"X-Request-ID": "req-deny-1"},
+        json={
+            "title": "Backend Engineer",
+            "description": "Build recruitment platform modules",
+            "department": "Engineering",
+            "status": "open",
+        },
+    )
+    assert deny_response.status_code == 403
+    assert deny_response.headers.get("X-Request-ID") == "req-deny-1"
 
-        context_holder["context"] = AuthContext(
-            subject_id=uuid4(),
-            role="intern",
-            session_id=uuid4(),
-            token_id=uuid4(),
-            expires_at=9999999999,
-        )
-        unknown_role_response = client.post(
-            "/api/v1/vacancies",
-            headers={"X-Request-ID": "req-unknown-role-1"},
-            json={
-                "title": "Backend Engineer",
-                "description": "Build recruitment platform modules",
-                "department": "Engineering",
-                "status": "open",
-            },
-        )
-        assert unknown_role_response.status_code == 403
-        assert unknown_role_response.headers.get("X-Request-ID") == "req-unknown-role-1"
+    context_holder["context"] = AuthContext(
+        subject_id=uuid4(),
+        role="intern",
+        session_id=uuid4(),
+        token_id=uuid4(),
+        expires_at=9999999999,
+    )
+    unknown_role_response = await api_client.post(
+        "/api/v1/vacancies",
+        headers={"X-Request-ID": "req-unknown-role-1"},
+        json={
+            "title": "Backend Engineer",
+            "description": "Build recruitment platform modules",
+            "department": "Engineering",
+            "status": "open",
+        },
+    )
+    assert unknown_role_response.status_code == 403
+    assert unknown_role_response.headers.get("X-Request-ID") == "req-unknown-role-1"
 
     events = _load_events(database_url)
     permission_events = [
@@ -162,48 +177,46 @@ def test_api_permission_decisions_are_audited(configured_app) -> None:
     assert permission_events[2].correlation_id == "req-unknown-role-1"
 
 
-def test_auth_login_is_audited(configured_app) -> None:
+async def test_auth_login_is_audited(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
     """Verify auth login endpoint records successful audit event."""
-    configured, context_holder, database_url = configured_app
+    _, context_holder, database_url = configured_app
 
-    login_identifier = f"hr-{uuid4().hex[:8]}"
-    login_password = "IntegrationPassword!123"
-    login_email = f"{login_identifier}@example.com"
-    with TestClient(configured) as client:
-        context_holder["context"] = AuthContext(
-            subject_id=uuid4(),
-            role="admin",
-            session_id=uuid4(),
-            token_id=uuid4(),
-            expires_at=9999999999,
-        )
-        create_response = client.post(
-            "/api/v1/admin/staff",
-            headers={"X-Request-ID": "req-create-staff-1"},
-            json={
-                "login": login_identifier,
-                "email": login_email,
-                "password": login_password,
-                "role": "hr",
-                "is_active": True,
-            },
-        )
-        assert create_response.status_code == 200
-        created_staff_id = create_response.json()["staff_id"]
+    login_identifier = "audit-login-user"
+    login_password = "AuditPassword!123"
+    context_holder["context"] = AuthContext(
+        subject_id=uuid4(),
+        role="admin",
+        session_id=uuid4(),
+        token_id=uuid4(),
+        expires_at=9999999999,
+    )
+    create_staff_response = await api_client.post(
+        "/api/v1/admin/staff",
+        json={
+            "login": login_identifier,
+            "email": f"{login_identifier}@example.com",
+            "password": login_password,
+            "role": "hr",
+            "is_active": True,
+        },
+    )
+    assert create_staff_response.status_code == 200
 
-        response = client.post(
-            "/api/v1/auth/login",
-            headers={"X-Request-ID": "req-login-1"},
-            json={"identifier": login_identifier, "password": login_password},
-        )
-        assert response.status_code == 200
-        assert response.headers.get("X-Request-ID") == "req-login-1"
+    response = await api_client.post(
+        "/api/v1/auth/login",
+        headers={"X-Request-ID": "req-login-1"},
+        json={"identifier": login_identifier, "password": login_password},
+    )
+    assert response.status_code == 200
+    assert response.headers.get("X-Request-ID") == "req-login-1"
 
     events = _load_events(database_url)
     login_events = [event for event in events if event.action == "auth.login"]
     assert len(login_events) == 1
     assert login_events[0].result == "success"
-    assert created_staff_id  # ensure staff creation succeeded with persisted identifier
     assert login_events[0].actor_sub == login_identifier
     assert login_events[0].actor_role is None
     assert login_events[0].correlation_id == "req-login-1"

--- a/apps/backend/tests/integration/vacancies/test_public_apply_hardening.py
+++ b/apps/backend/tests/integration/vacancies/test_public_apply_hardening.py
@@ -1,0 +1,431 @@
+"""Integration tests for public vacancy apply hardening controls."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from time import time
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from hrm_backend.audit.models.event import AuditEvent
+from hrm_backend.auth.dependencies.auth import get_current_auth_context
+from hrm_backend.auth.schemas.token_claims import AuthContext
+from hrm_backend.candidates.dependencies.candidates import get_candidate_storage
+from hrm_backend.core.models.base import Base
+from hrm_backend.main import app
+from hrm_backend.settings import AppSettings, get_settings
+from hrm_backend.vacancies.dependencies.vacancies import get_public_apply_rate_limiter
+from hrm_backend.vacancies.services.public_apply_rate_limiter import PublicApplyRateLimiter
+
+pytestmark = pytest.mark.anyio
+
+
+class InMemoryCandidateStorage:
+    """In-memory object storage replacement for integration tests."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, bytes] = {}
+
+    def put_object(
+        self,
+        *,
+        object_key: str,
+        data: bytes,
+        mime_type: str,
+        enable_sse: bool,
+    ) -> None:
+        del mime_type, enable_sse
+        self._store[object_key] = data
+
+    def get_object(self, *, object_key: str) -> bytes:
+        return self._store[object_key]
+
+
+@dataclass
+class _BucketState:
+    count: int = 0
+    expires_at: float | None = None
+
+
+class FakeRedis:
+    """Minimal in-memory Redis emulator for integration limiter tests."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, _BucketState] = {}
+        self._now = time()
+
+    def incr(self, key: str) -> int:
+        self._cleanup_key_if_expired(key)
+        state = self._store.setdefault(key, _BucketState())
+        state.count += 1
+        return state.count
+
+    def expire(self, key: str, seconds: int) -> bool:
+        state = self._store.setdefault(key, _BucketState())
+        state.expires_at = self._now + seconds
+        return True
+
+    def ttl(self, key: str) -> int:
+        self._cleanup_key_if_expired(key)
+        state = self._store.get(key)
+        if state is None:
+            return -2
+        if state.expires_at is None:
+            return -1
+        return max(int(state.expires_at - self._now), 0)
+
+    def _cleanup_key_if_expired(self, key: str) -> None:
+        state = self._store.get(key)
+        if state is None or state.expires_at is None:
+            return
+        if state.expires_at > self._now:
+            return
+        self._store.pop(key, None)
+
+
+@pytest.fixture()
+def sqlite_database_url(tmp_path: Path) -> str:
+    """Provide temporary SQLite URL for integration tests."""
+    return f"sqlite+pysqlite:///{tmp_path / 'public_apply_hardening.db'}"
+
+
+@pytest.fixture()
+def configured_app(sqlite_database_url: str):
+    """Configure app dependency overrides for public apply hardening tests."""
+    settings = AppSettings(
+        database_url=sqlite_database_url,
+        redis_url="redis://localhost:6379/15",
+        jwt_secret="integration-secret-with-minimum-32-bytes",
+        cv_max_size_bytes=1024,
+        public_apply_rate_limit_ip=20,
+        public_apply_rate_limit_ip_window_seconds=15 * 60,
+        public_apply_rate_limit_ip_vacancy=20,
+        public_apply_rate_limit_ip_vacancy_window_seconds=15 * 60,
+        public_apply_rate_limit_email_vacancy=20,
+        public_apply_rate_limit_email_vacancy_window_seconds=24 * 60 * 60,
+        public_apply_dedup_window_seconds=24 * 60 * 60,
+        public_apply_email_cooldown_seconds=60,
+    )
+    storage = InMemoryCandidateStorage()
+    redis = FakeRedis()
+    context_holder = {
+        "context": AuthContext(
+            subject_id=uuid4(),
+            role="hr",
+            session_id=uuid4(),
+            token_id=uuid4(),
+            expires_at=9999999999,
+        )
+    }
+
+    def _get_settings_override() -> AppSettings:
+        return settings
+
+    def _get_auth_context_override() -> AuthContext:
+        return context_holder["context"]
+
+    def _get_storage_override() -> InMemoryCandidateStorage:
+        return storage
+
+    def _get_rate_limiter_override() -> PublicApplyRateLimiter:
+        return PublicApplyRateLimiter(
+            redis_client=redis,  # type: ignore[arg-type]
+            key_prefix=settings.public_apply_rate_limit_redis_prefix,
+            ip_limit=settings.public_apply_rate_limit_ip,
+            ip_window_seconds=settings.public_apply_rate_limit_ip_window_seconds,
+            ip_vacancy_limit=settings.public_apply_rate_limit_ip_vacancy,
+            ip_vacancy_window_seconds=settings.public_apply_rate_limit_ip_vacancy_window_seconds,
+            email_vacancy_limit=settings.public_apply_rate_limit_email_vacancy,
+            email_vacancy_window_seconds=settings.public_apply_rate_limit_email_vacancy_window_seconds,
+        )
+
+    app.dependency_overrides[get_settings] = _get_settings_override
+    app.dependency_overrides[get_current_auth_context] = _get_auth_context_override
+    app.dependency_overrides[get_candidate_storage] = _get_storage_override
+    app.dependency_overrides[get_public_apply_rate_limiter] = _get_rate_limiter_override
+
+    engine = create_engine(sqlite_database_url, future=True)
+    Base.metadata.create_all(engine)
+    try:
+        yield app, settings, sqlite_database_url
+    finally:
+        app.dependency_overrides.pop(get_settings, None)
+        app.dependency_overrides.pop(get_current_auth_context, None)
+        app.dependency_overrides.pop(get_candidate_storage, None)
+        app.dependency_overrides.pop(get_public_apply_rate_limiter, None)
+        engine.dispose()
+
+
+@pytest.fixture()
+async def api_client(configured_app) -> AsyncClient:
+    """Provide async API client for public apply integration tests."""
+    configured, *_ = configured_app
+    async with AsyncClient(
+        transport=ASGITransport(app=configured),
+        base_url="http://testserver",
+    ) as client:
+        yield client
+
+
+def _load_events(database_url: str) -> list[AuditEvent]:
+    """Load ordered audit events from database URL."""
+    engine = create_engine(database_url, future=True)
+    try:
+        with Session(engine) as session:
+            return list(
+                session.execute(
+                    select(AuditEvent).order_by(AuditEvent.occurred_at, AuditEvent.event_id)
+                ).scalars()
+            )
+    finally:
+        engine.dispose()
+
+
+async def _create_vacancy(api_client: AsyncClient, suffix: str) -> str:
+    response = await api_client.post(
+        "/api/v1/vacancies",
+        json={
+            "title": f"Vacancy {suffix}",
+            "description": "Build hiring pipeline",
+            "department": "Engineering",
+            "status": "open",
+        },
+    )
+    assert response.status_code == 200
+    return response.json()["vacancy_id"]
+
+
+async def _apply_public(
+    api_client: AsyncClient,
+    *,
+    vacancy_id: str,
+    email: str,
+    cv_seed: str,
+    website: str | None = None,
+) -> Any:
+    content = f"cv-content-{cv_seed}".encode()
+    checksum = hashlib.sha256(content).hexdigest()
+    data: dict[str, str] = {
+        "first_name": "Alice",
+        "last_name": "Doe",
+        "email": email,
+        "phone": "+375291112233",
+        "checksum_sha256": checksum,
+    }
+    if website is not None:
+        data["website"] = website
+    return await api_client.post(
+        f"/api/v1/vacancies/{vacancy_id}/applications",
+        data=data,
+        files={"file": ("cv.pdf", content, "application/pdf")},
+    )
+
+
+def _extract_apply_failure_reasons(database_url: str) -> list[str]:
+    return [
+        str(event.reason)
+        for event in _load_events(database_url)
+        if event.action == "vacancy:apply_public" and event.result == "failure"
+    ]
+
+
+async def test_public_apply_honeypot_rejected_with_reason_code(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
+    """Verify honeypot field blocks request and writes specific audit reason."""
+    _, _, database_url = configured_app
+    vacancy_id = await _create_vacancy(api_client, "honeypot")
+
+    response = await _apply_public(
+        api_client,
+        vacancy_id=vacancy_id,
+        email="honeypot@example.com",
+        cv_seed="honeypot",
+        website="https://bot.invalid",
+    )
+    assert response.status_code == 422
+
+    reasons = _extract_apply_failure_reasons(database_url)
+    assert "honeypot_triggered" in reasons
+
+
+async def test_public_apply_rate_limit_ip_scope_returns_429_headers(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
+    """Verify IP rate limit returns 429 with required headers and reason code."""
+    _, settings, database_url = configured_app
+    settings.public_apply_rate_limit_ip = 2
+    settings.public_apply_rate_limit_ip_vacancy = 20
+    settings.public_apply_rate_limit_email_vacancy = 20
+    settings.public_apply_email_cooldown_seconds = 0
+    settings.public_apply_dedup_window_seconds = 0
+
+    vacancy_1 = await _create_vacancy(api_client, "ip-1")
+    vacancy_2 = await _create_vacancy(api_client, "ip-2")
+    vacancy_3 = await _create_vacancy(api_client, "ip-3")
+
+    assert (
+        await _apply_public(
+            api_client,
+            vacancy_id=vacancy_1,
+            email="ip-1@example.com",
+            cv_seed="ip-1",
+        )
+    ).status_code == 200
+    assert (
+        await _apply_public(
+            api_client,
+            vacancy_id=vacancy_2,
+            email="ip-2@example.com",
+            cv_seed="ip-2",
+        )
+    ).status_code == 200
+    blocked = await _apply_public(
+        api_client,
+        vacancy_id=vacancy_3,
+        email="ip-3@example.com",
+        cv_seed="ip-3",
+    )
+    assert blocked.status_code == 429
+    expected_headers = {
+        "Retry-After",
+        "X-RateLimit-Limit",
+        "X-RateLimit-Remaining",
+        "X-RateLimit-Reset",
+    }
+    expected_headers_lower = {header.lower() for header in expected_headers}
+    assert expected_headers_lower <= set(blocked.headers.keys())
+
+    reasons = _extract_apply_failure_reasons(database_url)
+    assert "rate_limited" in reasons
+
+
+async def test_public_apply_rate_limit_ip_vacancy_scope(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
+    """Verify IP+vacancy rate limit blocks repeated submissions to one vacancy."""
+    _, settings, _ = configured_app
+    settings.public_apply_rate_limit_ip = 20
+    settings.public_apply_rate_limit_ip_vacancy = 1
+    settings.public_apply_rate_limit_email_vacancy = 20
+    settings.public_apply_email_cooldown_seconds = 0
+    settings.public_apply_dedup_window_seconds = 0
+    vacancy_id = await _create_vacancy(api_client, "ip-vacancy")
+
+    first = await _apply_public(
+        api_client,
+        vacancy_id=vacancy_id,
+        email="ip-vacancy-1@example.com",
+        cv_seed="ip-vacancy-1",
+    )
+    second = await _apply_public(
+        api_client,
+        vacancy_id=vacancy_id,
+        email="ip-vacancy-2@example.com",
+        cv_seed="ip-vacancy-2",
+    )
+    assert first.status_code == 200
+    assert second.status_code == 429
+
+
+async def test_public_apply_rate_limit_email_vacancy_scope(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
+    """Verify email+vacancy rate limit is enforced for repeated submissions."""
+    _, settings, _ = configured_app
+    settings.public_apply_rate_limit_ip = 20
+    settings.public_apply_rate_limit_ip_vacancy = 20
+    settings.public_apply_rate_limit_email_vacancy = 1
+    settings.public_apply_email_cooldown_seconds = 0
+    settings.public_apply_dedup_window_seconds = 0
+    vacancy_id = await _create_vacancy(api_client, "email-vacancy")
+
+    first = await _apply_public(
+        api_client,
+        vacancy_id=vacancy_id,
+        email="same@example.com",
+        cv_seed="email-vacancy-1",
+    )
+    second = await _apply_public(
+        api_client,
+        vacancy_id=vacancy_id,
+        email="same@example.com",
+        cv_seed="email-vacancy-2",
+    )
+    assert first.status_code == 200
+    assert second.status_code == 429
+
+
+async def test_public_apply_duplicate_submission_rejected(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
+    """Verify duplicate checksum+vacancy is blocked with duplicate reason code."""
+    _, settings, database_url = configured_app
+    settings.public_apply_rate_limit_ip = 20
+    settings.public_apply_rate_limit_ip_vacancy = 20
+    settings.public_apply_rate_limit_email_vacancy = 20
+    settings.public_apply_email_cooldown_seconds = 0
+    settings.public_apply_dedup_window_seconds = 24 * 60 * 60
+    vacancy_id = await _create_vacancy(api_client, "duplicate")
+
+    first = await _apply_public(
+        api_client,
+        vacancy_id=vacancy_id,
+        email="duplicate-1@example.com",
+        cv_seed="same-seed",
+    )
+    second = await _apply_public(
+        api_client,
+        vacancy_id=vacancy_id,
+        email="duplicate-2@example.com",
+        cv_seed="same-seed",
+    )
+    assert first.status_code == 200
+    assert second.status_code == 409
+
+    reasons = _extract_apply_failure_reasons(database_url)
+    assert "duplicate_submission" in reasons
+
+
+async def test_public_apply_email_cooldown_rejected(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
+    """Verify cooldown guard rejects immediate second submission for one email+vacancy."""
+    _, settings, database_url = configured_app
+    settings.public_apply_rate_limit_ip = 20
+    settings.public_apply_rate_limit_ip_vacancy = 20
+    settings.public_apply_rate_limit_email_vacancy = 20
+    settings.public_apply_email_cooldown_seconds = 60
+    settings.public_apply_dedup_window_seconds = 0
+    vacancy_id = await _create_vacancy(api_client, "cooldown")
+
+    first = await _apply_public(
+        api_client,
+        vacancy_id=vacancy_id,
+        email="cooldown@example.com",
+        cv_seed="cooldown-1",
+    )
+    second = await _apply_public(
+        api_client,
+        vacancy_id=vacancy_id,
+        email="cooldown@example.com",
+        cv_seed="cooldown-2",
+    )
+    assert first.status_code == 200
+    assert second.status_code == 409
+
+    reasons = _extract_apply_failure_reasons(database_url)
+    assert "cooldown_active" in reasons

--- a/apps/backend/tests/unit/vacancies/test_public_apply_policy.py
+++ b/apps/backend/tests/unit/vacancies/test_public_apply_policy.py
@@ -1,0 +1,99 @@
+"""Unit tests for public apply anti-spam policy service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from hrm_backend.vacancies.schemas.application import (
+    PUBLIC_APPLY_REASON_COOLDOWN_ACTIVE,
+    PUBLIC_APPLY_REASON_DUPLICATE_SUBMISSION,
+    PUBLIC_APPLY_REASON_HONEYPOT_TRIGGERED,
+)
+from hrm_backend.vacancies.services.public_apply_exceptions import PublicApplyRejectedError
+from hrm_backend.vacancies.services.public_apply_policy import PublicApplyPolicyService
+
+
+@dataclass
+class _GuardDAOStub:
+    email_recent: bool = False
+    checksum_recent: bool = False
+
+    def has_recent_submission_for_email(
+        self,
+        *,
+        vacancy_id: str,
+        email: str,
+        window_seconds: int,
+    ) -> bool:
+        del vacancy_id, email, window_seconds
+        return self.email_recent
+
+    def has_recent_submission_for_checksum(
+        self,
+        *,
+        vacancy_id: str,
+        checksum_sha256: str,
+        window_seconds: int,
+    ) -> bool:
+        del vacancy_id, checksum_sha256, window_seconds
+        return self.checksum_recent
+
+
+def test_honeypot_submission_is_rejected() -> None:
+    """Verify non-empty honeypot field triggers blocked response."""
+    policy = PublicApplyPolicyService(
+        guard_dao=_GuardDAOStub(),
+        email_cooldown_seconds=60,
+        dedup_window_seconds=24 * 60 * 60,
+    )
+
+    with pytest.raises(PublicApplyRejectedError) as exc_info:
+        policy.enforce_honeypot(website="https://spam.invalid")
+
+    assert exc_info.value.reason_code == PUBLIC_APPLY_REASON_HONEYPOT_TRIGGERED
+    assert exc_info.value.status_code == 422
+
+
+def test_email_cooldown_rejects_recent_submission() -> None:
+    """Verify cooldown guard returns explicit cooldown reason code."""
+    policy = PublicApplyPolicyService(
+        guard_dao=_GuardDAOStub(email_recent=True),
+        email_cooldown_seconds=60,
+        dedup_window_seconds=24 * 60 * 60,
+    )
+
+    with pytest.raises(PublicApplyRejectedError) as exc_info:
+        policy.enforce_email_cooldown(vacancy_id="vacancy-1", email="user@example.com")
+
+    assert exc_info.value.reason_code == PUBLIC_APPLY_REASON_COOLDOWN_ACTIVE
+    assert exc_info.value.status_code == 409
+
+
+def test_checksum_dedup_rejects_duplicate_submission() -> None:
+    """Verify checksum dedup guard rejects duplicate requests."""
+    policy = PublicApplyPolicyService(
+        guard_dao=_GuardDAOStub(checksum_recent=True),
+        email_cooldown_seconds=60,
+        dedup_window_seconds=24 * 60 * 60,
+    )
+
+    with pytest.raises(PublicApplyRejectedError) as exc_info:
+        policy.enforce_checksum_dedup(vacancy_id="vacancy-1", checksum_sha256="a" * 64)
+
+    assert exc_info.value.reason_code == PUBLIC_APPLY_REASON_DUPLICATE_SUBMISSION
+    assert exc_info.value.status_code == 409
+
+
+def test_policy_passes_when_no_blocking_conditions_met() -> None:
+    """Verify policy allows request when honeypot/cooldown/dedup checks are clear."""
+    policy = PublicApplyPolicyService(
+        guard_dao=_GuardDAOStub(),
+        email_cooldown_seconds=60,
+        dedup_window_seconds=24 * 60 * 60,
+    )
+
+    policy.enforce_honeypot(website=None)
+    policy.enforce_email_cooldown(vacancy_id="vacancy-1", email="user@example.com")
+    policy.enforce_checksum_dedup(vacancy_id="vacancy-1", checksum_sha256="a" * 64)

--- a/apps/backend/tests/unit/vacancies/test_public_apply_rate_limiter.py
+++ b/apps/backend/tests/unit/vacancies/test_public_apply_rate_limiter.py
@@ -1,0 +1,129 @@
+"""Unit tests for Redis-backed public apply rate limiter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import time
+
+import pytest
+
+from hrm_backend.vacancies.schemas.application import PUBLIC_APPLY_REASON_RATE_LIMITED
+from hrm_backend.vacancies.services.public_apply_exceptions import PublicApplyRejectedError
+from hrm_backend.vacancies.services.public_apply_rate_limiter import PublicApplyRateLimiter
+
+
+@dataclass
+class _BucketState:
+    count: int = 0
+    expires_at: float | None = None
+
+
+class FakeRedis:
+    """Minimal in-memory Redis emulator for limiter unit tests."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, _BucketState] = {}
+        self._now = time()
+
+    def incr(self, key: str) -> int:
+        self._cleanup_key_if_expired(key)
+        state = self._store.setdefault(key, _BucketState())
+        state.count += 1
+        return state.count
+
+    def expire(self, key: str, seconds: int) -> bool:
+        state = self._store.setdefault(key, _BucketState())
+        state.expires_at = self._now + seconds
+        return True
+
+    def ttl(self, key: str) -> int:
+        self._cleanup_key_if_expired(key)
+        state = self._store.get(key)
+        if state is None:
+            return -2
+        if state.expires_at is None:
+            return -1
+        return max(int(state.expires_at - self._now), 0)
+
+    def _cleanup_key_if_expired(self, key: str) -> None:
+        state = self._store.get(key)
+        if state is None or state.expires_at is None:
+            return
+        if state.expires_at > self._now:
+            return
+        self._store.pop(key, None)
+
+
+def test_limiter_blocks_when_ip_bucket_exceeded() -> None:
+    """Verify limiter rejects requests when IP bucket crosses threshold."""
+    limiter = PublicApplyRateLimiter(
+        redis_client=FakeRedis(),
+        key_prefix="test:apply",
+        ip_limit=2,
+        ip_window_seconds=60,
+        ip_vacancy_limit=20,
+        ip_vacancy_window_seconds=60,
+        email_vacancy_limit=20,
+        email_vacancy_window_seconds=60,
+    )
+
+    limiter.enforce(ip="10.0.0.1", vacancy_id="vacancy-1", email="user-1@example.com")
+    limiter.enforce(ip="10.0.0.1", vacancy_id="vacancy-2", email="user-2@example.com")
+
+    with pytest.raises(PublicApplyRejectedError) as exc_info:
+        limiter.enforce(ip="10.0.0.1", vacancy_id="vacancy-3", email="user-3@example.com")
+
+    assert exc_info.value.reason_code == PUBLIC_APPLY_REASON_RATE_LIMITED
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.headers is not None
+    expected_headers = {
+        "Retry-After",
+        "X-RateLimit-Limit",
+        "X-RateLimit-Remaining",
+        "X-RateLimit-Reset",
+    }
+    assert expected_headers <= set(exc_info.value.headers)
+
+
+def test_limiter_blocks_on_ip_vacancy_scope_before_global_ip_scope() -> None:
+    """Verify dedicated IP+vacancy bucket can block while global IP bucket still allows."""
+    limiter = PublicApplyRateLimiter(
+        redis_client=FakeRedis(),
+        key_prefix="test:apply",
+        ip_limit=20,
+        ip_window_seconds=60,
+        ip_vacancy_limit=1,
+        ip_vacancy_window_seconds=60,
+        email_vacancy_limit=20,
+        email_vacancy_window_seconds=60,
+    )
+
+    limiter.enforce(ip="10.0.0.1", vacancy_id="vacancy-1", email="user-1@example.com")
+
+    with pytest.raises(PublicApplyRejectedError) as exc_info:
+        limiter.enforce(ip="10.0.0.1", vacancy_id="vacancy-1", email="user-2@example.com")
+
+    assert exc_info.value.reason_code == PUBLIC_APPLY_REASON_RATE_LIMITED
+    assert "ip+vacancy" in str(exc_info.value.detail)
+
+
+def test_limiter_normalizes_email_for_email_vacancy_scope() -> None:
+    """Verify same email in different case shares one email+vacancy limiter bucket."""
+    limiter = PublicApplyRateLimiter(
+        redis_client=FakeRedis(),
+        key_prefix="test:apply",
+        ip_limit=20,
+        ip_window_seconds=60,
+        ip_vacancy_limit=20,
+        ip_vacancy_window_seconds=60,
+        email_vacancy_limit=1,
+        email_vacancy_window_seconds=60,
+    )
+
+    limiter.enforce(ip="10.0.0.1", vacancy_id="vacancy-1", email="User@example.com")
+
+    with pytest.raises(PublicApplyRejectedError) as exc_info:
+        limiter.enforce(ip="10.0.0.1", vacancy_id="vacancy-1", email="user@example.com")
+
+    assert exc_info.value.reason_code == PUBLIC_APPLY_REASON_RATE_LIMITED
+    assert "email+vacancy" in str(exc_info.value.detail)

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -21,6 +21,7 @@ Use this log for decisions that change interfaces, data models, deployment topol
 | ADR-0014 | 2026-03-04 | accepted | Replace candidate auth flow with public vacancy application endpoint | architect + backend-engineer | recruitment API, RBAC, audit model |
 | ADR-0015 | 2026-03-04 | accepted | Use Celery as execution engine for CV parsing with DB job table as source of truth | architect + backend-engineer | async runtime, operations, reliability |
 | ADR-0016 | 2026-03-04 | accepted | Remove legacy auth login payload and temporary settings compatibility shims | architect + backend-engineer | auth API contract, backend shared config imports |
+| ADR-0017 | 2026-03-05 | accepted | Add layered anti-abuse controls for public vacancy application endpoint | architect + backend-engineer | recruitment API, observability, operations |
 
 ## ADR-0001
 - Context: Project is at bootstrap stage and lacks durable knowledge artifacts.
@@ -226,3 +227,21 @@ Use this log for decisions that change interfaces, data models, deployment topol
   - Login API contract is simplified and explicit.
   - Internal imports are normalized to one settings source of truth.
   - Legacy clients that still send `subject_id + role` must migrate before upgrade.
+
+## ADR-0017
+- Context: Public vacancy application endpoint is anonymous and vulnerable to spam and abuse without explicit guardrails.
+- Decision:
+  - Add Redis-backed rate limiting on three scopes:
+    - `ip`
+    - `ip+vacancy`
+    - `email+vacancy`
+  - Add anti-spam policy checks:
+    - honeypot field (`website`)
+    - duplicate checksum detection (`vacancy_id + checksum_sha256`)
+    - cooldown window for repeated submissions per `email+vacancy`.
+  - Extend audit failure reason codes for `vacancy:apply_public`.
+  - Emit structured monitoring signals for success/blocked outcomes.
+- Consequences:
+  - Public apply path gains deterministic abuse controls and clearer diagnostics.
+  - Endpoint contract now includes `409/429` paths and rate-limit headers.
+  - Operations must monitor blocked-rate anomalies and maintain Redis availability.

--- a/docs/architecture/diagrams.md
+++ b/docs/architecture/diagrams.md
@@ -1,7 +1,7 @@
 # Architecture Diagrams
 
 ## Last Updated
-- Date: 2026-03-04
+- Date: 2026-03-05
 - Updated by: architect + backend-engineer
 
 This file is the canonical diagram set for the system. Update diagrams whenever architecture, data flow, or critical business flow changes.
@@ -227,18 +227,25 @@ sequenceDiagram
   participant UI as React.js + TypeScript UI
   participant API as API Gateway
   participant VAC as Vacancy Application Service
+  participant RL as Redis Rate Limiter
   participant DB as PostgreSQL
   participant OBJ as MinIO
   participant Q as Celery/Redis
+  participant AUD as Audit/Monitoring
 
   C->>UI: Fill contacts + upload CV
   UI->>API: POST /api/v1/vacancies/{vacancy_id}/applications
-  API->>VAC: validate vacancy + cv payload
+  API->>VAC: validate anti-abuse + vacancy + cv payload
+  VAC->>RL: check buckets (ip, ip+vacancy, email+vacancy)
+  RL-->>VAC: allow / reject(429)
+  VAC->>DB: check honeypot + dedup + cooldown guards
+  DB-->>VAC: allow / reject(409|422)
+  VAC->>AUD: write success/failure reason code + counters
   VAC->>DB: upsert candidate_profiles
   VAC->>OBJ: put CV object (SSE-S3)
   VAC->>DB: insert candidate_documents + pipeline_transitions (None->applied) + cv_parsing_jobs(queued)
   VAC->>Q: enqueue process_cv_parsing_job(job_id)
-  API-->>UI: 201 Created (candidate_id, document_id, job_id)
+  API-->>UI: 201 Created or 409/422/429 with diagnostics
 ```
 
 ## Diagram 8: Delivery Pipeline (GitHub + CI)

--- a/docs/operations/release-checklist.md
+++ b/docs/operations/release-checklist.md
@@ -12,6 +12,7 @@
 - [ ] Smoke checks passed.
 - [ ] Monitoring and alerts verified.
 - [ ] Container baseline check passed (`docker compose config` + service health checks).
+- [ ] Public apply anti-abuse checks verified (`409/429` paths, rate-limit headers, audit reason codes).
 
 ## Post-Release
 - [ ] No critical regressions within observation window.

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -85,6 +85,28 @@ Shortcut wrappers:
 - Auth validation is fail-closed when Redis denylist is unavailable.
 - Expected behavior during Redis outage: protected auth checks return `503`.
 
+### Public Apply Abuse Diagnostics
+- Endpoint: `POST /api/v1/vacancies/{vacancy_id}/applications`.
+- Expected anti-abuse responses:
+  - `429 Too Many Requests` with headers:
+    - `Retry-After`
+    - `X-RateLimit-Limit`
+    - `X-RateLimit-Remaining`
+    - `X-RateLimit-Reset`
+  - `409 Conflict` for duplicate submission and active cooldown.
+  - `422` for honeypot trigger or validation failure.
+- Audit failure reason codes (`action=vacancy:apply_public`):
+  - `rate_limited`
+  - `honeypot_triggered`
+  - `duplicate_submission`
+  - `cooldown_active`
+  - `validation_failed`
+- Triage sequence:
+  1. Check API response status and reason code.
+  2. Query `audit_events` by `action=vacancy:apply_public` and recent `correlation_id`.
+  3. Verify Redis availability and limiter key activity.
+  4. Compare blocked volume with alert threshold (`PUBLIC_APPLY_BLOCKED_ALERT_THRESHOLD_PER_MINUTE`).
+
 ## Compliance Baseline (Dev Non-Blocking, Prod Blocking)
 This section defines provisional operational controls until final legal/security sign-off.
 

--- a/docs/testing/strategy.md
+++ b/docs/testing/strategy.md
@@ -36,6 +36,18 @@ apps/backend/tests/
     ...
 ```
 
+## Integration Harness Stability Rules
+- Canonical HTTP integration harness: `pytest-anyio` + `httpx.AsyncClient` + `ASGITransport`.
+- Do not use `starlette.testclient.TestClient` in backend integration tests.
+- Keep integration runtime pinned to `anyio_backend = "asyncio"` in `apps/backend/tests/integration/conftest.py`.
+- Keep `inline_threadpool_patch` integration-only; it exists to avoid environment-specific deadlocks in `anyio.to_thread` during in-process ASGI runs.
+- Integration tests should override external adapters (Redis/object storage/auth context) through FastAPI dependency overrides to keep runs deterministic.
+
+### Mandatory Pre-PR Smoke Gate (Security/Auth Integration)
+- Run before PR-B/PR-C/PR-D style contract-sensitive backend changes:
+  - `uv run --project apps/backend pytest -q apps/backend/tests/integration/security/test_audit_enforcement.py apps/backend/tests/integration/auth/test_auth_stack.py`
+- The gate must pass in two consecutive runs when harness-level changes are introduced.
+
 ## Change-Based Verification Matrix
 | Change Type | Required Checks |
 | --- | --- |


### PR DESCRIPTION
## Scope\n- Stabilize integration harness for deterministic runs\n- Add anti-abuse controls for public apply endpoint: redis rate limits, honeypot, dedup, cooldown\n- Extend audit reason codes and monitoring/logging for blocked and success paths\n- Update runbook and release checklist for 429 and abuse diagnostics\n\n## Verification\n- ./scripts/check-docs-structure.sh\n- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend ruff check apps/backend/src apps/backend/tests apps/backend/alembic\n- uv run --project apps/backend pytest -q apps/backend/tests/unit/vacancies/test_public_apply_policy.py apps/backend/tests/unit/vacancies/test_public_apply_rate_limiter.py apps/backend/tests/integration/vacancies/test_public_apply_hardening.py\n- uv run --project apps/backend pytest -q apps/backend/tests/integration/security/test_audit_enforcement.py apps/backend/tests/integration/auth/test_refresh_session_security.py\n\n## Notes\n- Replaces closed stacked PR #45 after PR-A branch deletion.