### PR TITLE
docs(interviews): freeze planning baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ Shortcut commands:
 - Approved M1 sprint ownership: `docs/project/sprint-m1-plan.md`
 - Legal mapping (NPA -> controls): `docs/project/legal-controls-matrix.md`
 - Compliance evidence ownership: `docs/project/evidence-registry.md`
+- Interview planning baseline: `docs/project/interview-planning-pass.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ This folder is the single source of truth for project context required for deliv
 - `project/legal-framework.md`: Priority NPAs for Belarus and Russia compliance baseline
 - `project/legal-controls-matrix.md`: NPA-to-controls compliance tracking matrix
 - `project/evidence-registry.md`: Evidence ownership and verification registry for compliance controls
+- `project/interview-planning-pass.md`: Decision-complete planning baseline for interview scheduling and candidate registration
 - `project/rbac-matrix.md`: Phase-1 role and permission matrix baseline
 - `project/auth-session-lifecycle.md`: Authentication/session lifecycle baseline and API contract
 - `architecture/overview.md`: System architecture and boundaries

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -32,6 +32,8 @@ Use this log for decisions that change interfaces, data models, deployment topol
 | ADR-0025 | 2026-03-06 | accepted | Track public candidate parsing by job ID and make browser smoke validate the full Phase 1 intake baseline | architect + backend-engineer + frontend-engineer | candidate workflow, compose runtime, browser verification, API contract |
 | ADR-0026 | 2026-03-09 | accepted | Land the Phase 1 baseline as one PR and make scoring the next vertical slice | architect + backend-engineer + frontend-engineer | delivery sequencing, scoring package boundary, API contracts, testing scope |
 | ADR-0027 | 2026-03-09 | accepted | Implement scoring as a dedicated backend package with DB-backed jobs/artifacts and shortlist review on `/` | architect + backend-engineer + frontend-engineer | scoring architecture, HR workspace UX, compose worker topology, OpenAPI contract |
+| ADR-0028 | 2026-03-09 | accepted | Harden frontend observability with canonical Sentry route tags and shared failure capture | architect + frontend-engineer | frontend observability, route semantics, error telemetry |
+| ADR-0029 | 2026-03-09 | accepted | Freeze interview scheduling and candidate registration as a public-token workflow on existing routes | architect + backend-engineer + frontend-engineer | interview product rules, public token model, Google Calendar sync semantics, route topology |
 
 ## ADR-0001
 - Context: Project is at bootstrap stage and lacks durable knowledge artifacts.
@@ -466,3 +468,26 @@ Use this log for decisions that change interfaces, data models, deployment topol
   - Critical frontend routes now emit one consistent Sentry tag model instead of admin-only tagging.
   - Browser request failures and render crashes become visible in Sentry without changing business contracts.
   - Route topology, typed API wrappers, auth behavior, and CORS assumptions stay unchanged while observability coverage increases.
+
+## ADR-0029
+- Context: Interview scheduling was the next business gap after scoring/observability/compliance, but implementation remained blocked by missing product rules around entity lifecycle, candidate identity, reschedule/cancel semantics, and Google Calendar conflicts. The repository also has no candidate auth or notification service, so the interview slice needed an implementation-safe baseline that works with existing route and transport constraints.
+- Decision:
+  - Freeze the planning baseline in `docs/project/interview-planning-pass.md` before any interview implementation work starts.
+  - Keep one non-terminal interview per `vacancy_id + candidate_id`; use `schedule_version` on the same row for reschedules.
+  - Keep candidate access anonymous through a public opaque invitation token stored hashed in the backend and bound to `interview_id + schedule_version`.
+  - Keep the existing route topology:
+    - HR interview controls extend `/`
+    - candidate interview registration extends `/candidate` through `?interviewToken=<token>`
+  - Do not introduce candidate auth, new CORS rules, or a new route tree in the interview slice.
+  - Separate business interview state from calendar execution state:
+    - interview `status`: `pending_sync`, `awaiting_candidate_confirmation`, `confirmed`, `reschedule_requested`, `cancelled`, `completed`
+    - `calendar_sync_status`: `queued`, `running`, `synced`, `conflict`, `failed`
+  - Treat Google Calendar sync as staff-calendar orchestration only for the next slice; candidate invitation delivery remains manual through `candidate_invite_url` until a notification service exists.
+  - Freeze the minimal public/backend API set around:
+    - HR create/list/get/reschedule/cancel/resend-invite endpoints
+    - public token read/confirm/request-reschedule/cancel endpoints
+  - Auto-append one `shortlist -> interview` pipeline transition on first successful interview sync when needed.
+- Consequences:
+  - Interview implementation can proceed without the implementer making hidden product decisions.
+  - Existing anonymous candidate transport assumptions remain intact.
+  - Notification delivery is intentionally deferred, so the next slice remains feasible in local-stage scope.

--- a/docs/architecture/diagrams.md
+++ b/docs/architecture/diagrams.md
@@ -196,19 +196,30 @@ sequenceDiagram
   participant INT as Interview Service
   participant GCA as Calendar Sync Service
   participant GCAL as Google Calendar
+  participant C as Candidate
 
   HR->>UI: Propose interview slot
-  UI->>API: Create interview request
-  API->>INT: Validate stage and participants
-  INT->>GCA: Sync interview event
-  GCA->>GCAL: Create/Update calendar event
-  GCAL-->>GCA: Event id and status
-  GCA-->>INT: Reconciliation result
-  INT-->>API: Interview scheduled
-  API-->>UI: Confirm schedule and invitations
+  UI->>API: POST /api/v1/vacancies/{vacancy_id}/interviews
+  API->>INT: Validate stage, one-active-interview rule, and staff participants
+  INT->>GCA: Enqueue calendar sync
+  GCA->>GCAL: Create/Update staff calendar event
+  GCAL-->>GCA: synced | conflict | failed
+  GCA-->>INT: Persist sync result
+  INT-->>API: status + calendar_sync_status + invite metadata
+  API-->>UI: Show sync state in HR workspace on /
+  UI-->>HR: Copy candidate_invite_url after sync success
+  HR->>C: Share invite link manually
+  C->>UI: Open /candidate?interviewToken=...
+  UI->>API: GET /api/v1/public/interview-registrations/{token}
+  API-->>UI: Current invitation payload
+  C->>UI: Confirm / Request reschedule / Decline
+  UI->>API: POST public interview action
+  API->>INT: Apply token-bound action
+  INT-->>API: Updated interview state
+  API-->>UI: Updated candidate-facing status
 ```
 
-Interview scheduling implementation remains deferred until a dedicated planning pass closes interview entity, registration, reschedule/cancel, and calendar sync conflict rules.
+The planning baseline for this flow is now frozen in `docs/project/interview-planning-pass.md`. The next implementation slice must follow that document without adding candidate auth or a new route tree.
 
 ## Diagram 6: Deployment and Trust Boundaries
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -58,8 +58,10 @@ flowchart LR
    `409` if parsed CV analysis is not ready, otherwise async scoring via Ollama ->
    persisted score artifact -> recruiter review -> shortlist.
 2. Interview Scheduling Flow:
-   pipeline stage change -> interview request -> Google Calendar sync -> participant notifications.
-   Implementation is planning-blocked until interview product rules are finalized.
+   recruiter selects vacancy + candidate in `/` -> interview create/reschedule ->
+   async Google Calendar sync for staff calendars -> sync success issues a public invitation token ->
+   HR shares `candidate_invite_url` manually -> candidate opens `/candidate?interviewToken=...` ->
+   confirm / request reschedule / decline -> HR resolves follow-up actions.
 3. Onboarding Flow:
    accepted candidate -> employee profile creation -> onboarding checklist -> completion tracking.
 4. HR Automation Flow:
@@ -139,7 +141,7 @@ flowchart LR
 ## Known Technical Risks
 - Scope risk from broad v1 expectation.
 - AI output quality variance across candidate domains and CV formats.
-- Interview workflow remains under-specified for safe implementation without a planning pass.
+- Interview workflow is now decision-complete in `docs/project/interview-planning-pass.md`, but implementation still carries calendar-integration and manual-invite delivery risk.
 - Integration instability risk with calendar sync edge cases.
 - Compliance risk if country-specific legal acts are not mapped early.
 
@@ -148,7 +150,7 @@ flowchart LR
    admin control plane, public candidate intake/tracking, HR vacancy/pipeline workspace, and browser smoke.
 2. Phase 1 scoring slice:
    dedicated scoring backend package + async scoring lifecycle + shortlist review in the existing HR workspace.
-3. Phase 1 interview planning gate:
-   finalize interview/registration/sync rules before `TASK-11-08` implementation starts.
+3. Phase 1 interview scheduling slice:
+   implement the planning baseline from `docs/project/interview-planning-pass.md` without changing candidate auth or route topology.
 4. Phase 2:
    Manager/Employee/Accountant/Leader capabilities, expanded automation and reporting.

--- a/docs/project/epics.md
+++ b/docs/project/epics.md
@@ -23,7 +23,7 @@
 - `EPIC-02` backend scope is materially implemented for Phase 1 local baseline: vacancy CRUD, canonical pipeline transitions, and ordered transition history.
 - `EPIC-11` local baseline now includes candidate self-service, HR vacancy/pipeline workspace, RU/EN strings for critical flows, and browser smoke for login + public candidate apply.
 - The immediate next epic gap is the handoff from parsed candidate data into `EPIC-04` recruiter-facing scoring review.
-- `EPIC-05` remains deliberately deferred until a short planning pass resolves interview entity, candidate registration, reschedule/cancel, and calendar sync conflict rules.
+- `EPIC-05` now has a decision-complete planning baseline in `docs/project/interview-planning-pass.md`; implementation is still deferred until a dedicated slice follows that spec.
 
 ## Epic Portfolio
 
@@ -117,7 +117,7 @@
 - Low-confidence cases are routed to manual HR review.
 
 ### EPIC-05: Interview Scheduling and Fairness Controls
-- Implementation starts only after a dedicated planning pass closes interview product rules and sync semantics.
+- Implementation starts from the frozen planning baseline in `docs/project/interview-planning-pass.md`.
 - Interview slots sync with Google Calendar.
 - Structured feedback form is mandatory before decision stage.
 - Interview rubric enforces consistent evaluation criteria.
@@ -165,4 +165,4 @@
 
 ## Execution Mapping
 - Task-level decomposition, dependencies, and global priority queue are documented in `docs/project/tasks.md`.
-- Immediate sequencing rule after the current baseline merge: finish the `EPIC-04` scoring/shortlist-review slice first, then run the `EPIC-05` planning pass before interview implementation starts.
+- Immediate sequencing rule after the current baseline merge: finish the `EPIC-04` scoring/shortlist-review slice first, then use the `EPIC-05` planning pass as the implementation baseline for the next interview slice.

--- a/docs/project/frontend-requirements.md
+++ b/docs/project/frontend-requirements.md
@@ -15,14 +15,14 @@
 - Current stage target: frontend must run stably in local environment on the current device.
 - Candidate self-service in v1:
   CV upload and profile information submission with confirmation.
-- Candidate interview registration UI is delivered as a dedicated follow-up flow after the scoring slice and a separate interview-planning pass.
+- Candidate interview registration UI is the next planned follow-up flow after the scoring slice and now uses the decision-complete baseline in `docs/project/interview-planning-pass.md`.
 - Delivery priority inside phase-1 frontend:
   1. Admin workspace,
   2. Candidate CV upload and parsing visibility,
   3. HR vacancy/pipeline workspace,
   4. shortlist review inside the existing HR workspace on `/`,
-  5. interview scheduling/registration only after a dedicated planning pass.
-- Interview scheduling UX with Google Calendar sync status visibility remains required, but it is not the next implementation slice.
+  5. interview scheduling/registration from the dedicated planning baseline in `docs/project/interview-planning-pass.md`.
+- Interview scheduling UX with Google Calendar sync status visibility remains required and must now follow `docs/project/interview-planning-pass.md`.
 - Consistent UI components and validation behavior across modules.
 - Accessibility baseline for forms, tables, and primary workflows.
 - Responsive web for desktop-first usage.
@@ -43,7 +43,7 @@
 | UI framework/design system | Popular ready-made libraries |
 | Localization | `ru` + `en` in v1 |
 | Browser support | Google Chrome |
-| Candidate portal scope | CV upload + self information confirmation (interview registration via dedicated follow-up flow) |
+| Candidate portal scope | CV upload + self information confirmation + public token-based interview registration on `/candidate` |
 | Mobile depth | No mobile app, responsive web only |
 | Frontend monitoring | Sentry |
 
@@ -146,12 +146,24 @@
   - `VITE_SENTRY_TRACES_SAMPLE_RATE`
 - Do not change typed API wrappers, OpenAPI artifacts, auth flow, or CORS behavior in this slice.
 
-## TASK-11-08 Planning Gate
-- Do not start implementation until a short planning pass defines:
-  - interview entity and lifecycle rules;
-  - candidate registration token/identity model;
-  - reschedule and cancel semantics;
-  - Google Calendar sync conflict behavior.
+## TASK-11-08 Planned Slice
+- Planning baseline source of truth: `docs/project/interview-planning-pass.md`.
+- Keep the current route model:
+  - HR scheduling stays on `/`;
+  - candidate interview registration stays on `/candidate?interviewToken=<token>`.
+- HR workspace requirements:
+  - do not add a new HR route;
+  - add interview scheduling controls only when vacancy and candidate are selected;
+  - show both business `status` and `calendar_sync_status`;
+  - expose `candidate_invite_url` only to authorized staff users;
+  - support `reschedule`, `cancel`, and `resend invite`.
+- Candidate route requirements:
+  - keep public access anonymous and token-based;
+  - support `Confirm`, `Request reschedule`, and `Decline`;
+  - render localized `404`, `409`, `410`, `422`, and generic HTTP errors;
+  - reject mixed `vacancyId` and `interviewToken` modes with a localized invalid-link state.
+- Do not introduce candidate auth, new CORS rules, or a new routing tree in this slice.
+- Invitation delivery remains manual in the next slice; do not add notification-service scope here.
 
 ## Library Baseline (Popular Ready-Made Stack)
 - UI components: Material UI (MUI).

--- a/docs/project/interview-planning-pass.md
+++ b/docs/project/interview-planning-pass.md
@@ -1,0 +1,254 @@
+# Interview Planning Pass (`TASK-11-08`, `TASK-05-01`, `TASK-05-02`)
+
+## Last Updated
+- Date: 2026-03-09
+- Updated by: architect + backend-engineer + frontend-engineer
+
+## Purpose
+- This document is a planning-only deliverable. It freezes the product and interface decisions required before interview scheduling implementation starts.
+- It does not introduce runtime, API, routing, auth, or infrastructure changes by itself.
+
+## Scope of the Next Implementation Slice
+- HR scheduling and rescheduling of one active interview per `vacancy_id + candidate_id`.
+- Candidate self-service confirmation, reschedule request, and cancellation through a public invitation token.
+- Google Calendar synchronization for staff/interviewer calendars with explicit sync states and conflict handling.
+- HR review and control inside the existing `/` workspace.
+- Candidate interview registration inside the existing `/candidate` route.
+
+## Out of Scope for the Next Slice
+- Candidate authentication or any return to a candidate session model.
+- New CORS or transport rewrites.
+- Email/SMS notification service rollout.
+- Multi-slot availability collection from candidates.
+- Structured interviewer feedback and fairness rubric enforcement (`TASK-05-03`, `TASK-05-04`).
+- Manager-specific frontend workspace changes.
+
+## Assumptions
+- Current delivery target remains stable local operation on the current device.
+- Notification service is not implemented yet, so invitation delivery stays manual in the next slice.
+- Candidate identity source of truth remains the profile created by the public apply flow.
+- Google Calendar is required, but only staff/interviewer availability is synchronized in the next slice. Candidate attendance is managed through the public invitation token, not calendar account federation.
+
+## Actor Boundaries
+
+| Actor | Allowed Actions | Explicitly Not Allowed |
+| --- | --- | --- |
+| `admin`, `hr`, `manager` via `interview:manage` | Create interview, reschedule, cancel, resend invite, inspect sync state | Use candidate public token endpoints |
+| Candidate via public token | Read current interview invitation, confirm, request reschedule, cancel/decline | Edit vacancy data, choose interviewers, change slot directly, read internal HR notes |
+| Background calendar sync worker | Create/update calendar event, persist sync status, persist conflict/failure reason | Decide candidate-facing product behavior beyond persisted status rules |
+
+The first frontend implementation remains HR-only on `/`. Manager role keeps backend permission compatibility but does not get a dedicated UI in this slice.
+
+## Canonical Entity Model
+
+One interview row represents one active interview process for a single `vacancy_id + candidate_id` pair.
+
+### Constraints
+- At most one non-terminal interview may exist per `vacancy_id + candidate_id`.
+- Rescheduling updates the same interview row and increments `schedule_version`.
+- Cancelled interviews are terminal. A new interview requires a new row.
+- Historical rows remain queryable for audit and future reporting.
+
+### Minimal Interview Fields
+
+| Field | Purpose |
+| --- | --- |
+| `id` | Interview identifier |
+| `vacancy_id`, `candidate_id` | Recruitment linkage |
+| `status` | Business lifecycle state |
+| `calendar_sync_status` | Calendar execution state |
+| `schedule_version` | Invalidates old candidate tokens on reschedule |
+| `scheduled_start_at`, `scheduled_end_at`, `timezone` | Canonical schedule window |
+| `location_kind` | `google_meet`, `onsite`, or `phone` |
+| `location_details` | Meet link, office address, or dial-in details |
+| `interviewer_staff_ids[]` | Staff participants whose calendars are synchronized |
+| `calendar_event_id` | External Google Calendar event reference |
+| `candidate_token_hash`, `candidate_token_expires_at` | Public invitation token state |
+| `candidate_response_status` | `pending`, `confirmed`, `reschedule_requested`, `declined` |
+| `candidate_response_note` | Optional free-text note from candidate |
+| `cancelled_by`, `cancel_reason_code` | Terminal cancellation metadata |
+| `created_by_staff_id`, `updated_by_staff_id` | Ownership and audit linkage |
+| `created_at`, `updated_at`, `last_synced_at` | Operational traceability |
+
+## Lifecycle Rules
+
+### Business Status
+- `pending_sync`: HR created or rescheduled the interview and calendar sync has not succeeded yet.
+- `awaiting_candidate_confirmation`: calendar sync succeeded and a current candidate token is active.
+- `confirmed`: candidate accepted the current schedule version.
+- `reschedule_requested`: candidate requested a new slot or calendar sync returned a hard conflict.
+- `cancelled`: HR or candidate cancelled the interview.
+- `completed`: reserved for a later slice when interview completion and feedback are implemented.
+
+### Calendar Sync Status
+- `queued`
+- `running`
+- `synced`
+- `conflict`
+- `failed`
+
+### Transition Rules
+- `create interview`:
+  - precondition: candidate pipeline stage is `shortlist` or `interview`;
+  - result: `status=pending_sync`, `calendar_sync_status=queued`, `schedule_version=1`.
+- `calendar sync success`:
+  - set `calendar_sync_status=synced`;
+  - set `status=awaiting_candidate_confirmation`;
+  - mint candidate invitation token;
+  - if current pipeline stage is `shortlist`, append one transition to `interview`.
+- `calendar sync conflict`:
+  - set `calendar_sync_status=conflict`;
+  - set `status=reschedule_requested`;
+  - do not keep an active candidate token for the conflicting schedule.
+- `calendar sync failure`:
+  - set `calendar_sync_status=failed`;
+  - keep `status=pending_sync`;
+  - HR must retry, reschedule, or cancel explicitly.
+- `candidate confirm`:
+  - allowed only from `awaiting_candidate_confirmation`;
+  - result: `status=confirmed`, `candidate_response_status=confirmed`.
+- `candidate request reschedule`:
+  - allowed from `awaiting_candidate_confirmation` or `confirmed`;
+  - result: `status=reschedule_requested`, `candidate_response_status=reschedule_requested`.
+- `candidate cancel/decline`:
+  - allowed from `awaiting_candidate_confirmation` or `confirmed`;
+  - result: `status=cancelled`, `candidate_response_status=declined`, `cancelled_by=candidate`.
+- `HR reschedule`:
+  - allowed from any non-terminal status except `completed`;
+  - increments `schedule_version`;
+  - invalidates the previous token immediately;
+  - returns the interview to `pending_sync`.
+- `HR cancel`:
+  - allowed from any non-terminal status;
+  - invalidates the current token immediately;
+  - result: `status=cancelled`, `cancelled_by=staff`.
+
+## Candidate Registration Token Model
+- Keep candidate access anonymous and token-based. Do not add candidate login, refresh tokens, or candidate sessions.
+- Generate one opaque random token per successful schedule version.
+- Persist only the token hash plus metadata in the database.
+- Bind the token to:
+  - `interview_id`
+  - `schedule_version`
+  - candidate identity already linked to the application record
+- Expire the token at `min(scheduled_end_at + 12h, issued_at + 30d)`.
+- Revoke the token immediately when:
+  - the interview is rescheduled;
+  - the interview is cancelled;
+  - HR explicitly resends the invite;
+  - a newer schedule version is created.
+- HR-facing responses may expose `candidate_invite_url` and `candidate_token_expires_at`.
+- Public token responses must never expose internal staff notes or interviewer private metadata.
+
+## Invitation Delivery Rule
+- The next implementation slice will not introduce email/SMS transport.
+- After calendar sync succeeds, the backend returns `candidate_invite_url` to authorized staff users.
+- HR shares that link with the candidate manually out of band during the current local-stage baseline.
+- A future notification service may automate delivery without changing the public token contract.
+
+## Minimal Backend API Set
+
+### HR APIs
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/v1/vacancies/{vacancy_id}/interviews` | Create the active interview for one candidate and enqueue calendar sync |
+| `GET` | `/api/v1/vacancies/{vacancy_id}/interviews` | List interviews for the vacancy, optionally filtered by `candidate_id` or `status` |
+| `GET` | `/api/v1/vacancies/{vacancy_id}/interviews/{interview_id}` | Read one interview with calendar state and current invite metadata |
+| `POST` | `/api/v1/vacancies/{vacancy_id}/interviews/{interview_id}/reschedule` | Replace the schedule window, bump `schedule_version`, and enqueue sync again |
+| `POST` | `/api/v1/vacancies/{vacancy_id}/interviews/{interview_id}/cancel` | Cancel the interview with a reason code |
+| `POST` | `/api/v1/vacancies/{vacancy_id}/interviews/{interview_id}/resend-invite` | Reissue a fresh token for the current schedule version after successful sync |
+
+### Public Candidate APIs
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/v1/public/interview-registrations/{token}` | Read the current invitation payload for the token |
+| `POST` | `/api/v1/public/interview-registrations/{token}/confirm` | Confirm attendance for the current schedule version |
+| `POST` | `/api/v1/public/interview-registrations/{token}/request-reschedule` | Request a new slot and optionally send a note |
+| `POST` | `/api/v1/public/interview-registrations/{token}/cancel` | Cancel/decline the interview |
+
+### Canonical Interview Response Shape
+- `interview_id`
+- `vacancy_id`
+- `candidate_id`
+- `status`
+- `calendar_sync_status`
+- `schedule_version`
+- `scheduled_start_at`
+- `scheduled_end_at`
+- `timezone`
+- `location_kind`
+- `location_details`
+- `interviewer_staff_ids`
+- `candidate_response_status`
+- `candidate_response_note`
+- `candidate_token_expires_at`
+- `candidate_invite_url` (`HR` responses only)
+- `calendar_event_id`
+- `last_synced_at`
+- `cancelled_by`
+- `cancel_reason_code`
+- `created_at`
+- `updated_at`
+
+## Error Contract Rules
+
+### HR APIs
+- `403`: caller lacks `interview:manage`.
+- `404`: vacancy, candidate, or interview not found in the allowed scope.
+- `409`: active interview already exists, interview is terminal, or calendar conflict blocks the requested action.
+- `422`: invalid schedule window, invalid stage, duplicate interviewer list, or unsupported location mode.
+
+### Public Token APIs
+- `404`: token not found or already revoked.
+- `409`: current interview state does not allow the requested action.
+- `410`: token expired.
+- `422`: malformed note payload or invalid public action body.
+
+## Frontend Route and UX Model
+
+### HR Route
+- Keep the current HR workspace on `/`.
+- Add an interview scheduling block beside the existing shortlist review area when a vacancy and candidate are selected.
+- Required HR UI elements:
+  - create interview form;
+  - current `status` and `calendar_sync_status`;
+  - copyable `candidate_invite_url` when available;
+  - actions for `reschedule`, `cancel`, and `resend invite`;
+  - localized errors for `403`, `404`, `409`, `422`, and generic HTTP failures.
+
+### Candidate Route
+- Keep the existing public route `/candidate`.
+- Add an interview-registration mode selected by `?interviewToken=<token>`.
+- Route mode rules:
+  - `vacancyId` mode: public apply/tracking flow;
+  - `interviewToken` mode: interview registration flow;
+  - mixed parameters are invalid and must render a localized error state.
+- Candidate interview mode must show:
+  - vacancy title and interview schedule;
+  - timezone and location details;
+  - calendar sync-derived meeting link/details when available;
+  - actions `Confirm`, `Request reschedule`, and `Decline`.
+
+## Pipeline and Audit Boundaries
+- Interview creation is allowed only from candidate pipeline stages `shortlist` or `interview`.
+- First successful interview sync appends `shortlist -> interview` if the candidate has not yet entered the `interview` stage.
+- Candidate public actions do not modify vacancy data or pipeline stages directly beyond interview state.
+- All HR interview actions and public token actions must emit audit events with reason codes and correlation identifiers.
+
+## Future Implementation Acceptance Baseline
+- Freeze OpenAPI and generate frontend types in the same change.
+- Do not change auth, CORS, or the anonymous candidate transport model.
+- Keep compose smoke green without adding Google Calendar nondeterministic browser steps.
+- Cover at minimum:
+  - HR create/reschedule/cancel happy and negative paths;
+  - calendar `queued/running/synced/conflict/failed` transitions;
+  - candidate token `confirm/reschedule/cancel` paths;
+  - expired/revoked token handling;
+  - `/candidate?interviewToken=...` route-mode rendering and localized failures.
+
+## Explicit Deferrals
+- `TASK-05-03` keeps structured feedback out of the scheduling slice.
+- `TASK-05-04` keeps fairness rubric enforcement out of the scheduling slice.
+- Candidate notification automation remains a later platform slice.

--- a/docs/project/sprint-m1-plan.md
+++ b/docs/project/sprint-m1-plan.md
@@ -21,14 +21,14 @@ Current sprint acceptance target is stable local end-to-end operation on the cur
 | `TASK-04-01/02/03 + TASK-11-07` | implemented/local-scoring-slice | Dedicated scoring backend and shortlist review block are present in repo with frozen contract and compose/runtime wiring |
 | `TASK-11-10` | implemented/local-observability-slice | Critical-route Sentry tags, shared HTTP failure capture, render boundary, and release/env tracing config are present in repo |
 | `TASK-13-01/02` | implemented/local-compliance-slice | Article-level control mapping and evidence registry are present in repo and linked to real artifacts |
-| `TASK-11-08` | next/planning-only | Requires a dedicated planning pass for interview entity, registration, reschedule/cancel, and sync-conflict rules |
+| `TASK-11-08` | planned/spec-complete | Decision-complete interview planning is now documented in `docs/project/interview-planning-pass.md`; implementation is still pending |
 
 ## Scope Normalization
 - The original M1 sprint text stopped at FE-9, but the repo now contains a broader local acceptance baseline: `TASK-11-05`, `TASK-11-06`, `TASK-11-09`, and `TASK-11-11` are no longer future-only scope.
 - Immediate follow-on work must not reopen auth, CORS, routing topology, or transport architecture.
 - The scoring/shortlist-review track is now implemented in repo as one backend+frontend slice.
-- The current approved local diff is limited to `TASK-13-01/02` compliance documentation and evidence ownership work.
-- Interview scheduling (`TASK-11-08`) is deliberately deferred until after a short planning pass.
+- The current approved local diff is limited to the `TASK-11-08` planning-only documentation slice.
+- Interview scheduling implementation remains deferred until a dedicated implementation branch follows `docs/project/interview-planning-pass.md`.
 
 ## Phase 0 Merge Gate
 - The current baseline PR must keep exactly this scope:
@@ -51,13 +51,13 @@ Current sprint acceptance target is stable local end-to-end operation on the cur
 - After merge, sync local `main` before starting the next implementation increment.
 
 ## Approved Immediate Follow-On Slice
-- Implement `TASK-13-01/02` as a dedicated compliance documentation slice.
+- Implement the next `TASK-11-08` slice from the planning baseline in `docs/project/interview-planning-pass.md`.
 - Slice rules:
-  - use only real repo-backed artifacts as evidence;
-  - update legal-controls matrix and evidence registry in the same change;
-  - do not change runtime, routing, auth, CORS, or API contracts.
-- Next after this slice:
-  - a dedicated planning pass for `TASK-11-08`.
+  - keep HR interview controls on `/`;
+  - keep candidate interview registration on `/candidate?interviewToken=<token>`;
+  - do not introduce candidate auth, new CORS behavior, or notification-service scope;
+  - freeze OpenAPI and generated frontend types in the same change.
+- This planning pass itself remains docs-only and introduces no runtime or API changes.
 
 ## Team Roles
 - architect

--- a/docs/project/tasks.md
+++ b/docs/project/tasks.md
@@ -29,6 +29,7 @@
 | TASK-11-07 | implemented/local-scoring-slice | `/` now includes shortlist review with `Run score`, polling, confidence/summary card, requirements delta, evidence, and localized `409/403/404/422` errors |
 | TASK-11-10 | implemented/local-observability-slice | Frontend Sentry now tags `/`, `/candidate`, `/login`, `/admin`, `/admin/staff`, and `/admin/employee-keys`; shared HTTP capture, render boundary, and release/env tracing config are present in repo with frontend unit coverage |
 | TASK-13-01/02 | implemented/local-compliance-slice | Legal-controls matrix now maps article-level obligations to current repo-backed controls and evidence registry entries with owners, verification sources, and update triggers |
+| TASK-11-08 | planned/spec-complete | Interview scheduling and candidate registration now have a decision-complete planning baseline in `docs/project/interview-planning-pass.md`; implementation is not started yet |
 | COMPLIANCE-01 | planned | EPIC-13 article-level legal mapping and evidence pack track |
 
 ## 2026-03-09 Delivery Control Notes
@@ -36,17 +37,17 @@
 - The main remaining frontend gaps after the login/browser hotfix were `TASK-11-06` and `TASK-11-05`; the current repository now contains a local acceptance baseline for both flows.
 - The scoring/shortlist-review slice (`TASK-04-01/02/03 + TASK-11-07`) is now implemented in repo as one vertical delivery unit.
 - The compliance follow-on slice (`TASK-13-01/02`) is now implemented in repo as documentation and evidence-model work only; no runtime/API/routing changes were introduced.
-- The next active workstream after compliance is the dedicated planning pass for `TASK-11-08`.
-- `TASK-11-08` is explicitly deferred until a separate planning pass resolves interview entity boundaries, candidate registration/identity rules, reschedule/cancel semantics, and calendar sync conflict behavior.
+- The dedicated planning pass for `TASK-11-08` is now written down in `docs/project/interview-planning-pass.md`.
+- The next active workstream is implementation of `TASK-11-08` against that planning baseline without reopening auth, CORS, or the public candidate transport model.
 - Existing auth/CORS/public candidate transport assumptions stay unchanged across the observability and compliance follow-on slices.
 
-## Active Queue After Compliance Slice
+## Active Queue After Planning Pass
 
 | Order | Task ID | Why Now |
 | --- | --- | --- |
-| A-1 | TASK-11-08 | Current blocker is no longer implementation capacity but missing product decisions; planning pass is the next required slice |
+| A-1 | TASK-11-08 | Planning risk is closed; next slice is implementation of interview scheduling and candidate registration against the frozen planning spec |
 
-- Execution rule: keep `TASK-11-08` blocked until the dedicated interview-planning pass is written down and approved.
+- Execution rule: implement `TASK-11-08` only from `docs/project/interview-planning-pass.md`; do not reopen candidate auth, CORS, or route-topology scope during that slice.
 
 ## Task Breakdown by Epic
 
@@ -206,7 +207,7 @@ Use this queue together with the global queue when planning phase implementation
 | FE-12 | TASK-11-11 | Delivered in local baseline: Chrome browser smoke for login + public candidate apply |
 | FE-13 | TASK-11-07 | Delivered in local scoring slice: shortlist review block inside the existing `/` HR workspace with scoring polling and explainable payload rendering |
 | FE-14 | TASK-11-10 | Delivered in local observability slice: Sentry hardening for critical routes, shared HTTP failure capture, render boundary, and release/env tracing config without route changes |
-| FE-15 | TASK-11-08 | Next planning-only slice after compliance: interview entity, registration, and sync rules still need a decision-complete spec |
+| FE-15 | TASK-11-08 | Next implementation slice: use the frozen interview planning spec to extend `/` and `/candidate` without adding candidate auth |
 | FE-16 | ADMIN-04 | Unified admin CRUD consoles |
 | FE-17 | ADMIN-05 | Admin observability and audit dashboards |
 | FE-18 | TASK-11-12 | Phase-2 role workspace rollout |
@@ -214,7 +215,7 @@ Use this queue together with the global queue when planning phase implementation
 ## Milestone Cut Suggestion
 - `M1` (Phase 1 MVP): infra/security + ADMIN-01/02/03 + candidate CV intake/parsing/normalization + candidate self-service upload/tracking + HR vacancy/pipeline workspace baseline + RU/EN critical flows + browser smoke.
 - `M2` (Immediate post-baseline slice): `TASK-04-01/02/03 + TASK-11-07` as one scoring/shortlist-review deliverable, with `TASK-11-10` and `TASK-13-01/02` proceeding immediately after or in parallel.
-- `M2` planning gate: run a short dedicated planning pass for `TASK-11-08` before interview scheduling/registration implementation.
+- `M2` planning gate: completed in `docs/project/interview-planning-pass.md`; use that document as the baseline for interview scheduling/registration implementation.
 - `M3` (Phase 2 core): interview scheduling/fairness controls + offer-to-hire + onboarding workflows + phase-2 role workspace baseline.
 - `M4` (Phase 2 expansion): manager/leader/accountant rollout + reporting exports + notification optimization + final legal sign-off package.
 - Note: until first production launch planning starts, acceptance focus is local end-to-end operation on the current device.

--- a/docs/testing/strategy.md
+++ b/docs/testing/strategy.md
@@ -198,6 +198,29 @@ apps/backend/tests/
 - Keep scoring verification at unit/integration level; do not extend compose browser smoke to scoring until runtime nondeterminism is addressed.
 - Shortlist review must work against the real backend scoring contract, not mock-only placeholder data.
 
+## Interview Scheduling and Candidate Registration Planning Baseline (`TASK-11-08`, `TASK-05-01`, `TASK-05-02`)
+
+Planning source of truth:
+- `docs/project/interview-planning-pass.md`
+
+Future implementation must cover at minimum:
+
+| Capability | Unit Coverage | Integration/Smoke Coverage | Required Evidence |
+| --- | --- | --- | --- |
+| Interview lifecycle validation (`pending_sync`, `awaiting_candidate_confirmation`, `confirmed`, `reschedule_requested`, `cancelled`) | interview service state-transition tests | interview API integration suite | invalid transitions return `409`; terminal interviews cannot be mutated |
+| Calendar sync lifecycle (`queued`, `running`, `synced`, `conflict`, `failed`) | calendar adapter and worker mapping tests | interview/calendar integration suite with deterministic fake adapter | sync result persists correct interview and calendar statuses |
+| One-active-interview rule per `vacancy_id + candidate_id` | interview service unit tests | `POST /api/v1/vacancies/{vacancy_id}/interviews` integration negatives | duplicate active interview returns `409` |
+| Candidate invitation token hashing, expiry, and schedule-version invalidation | token service unit tests | public interview registration integration suite | revoked/rescheduled tokens return `404`; expired token returns `410` |
+| Candidate public actions (`confirm`, `request-reschedule`, `cancel`) | interview/public token service unit tests | public interview registration integration suite | token-bound actions update state without candidate auth |
+| HR route integration on `/` | `apps/frontend/src/pages/HrDashboardPage.test.tsx` | backend interview integration suite | create/reschedule/cancel and sync-state render are localized and stable |
+| Candidate route-mode integration on `/candidate?interviewToken=...` | `apps/frontend/src/pages/CandidatePage.test.tsx` | backend interview integration suite | candidate interview mode renders localized `404/409/410/422` errors and rejects mixed route params |
+
+Acceptance rules for the future interview slice:
+- Freeze OpenAPI and generated frontend types in the same change.
+- Keep candidate transport anonymous and token-based.
+- Do not add candidate auth, Vite proxy rewrites, or new CORS behavior.
+- Keep compose smoke green without adding nondeterministic Google Calendar browser automation.
+
 ## Frontend Admin Verification (ADMIN-01)
 
 | Capability | Unit Coverage | Integration/Smoke Coverage | Required Evidence |


### PR DESCRIPTION
## Summary
- add a decision-complete planning spec for interview scheduling and candidate registration
- sync backlog, frontend requirements, ADRs, diagrams, and testing strategy to the planning baseline
- keep the change docs-only so the next implementation slice has fixed product rules

## Verification
- ./scripts/check-docs-structure.sh