### PR TITLE
docs(compliance): add legal evidence registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ Shortcut commands:
 - PR Definition of Done: `.github/PULL_REQUEST_TEMPLATE.md`
 - Approved M1 sprint ownership: `docs/project/sprint-m1-plan.md`
 - Legal mapping (NPA -> controls): `docs/project/legal-controls-matrix.md`
+- Compliance evidence ownership: `docs/project/evidence-registry.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ This folder is the single source of truth for project context required for deliv
 - `project/migration-notes-auth-login.md`: Client migration note for auth login contract changes
 - `project/legal-framework.md`: Priority NPAs for Belarus and Russia compliance baseline
 - `project/legal-controls-matrix.md`: NPA-to-controls compliance tracking matrix
+- `project/evidence-registry.md`: Evidence ownership and verification registry for compliance controls
 - `project/rbac-matrix.md`: Phase-1 role and permission matrix baseline
 - `project/auth-session-lifecycle.md`: Authentication/session lifecycle baseline and API contract
 - `architecture/overview.md`: System architecture and boundaries

--- a/docs/operations/release-checklist.md
+++ b/docs/operations/release-checklist.md
@@ -3,6 +3,7 @@
 ## Pre-Release
 - [ ] Acceptance criteria are satisfied.
 - [ ] Required tests passed and evidence attached.
+- [ ] Legal controls matrix and evidence registry are current (`docs/project/legal-controls-matrix.md`, `docs/project/evidence-registry.md`).
 - [ ] OpenAPI frozen contract check passed (`./scripts/check-openapi-freeze.sh`).
 - [ ] PostgreSQL migrations verified (`alembic upgrade head` / rollback check as needed).
 - [ ] Rollback strategy is documented.

--- a/docs/project/evidence-registry.md
+++ b/docs/project/evidence-registry.md
@@ -1,0 +1,39 @@
+# Evidence Registry
+
+## Last Updated
+- Date: 2026-03-09
+- Updated by: business-analyst + architect + frontend-engineer + backend-engineer
+
+## Registry Model
+- `Evidence ID`: stable identifier for cross-references from `legal-controls-matrix.md`.
+- `Control IDs`: legal controls supported by the artifact.
+- `Owner`: who must refresh the evidence when the trigger fires.
+- `Artifact`: only real in-repo code/docs/scripts/tests or repeatable commands.
+- `Verification Source`: command or procedure that proves the artifact is current.
+- `Update Trigger`: concrete change that requires the row to be refreshed.
+
+## Evidence Entries
+
+| Evidence ID | Control IDs | Owner | Artifact | Verification Source | Update Trigger |
+| --- | --- | --- | --- | --- | --- |
+| EVID-001 | CTRL-BY-03, CTRL-RU-02, CTRL-RU-05 | backend-engineer + architect | `apps/backend/src/hrm_backend/rbac.py`, `apps/backend/src/hrm_backend/audit/`, `apps/backend/alembic/versions/20260304_000002_audit_events.py`, `docs/project/rbac-matrix.md`, `docs/project/auth-session-lifecycle.md` | `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend pytest -q apps/backend/tests/integration/security/test_audit_enforcement.py apps/backend/tests/integration/auth/test_auth_stack.py` | Any RBAC permission, audit payload, auth session, or audit migration change |
+| EVID-002 | CTRL-BY-01, CTRL-RU-01 | backend-engineer + frontend-engineer | `docs/api/openapi.frozen.json`, `apps/frontend/src/api/generated/openapi-types.ts` | `./scripts/check-openapi-freeze.sh`, `npm --prefix apps/frontend run api:types:check` | Any public API contract or generated type change |
+| EVID-003 | CTRL-BY-01, CTRL-RU-01 | frontend-engineer | `apps/frontend/src/pages/CandidatePage.tsx`, `apps/frontend/src/pages/LoginPage.tsx`, `apps/frontend/src/api/auth.ts` | `npm --prefix apps/frontend run test -- --run src/pages/CandidatePage.test.tsx src/pages/LoginPage.test.tsx src/api/auth.test.ts` | Any field added/removed on login or candidate-apply flows |
+| EVID-004 | CTRL-BY-03, CTRL-RU-05 | qa-engineer + devops-engineer | `./scripts/smoke-compose.sh`, `scripts/browser_auth_smoke.py`, `scripts/browser_candidate_apply_smoke.py` | `docker compose up -d --build`, `./scripts/smoke-compose.sh` | Any compose topology, critical browser flow, or CORS/runtime change |
+| EVID-005 | CTRL-RU-02 | frontend-engineer | `apps/frontend/src/app/observability/sentry.ts`, `apps/frontend/src/app/observability/AppErrorBoundary.tsx`, `apps/frontend/src/main.tsx` | `npm --prefix apps/frontend run test -- --run src/api/httpClient.test.ts src/app/router.observability.test.tsx src/app/observability/AppErrorBoundary.test.tsx` | Any critical-route list, Sentry env contract, or shared HTTP-capture change |
+| EVID-006 | CTRL-BY-03 | devops-engineer + backend-engineer | `.env.example`, `docker-compose.yml`, `docs/operations/runbook.md` | `./scripts/check-docs-structure.sh`, compose config review, `./scripts/smoke-compose.sh` | Any object-storage, encryption, compose env, or runbook change |
+| EVID-007 | CTRL-RU-01, CTRL-RU-02 | backend-engineer + frontend-engineer | `apps/backend/tests/integration/candidates/test_candidate_api.py`, `apps/backend/tests/integration/scoring/test_match_scoring_api.py`, `apps/frontend/src/pages/HrDashboardPage.test.tsx` | `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend pytest -q apps/backend/tests/integration/candidates/test_candidate_api.py apps/backend/tests/integration/scoring/test_match_scoring_api.py`, `npm --prefix apps/frontend run test -- --run src/pages/HrDashboardPage.test.tsx` | Any candidate-analysis, scoring contract, shortlist review, or evidence payload change |
+
+## Coverage Gaps (No Current Evidence Artifact)
+
+| Control ID | Missing Artifact | Owner | Due Trigger |
+| --- | --- | --- | --- |
+| CTRL-BY-02 | Runbook procedure for access/correction/deletion or stop-processing requests | backend + hr-ops | Before any public subject-rights workflow or production readiness review |
+| CTRL-RU-03 | Runbook/ticket workflow for data-subject requests under 152-ФЗ | backend + hr-ops | Before any production readiness review |
+| CTRL-RU-04 | Infra/data-residency ADR and deployment evidence for RU localization | architect + devops | Before storing production RU citizen data |
+| CTRL-RU-06 | ISPDn class checklist and attestation pack | security + business-analyst | Before first production release |
+
+## Usage Rules
+- Use this registry together with `docs/project/legal-controls-matrix.md`; do not treat it as a substitute for legal review.
+- When a verification command changes, update the matching `Evidence ID` row in the same change.
+- When an artifact path is removed or renamed, either replace the evidence with a new real artifact or move the control back to a gap state.

--- a/docs/project/legal-controls-matrix.md
+++ b/docs/project/legal-controls-matrix.md
@@ -1,45 +1,48 @@
 # Legal Controls Matrix (Belarus + Russia)
 
 ## Last Updated
-- Date: 2026-03-06
-- Updated by: business-analyst + backend-engineer
+- Date: 2026-03-09
+- Updated by: business-analyst + architect + backend-engineer
 
 ## Status Legend
-- `planned`: control designed, not implemented.
-- `in-progress`: implementation started.
-- `implemented`: implemented in code/process.
+- `planned`: control not yet represented by a concrete product/process artifact in the repo.
+- `in-progress`: some repo artifacts exist, but the control is not yet complete enough for release sign-off.
+- `implemented`: control is represented by concrete code/process artifacts and repeatable verification.
 - `verified`: evidence and legal/security review completed.
 
 ## Matrix
 
-| Jurisdiction | NPA | Obligation (short) | Control ID | Product/Process Control | Owner | Status | Evidence |
+| Jurisdiction | NPA / Article | Obligation (short) | Control ID | Product/Process Control | Owner | Status | Evidence |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Belarus | Law No. 99-З (2021) | Lawful and secure personal data processing | CTRL-BY-01 | Data inventory and processing purpose registry | business-analyst | planned | `docs/project/data-inventory.md` (to create) |
-| Belarus | Law No. 99-З (2021) | Data subject rights handling | CTRL-BY-02 | Request workflow: access/correction/deletion SLA | backend + hr-ops | planned | `docs/operations/runbook.md` update |
-| Belarus | Law No. 455-З (2008) | Information protection measures | CTRL-BY-03 | Encryption at rest/in transit + RBAC + audit logs | architect + backend | implemented | `docs/project/rbac-matrix.md`, `docs/project/auth-session-lifecycle.md`, `apps/backend/src/hrm_backend/audit/`, `apps/backend/src/hrm_backend/rbac.py` |
-| Russia | Federal Law 152-ФЗ | Personal data processing lawfulness and minimization | CTRL-RU-01 | Personal data classification and minimization policy | business-analyst | planned | Policy doc (to create) |
-| Russia | Federal Law 152-ФЗ | Security of PD information systems | CTRL-RU-02 | Threat model + protection controls baseline | architect + security | planned | `docs/architecture/decisions.md` entry |
-| Russia | Federal Law 242-ФЗ | Localization of Russian citizens' data | CTRL-RU-03 | Data residency control for RU citizen records | architect + devops | planned | Infrastructure ADR (to create) |
-| Russia | Federal Law 149-ФЗ | Information security and access protection | CTRL-RU-04 | Access control enforcement and immutable audit trail | backend | implemented | `docs/project/rbac-matrix.md`, `docs/project/auth-session-lifecycle.md`, `apps/backend/alembic/versions/20260304_000002_audit_events.py`, `apps/backend/src/hrm_backend/audit/`, PR #37 |
-| Russia | Decree No. 1119 (2012) | Organizational and technical PD protection requirements | CTRL-RU-05 | Security control checklist per ISPDn class | security + business-analyst | planned | Security checklist (to create) |
+| Belarus | Law No. 99-З (2021), Art. 5 | Obtain informed consent and limit consent payload to declared purposes | CTRL-BY-01 | Candidate/staff data collection uses explicit field contracts and frozen API payloads; separate purpose registry still missing | business-analyst + frontend | in-progress | `EVID-002`, `EVID-003` |
+| Belarus | Law No. 99-З (2021), Arts. 11, 13 | Support access, correction, and deletion/stop-processing requests | CTRL-BY-02 | Runbook workflow and owner model for subject requests | backend + hr-ops | planned | Coverage gap (see `docs/project/evidence-registry.md`) |
+| Belarus | Law No. 99-З (2021), Art. 17; Law No. 455-З (2008), Art. 17 | Protect restricted/personal information with legal, organizational, and technical measures | CTRL-BY-03 | RBAC, immutable audit events, object-storage protection baseline, and reproducible smoke verification | architect + backend + devops | implemented | `EVID-001`, `EVID-004`, `EVID-006` |
+| Russia | Federal Law 152-ФЗ, Art. 5 | Minimize collected PD and keep purpose-bound data contracts | CTRL-RU-01 | Frozen OpenAPI contract plus frontend/backend forms limited to the current Phase 1 fields | business-analyst + frontend + backend | in-progress | `EVID-002`, `EVID-003`, `EVID-007` |
+| Russia | Federal Law 152-ФЗ, Arts. 18.1, 19 | Implement operator measures and security baseline for PD processing | CTRL-RU-02 | RBAC/audit controls, scoring/candidate evidence traceability, and Sentry observability baseline | architect + backend + frontend | implemented | `EVID-001`, `EVID-005`, `EVID-007` |
+| Russia | Federal Law 152-ФЗ, Arts. 14, 20 | Provide data-subject access/correction/deletion workflow within statutory response path | CTRL-RU-03 | Request handling workflow and response SLA process | backend + hr-ops | planned | Coverage gap (see `docs/project/evidence-registry.md`) |
+| Russia | Federal Law 242-ФЗ; Federal Law 152-ФЗ, Art. 18(5) | Localize Russian citizens' data in the required jurisdiction | CTRL-RU-04 | Infrastructure/data-residency control for RU citizen records and backups | architect + devops | planned | Coverage gap (see `docs/project/evidence-registry.md`) |
+| Russia | Federal Law 149-ФЗ, Art. 16 | Apply organizational/technical measures to protect restricted information and access | CTRL-RU-05 | Unified access control enforcement, audit trail, compose smoke, and browser auth/public-flow verification | backend + devops | implemented | `EVID-001`, `EVID-004` |
+| Russia | Decree No. 1119 (2012) | Maintain class-based PD protection checklist and attestations | CTRL-RU-06 | Security control checklist by ISPDn class and release-time attestations | security + business-analyst | planned | Coverage gap (see `docs/project/evidence-registry.md`) |
 
 ## Control Detail (Obligation -> Control -> Evidence)
 
 | Control ID | Obligation Detail | Technical/Process Control | Evidence Baseline | Verification Baseline |
 | --- | --- | --- | --- | --- |
-| CTRL-BY-01 | Keep lawful basis and processing purpose for each PD category | Data inventory registry + purpose mapping document | `docs/project/data-inventory.md` (planned) | Legal review checklist before prod |
-| CTRL-BY-02 | Handle subject access/correction/deletion requests within SLA | Runbook procedure + ticket workflow + actor responsibility | `docs/operations/runbook.md` request handling section (planned) | Quarterly SLA evidence audit |
-| CTRL-BY-03 | Ensure confidentiality and integrity of PD systems | Encryption in transit, encryption at rest, RBAC, immutable audit events | `docs/operations/runbook.md`, `docs/project/rbac-matrix.md`, PR #37 | Security review + penetration test report |
-| CTRL-RU-01 | Minimize collected PD and justify processing | Data minimization policy per domain object and API payload | Policy doc (planned) | Product/legal sign-off before prod |
-| CTRL-RU-02 | Define protection baseline by threat model | Threat model + compensating controls registry | `docs/architecture/decisions.md` entry (planned) | Security architecture review |
-| CTRL-RU-03 | Localize RU citizens data in approved jurisdiction | Infrastructure placement controls + backup residency checks | Infra ADR (planned) | DevOps/legal go-live checklist |
-| CTRL-RU-04 | Enforce access controls and immutable logging | Unified policy evaluator for API/jobs + append-only audit events | PR #37 + `docs/project/auth-session-lifecycle.md` | Integration tests + DB audit trail sampling |
-| CTRL-RU-05 | Apply organizational/technical ISPDn safeguards | Control checklist by class + periodic control attestations | Security checklist (planned) | External/internal security audit |
+| CTRL-BY-01 | Consent must be informed and field scope limited to declared purposes | Candidate apply/login payloads stay frozen through OpenAPI and typed frontend forms | `EVID-002`, `EVID-003` | `./scripts/check-openapi-freeze.sh`, `npm --prefix apps/frontend run api:types:check`, frontend tests |
+| CTRL-BY-02 | Subject must be able to request access/correction/deletion or stop-processing | Runbook procedure + owner/SLA workflow | No current evidence artifact | To implement under future request-handling slice |
+| CTRL-BY-03 | Personal/restricted information must be protected against unauthorized actions | RBAC enforcement, immutable audit events, storage/security baseline, smoke verification | `EVID-001`, `EVID-004`, `EVID-006` | backend security/auth tests, compose smoke, config review |
+| CTRL-RU-01 | Processing must stay purpose-bound and data-minimized | Frozen contracts and UI/API payload boundaries define the current Phase 1 data set | `EVID-002`, `EVID-003`, `EVID-007` | OpenAPI drift check, frontend tests, targeted backend/frontend scoring tests |
+| CTRL-RU-02 | Operator must implement and confirm adequate security measures | Access control, auditability, explainable AI artifacts, and critical-route observability | `EVID-001`, `EVID-005`, `EVID-007` | backend security tests, frontend observability tests, scoring/candidate test suites |
+| CTRL-RU-03 | Subject rights requests need a repeatable response workflow | Request intake/runbook + actor ownership | No current evidence artifact | To implement under future request-handling slice |
+| CTRL-RU-04 | RU citizens' PD must be stored/localized in the required jurisdiction | Infra placement and backup residency controls | No current evidence artifact | Infra/legal sign-off before production |
+| CTRL-RU-05 | Restricted information requires legal/organizational/technical protection measures | Access control, audit trail, and repeatable smoke verification of critical routes | `EVID-001`, `EVID-004` | backend security tests + compose/browser smoke |
+| CTRL-RU-06 | ISPDn safeguards must be documented and attested by class | Security checklist and attestation workflow | No current evidence artifact | External/internal security review before production |
 
 ## Delivery Gate
 - Current stage delivery target is local runtime on the current device; production launch is not in scope for this stage.
 - Development environment is non-blocking for controls in `planned` or `in-progress` status.
-- Production release is blocked until all critical controls (`CTRL-BY-03`, `CTRL-RU-02`, `CTRL-RU-03`, `CTRL-RU-04`, `CTRL-RU-05`) reach at least `implemented`.
+- Current repo-backed controls (`CTRL-BY-03`, `CTRL-RU-02`, `CTRL-RU-05`) can be treated as `implemented`, but none are `verified` yet.
+- Production release is blocked until all critical controls (`CTRL-BY-03`, `CTRL-RU-02`, `CTRL-RU-04`, `CTRL-RU-05`, `CTRL-RU-06`) reach at least `implemented`.
 - Production release is additionally blocked until legal sign-off confirms `verified` status and attached evidence for critical controls.
 - Execution tracking for this matrix is formalized under `EPIC-13` in:
   - `TASK-13-01` (article-level mapping),

--- a/docs/project/sprint-m1-plan.md
+++ b/docs/project/sprint-m1-plan.md
@@ -20,14 +20,14 @@ Current sprint acceptance target is stable local end-to-end operation on the cur
 | `TASK-11-11` | implemented/local-baseline | Compose browser smoke covers both staff login and public candidate apply journeys |
 | `TASK-04-01/02/03 + TASK-11-07` | implemented/local-scoring-slice | Dedicated scoring backend and shortlist review block are present in repo with frozen contract and compose/runtime wiring |
 | `TASK-11-10` | implemented/local-observability-slice | Critical-route Sentry tags, shared HTTP failure capture, render boundary, and release/env tracing config are present in repo |
-| `TASK-13-01/02` | next | Compliance mapping/evidence ownership should progress now that the controls, tests, smoke outputs, and observability baseline exist |
-| `TASK-11-08` | deferred/planning-blocked | Requires a dedicated planning pass for interview entity, registration, reschedule/cancel, and sync-conflict rules |
+| `TASK-13-01/02` | implemented/local-compliance-slice | Article-level control mapping and evidence registry are present in repo and linked to real artifacts |
+| `TASK-11-08` | next/planning-only | Requires a dedicated planning pass for interview entity, registration, reschedule/cancel, and sync-conflict rules |
 
 ## Scope Normalization
 - The original M1 sprint text stopped at FE-9, but the repo now contains a broader local acceptance baseline: `TASK-11-05`, `TASK-11-06`, `TASK-11-09`, and `TASK-11-11` are no longer future-only scope.
 - Immediate follow-on work must not reopen auth, CORS, routing topology, or transport architecture.
 - The scoring/shortlist-review track is now implemented in repo as one backend+frontend slice.
-- The current approved local diff is limited to `TASK-11-10` Sentry hardening.
+- The current approved local diff is limited to `TASK-13-01/02` compliance documentation and evidence ownership work.
 - Interview scheduling (`TASK-11-08`) is deliberately deferred until after a short planning pass.
 
 ## Phase 0 Merge Gate
@@ -51,17 +51,13 @@ Current sprint acceptance target is stable local end-to-end operation on the cur
 - After merge, sync local `main` before starting the next implementation increment.
 
 ## Approved Immediate Follow-On Slice
-- Implement `TASK-11-10` as a dedicated frontend observability slice.
+- Implement `TASK-13-01/02` as a dedicated compliance documentation slice.
 - Slice rules:
-  - keep route topology unchanged (`/`, `/candidate`, `/login`, `/admin`, `/admin/staff`, `/admin/employee-keys`);
-  - keep auth model, CORS model, and typed API contracts unchanged;
-  - emit canonical Sentry tags (`workspace`, `role`, `route`) on critical-route access;
-  - capture shared HTTP failures in the frontend HTTP client;
-  - capture render failures behind a top-level localized boundary;
-  - configure Sentry release/environment/tracing through frontend env variables.
+  - use only real repo-backed artifacts as evidence;
+  - update legal-controls matrix and evidence registry in the same change;
+  - do not change runtime, routing, auth, CORS, or API contracts.
 - Next after this slice:
-  - `TASK-13-01/02`;
-  - then a dedicated planning pass for `TASK-11-08`.
+  - a dedicated planning pass for `TASK-11-08`.
 
 ## Team Roles
 - architect

--- a/docs/project/tasks.md
+++ b/docs/project/tasks.md
@@ -28,24 +28,23 @@
 | TASK-04-01/02/03 | implemented/local-scoring-slice | Dedicated `hrm_backend/scoring` package, Ollama adapter, async scoring jobs/artifacts, and frozen scoring API contract are present in repo with unit and integration coverage |
 | TASK-11-07 | implemented/local-scoring-slice | `/` now includes shortlist review with `Run score`, polling, confidence/summary card, requirements delta, evidence, and localized `409/403/404/422` errors |
 | TASK-11-10 | implemented/local-observability-slice | Frontend Sentry now tags `/`, `/candidate`, `/login`, `/admin`, `/admin/staff`, and `/admin/employee-keys`; shared HTTP capture, render boundary, and release/env tracing config are present in repo with frontend unit coverage |
+| TASK-13-01/02 | implemented/local-compliance-slice | Legal-controls matrix now maps article-level obligations to current repo-backed controls and evidence registry entries with owners, verification sources, and update triggers |
 | COMPLIANCE-01 | planned | EPIC-13 article-level legal mapping and evidence pack track |
 
 ## 2026-03-09 Delivery Control Notes
 - Backend implementation is ahead of the original planning docs for `TASK-03-01/02/03/05/06` and `TASK-02-01/02/03`; these items are no longer backlog-only work.
 - The main remaining frontend gaps after the login/browser hotfix were `TASK-11-06` and `TASK-11-05`; the current repository now contains a local acceptance baseline for both flows.
 - The scoring/shortlist-review slice (`TASK-04-01/02/03 + TASK-11-07`) is now implemented in repo as one vertical delivery unit.
-- The current local diff is limited to `TASK-11-10` Sentry hardening without changing route topology, auth/CORS behavior, or frozen API contracts.
-- The next active workstream after observability is `TASK-13-01/02`, while `TASK-11-08` remains planning-blocked.
+- The compliance follow-on slice (`TASK-13-01/02`) is now implemented in repo as documentation and evidence-model work only; no runtime/API/routing changes were introduced.
+- The next active workstream after compliance is the dedicated planning pass for `TASK-11-08`.
 - `TASK-11-08` is explicitly deferred until a separate planning pass resolves interview entity boundaries, candidate registration/identity rules, reschedule/cancel semantics, and calendar sync conflict behavior.
 - Existing auth/CORS/public candidate transport assumptions stay unchanged across the observability and compliance follow-on slices.
 
-## Active Queue After Observability Slice
+## Active Queue After Compliance Slice
 
 | Order | Task ID | Why Now |
 | --- | --- | --- |
-| A-1 | TASK-13-01 | Compliance mapping can now point to real admin/candidate/HR/scoring/observability controls |
-| A-2 | TASK-13-02 | Evidence ownership can now attach to tests, OpenAPI artifacts, compose smoke, and Sentry QA checks |
-| A-3 | TASK-11-08 | Still deferred until a short planning pass closes interview workflow/product gaps |
+| A-1 | TASK-11-08 | Current blocker is no longer implementation capacity but missing product decisions; planning pass is the next required slice |
 
 - Execution rule: keep `TASK-11-08` blocked until the dedicated interview-planning pass is written down and approved.
 
@@ -207,7 +206,7 @@ Use this queue together with the global queue when planning phase implementation
 | FE-12 | TASK-11-11 | Delivered in local baseline: Chrome browser smoke for login + public candidate apply |
 | FE-13 | TASK-11-07 | Delivered in local scoring slice: shortlist review block inside the existing `/` HR workspace with scoring polling and explainable payload rendering |
 | FE-14 | TASK-11-10 | Delivered in local observability slice: Sentry hardening for critical routes, shared HTTP failure capture, render boundary, and release/env tracing config without route changes |
-| FE-15 | TASK-11-08 | Deferred until a short planning pass after scoring clarifies interview entity, registration, and sync behavior |
+| FE-15 | TASK-11-08 | Next planning-only slice after compliance: interview entity, registration, and sync rules still need a decision-complete spec |
 | FE-16 | ADMIN-04 | Unified admin CRUD consoles |
 | FE-17 | ADMIN-05 | Admin observability and audit dashboards |
 | FE-18 | TASK-11-12 | Phase-2 role workspace rollout |


### PR DESCRIPTION
## Summary
- add a repo-backed evidence registry for legal controls
- update the legal controls matrix to reference concrete evidence and current coverage gaps
- wire the new compliance registry into release/checklist and planning docs

## Verification
- ./scripts/check-docs-structure.sh