### PR TITLE
docs: freeze TASK-05-03/04 interview feedback plan

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This folder is the single source of truth for project context required for deliv
 - `project/legal-controls-matrix.md`: NPA-to-controls compliance tracking matrix
 - `project/evidence-registry.md`: Evidence ownership and verification registry for compliance controls
 - `project/interview-planning-pass.md`: Decision-complete planning baseline for interview scheduling and candidate registration
+- `project/interview-feedback-fairness-pass.md`: Decision-complete planning baseline for structured interviewer feedback and fairness gate before `offer`
 - `project/rbac-matrix.md`: Phase-1 role and permission matrix baseline
 - `project/auth-session-lifecycle.md`: Authentication/session lifecycle baseline and API contract
 - `architecture/overview.md`: System architecture and boundaries

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -34,6 +34,7 @@ Use this log for decisions that change interfaces, data models, deployment topol
 | ADR-0027 | 2026-03-09 | accepted | Implement scoring as a dedicated backend package with DB-backed jobs/artifacts and shortlist review on `/` | architect + backend-engineer + frontend-engineer | scoring architecture, HR workspace UX, compose worker topology, OpenAPI contract |
 | ADR-0028 | 2026-03-09 | accepted | Harden frontend observability with canonical Sentry route tags and shared failure capture | architect + frontend-engineer | frontend observability, route semantics, error telemetry |
 | ADR-0029 | 2026-03-09 | accepted | Freeze interview scheduling and candidate registration as a public-token workflow on existing routes | architect + backend-engineer + frontend-engineer | interview product rules, public token model, Google Calendar sync semantics, route topology |
+| ADR-0030 | 2026-03-10 | accepted | Freeze interviewer feedback as schedule-versioned interview data and enforce fairness gate on the existing `interview -> offer` transition | architect + backend-engineer + frontend-engineer | interview feedback data model, HR workspace UX, pipeline transition semantics, OpenAPI contract |
 
 ## ADR-0001
 - Context: Project is at bootstrap stage and lacks durable knowledge artifacts.
@@ -497,3 +498,28 @@ Use this log for decisions that change interfaces, data models, deployment topol
   - Existing anonymous candidate transport assumptions remain intact.
   - Free-mode calendar access is operationally simple but depends on manual sharing and explicit staff-to-calendar configuration.
   - Notification delivery is intentionally deferred, so the slice remains feasible in local-stage scope.
+
+## ADR-0030
+- Context: Interview scheduling and candidate registration are now implemented, but the next interview-domain work remained under-specified around who can submit structured feedback, how reschedules affect feedback validity, and where the fairness guard should live before `offer`. Reopening auth, route topology, or adding a parallel decision API would create avoidable scope creep.
+- Decision:
+  - Freeze the planning baseline in `docs/project/interview-feedback-fairness-pass.md` before implementation of `TASK-05-03/04`.
+  - Keep interviewer feedback as interview-domain data rather than pipeline metadata:
+    - one current feedback row per `interview_id + schedule_version + interviewer_staff_id`
+    - previous schedule-version feedback remains audit history but does not satisfy the fairness gate
+  - Keep the existing route topology:
+    - HR feedback UX extends `/`
+    - candidate route `/candidate` remains unchanged and never exposes interviewer feedback
+  - Keep the existing transition endpoint `POST /api/v1/pipeline/transitions`; when `to_stage=offer`, run the fairness gate there instead of adding a parallel offer-decision API.
+  - Limit the fairness gate in this slice to current-version completeness and payload validity:
+    - all assigned interviewers must submit feedback for the active `schedule_version`
+    - mandatory rubric scores and qualitative notes must be present
+    - recommendation disagreement is surfaced to HR but does not auto-block `offer`
+  - Freeze the minimal backend API set around:
+    - `GET /api/v1/vacancies/{vacancy_id}/interviews/{interview_id}/feedback`
+    - `PUT /api/v1/vacancies/{vacancy_id}/interviews/{interview_id}/feedback/me`
+  - Keep auth, CORS behavior, public candidate transport, and compose smoke scope unchanged for this slice.
+- Consequences:
+  - The next interview slice can be implemented without hidden product or API decisions.
+  - Feedback remains traceable to the real interview schedule and interviewer assignment.
+  - Pipeline semantics stay centralized in the existing transition flow, which reduces route and audit fragmentation.
+  - More sophisticated fairness policy, interviewer reminders, and candidate-facing visibility remain explicitly deferred.

--- a/docs/project/interview-feedback-fairness-pass.md
+++ b/docs/project/interview-feedback-fairness-pass.md
@@ -1,0 +1,271 @@
+# Interview Feedback and Fairness Pass (`TASK-05-03`, `TASK-05-04`)
+
+## Last Updated
+- Date: 2026-03-10
+- Updated by: architect + backend-engineer + frontend-engineer
+
+## Purpose
+- This document is a planning-only deliverable.
+- It freezes the product and interface decisions required before implementation of structured interview feedback and fairness gating starts.
+- It does not introduce runtime, API, routing, auth, or infrastructure changes by itself.
+
+## Scope of the Next Implementation Slice
+- Structured interviewer feedback capture for the current interview panel.
+- Readable HR summary of submitted and missing interviewer feedback.
+- Fairness gate before the existing pipeline transition from `interview` to `offer`.
+- Feedback UX inside the existing HR workspace on `/`.
+- Backend validation and audit behavior for feedback submission and decision gating.
+
+## Out of Scope for the Next Slice
+- Candidate authentication or any change to public token-based candidate transport.
+- New route tree, new candidate route mode, or new CORS behavior.
+- Notification-service rollout for interviewer reminders or feedback chasers.
+- Manager-specific frontend workspace outside the existing `/` screen.
+- Automatic hire/reject decisions based on feedback sentiment.
+- New recruitment pipeline stages or route topology changes.
+- Google Calendar browser automation inside compose smoke.
+
+## Preserved Constraints
+- Keep HR controls on `/`.
+- Keep candidate interview registration on `/candidate?interviewToken=<token>`.
+- Do not reopen auth model, CORS model, route topology, or public candidate transport model.
+- Keep changes minimal and reversible when implementation starts.
+- Freeze OpenAPI and generated frontend types in the same implementation change.
+
+## Assumptions
+- Interview scheduling and candidate registration are already implemented from `docs/project/interview-planning-pass.md`.
+- The canonical recruitment pipeline stays unchanged:
+  `shortlist -> interview -> offer -> hired/rejected`.
+- The fairness gate is applied only to the transition `interview -> offer`.
+- Feedback completeness is the minimum fairness control for this slice; recommendation disagreement is surfaced to HR but does not auto-block `offer`.
+- One current schedule version is the source of truth for required interviewer feedback.
+
+## Actor Boundaries
+
+| Actor | Allowed Actions | Explicitly Not Allowed |
+| --- | --- | --- |
+| Assigned interviewer (authenticated staff whose subject id is present in `interviewer_staff_ids`) | Create or update only their own feedback for the current `schedule_version`; read the current interview feedback summary in HR workspace | Submit feedback for another interviewer; bypass required rubric fields; submit stale feedback for an older schedule version |
+| `admin`, `hr`, `manager` via existing `interview:manage` permission | Read panel summary, inspect missing interviewers, and attempt pipeline transition to `offer` subject to fairness gate | Override or edit another interviewer's submitted feedback in this slice |
+| Candidate via public token | Continue using existing interview registration endpoints | Read or mutate interviewer feedback |
+| Background workers | None for this slice | Auto-generate interviewer feedback or auto-resolve hiring outcome |
+
+## Canonical Feedback Model
+
+One feedback row represents one interviewer's latest submission for one interview and one `schedule_version`.
+
+### Constraints
+- At most one active feedback row exists per `interview_id + schedule_version + interviewer_staff_id`.
+- Rescheduling an interview increments `schedule_version`; previous-version feedback remains audit history but no longer satisfies the fairness gate.
+- Feedback is interviewer-scoped and cannot be shared across different interview rows or schedule versions.
+
+### Minimal Feedback Fields
+
+| Field | Purpose |
+| --- | --- |
+| `feedback_id` | Unique feedback identifier |
+| `interview_id` | Parent interview row |
+| `schedule_version` | Binds feedback to the current interview schedule |
+| `interviewer_staff_id` | Submitting interviewer identity |
+| `requirements_match_score` | Standardized 1-5 rubric score |
+| `communication_score` | Standardized 1-5 rubric score |
+| `problem_solving_score` | Standardized 1-5 rubric score |
+| `collaboration_score` | Standardized 1-5 rubric score |
+| `recommendation` | `strong_yes`, `yes`, `mixed`, or `no` |
+| `strengths_note` | Required qualitative evidence for positives |
+| `concerns_note` | Required qualitative evidence for risks/concerns |
+| `evidence_note` | Required free-text evidence that supports the ratings |
+| `submitted_at`, `updated_at` | Traceability for fairness gate and audit |
+
+## Rubric and Recommendation Rules
+
+### Score Scale
+- All rubric scores use integer values `1..5`.
+- `1` means the interviewer observed a clear deficit for that criterion.
+- `3` means borderline or mixed evidence.
+- `5` means strong, explicit evidence for the criterion.
+
+### Mandatory Rubric Criteria
+- `requirements_match_score`
+- `communication_score`
+- `problem_solving_score`
+- `collaboration_score`
+
+### Recommendation Enum
+- `strong_yes`
+- `yes`
+- `mixed`
+- `no`
+
+### Qualitative Field Rules
+- `strengths_note` is required and must be non-empty.
+- `concerns_note` is required and must be non-empty.
+- `evidence_note` is required and must be non-empty.
+- Free-text notes are capped at implementation-defined safe lengths, but the fields are mandatory for every submission.
+
+## Feedback Lifecycle Rules
+- Feedback submission is allowed only for the current interview `schedule_version`.
+- Feedback submission is allowed only when:
+  - the interview is not `cancelled`;
+  - the interview has a real schedule window;
+  - `scheduled_end_at <= now`.
+- Feedback submission is rejected before the interview window ends with `409 interview_feedback_window_not_open`.
+- Rescheduling invalidates the previous schedule version for fairness-gate purposes immediately.
+- Assigned interviewers may update their own submission for the current version any number of times until HR moves the candidate past `interview`.
+- Once the candidate leaves pipeline stage `interview`, feedback becomes read-only audit history in this slice.
+
+## Fairness Gate Rules
+
+The fairness gate is evaluated only when the existing pipeline transition request asks for `to_stage=offer`.
+
+### Gate Preconditions
+- Candidate is currently in pipeline stage `interview`.
+- There is one active interview row for the same `vacancy_id + candidate_id`.
+- The active interview is not `cancelled`.
+- `scheduled_end_at <= now` for the active interview.
+- Every interviewer listed in `interviewer_staff_ids` for the current `schedule_version` has exactly one current-version feedback submission.
+- Every current-version feedback submission contains all mandatory rubric scores and all mandatory qualitative notes.
+
+### Gate Outcomes
+- `passed`:
+  - all current-version interviewer feedback is present and complete.
+- `blocked` with reason codes:
+  - `interview_feedback_window_not_open`
+  - `interview_feedback_missing`
+  - `interview_feedback_incomplete`
+  - `interview_feedback_stale`
+  - `interview_feedback_not_required_for_terminal_interview`
+
+### Recommendation Disagreement Policy
+- Recommendation disagreement does not block `interview -> offer` by itself in this slice.
+- HR remains the human decision owner.
+- The system surfaces distribution of recommendations and average rubric scores, but does not auto-reject or auto-hire.
+
+## Minimal Backend API Set
+
+### HR Feedback APIs
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/v1/vacancies/{vacancy_id}/interviews/{interview_id}/feedback` | Read current-version panel summary plus submitted feedback rows |
+| `PUT` | `/api/v1/vacancies/{vacancy_id}/interviews/{interview_id}/feedback/me` | Create or replace the current interviewer's feedback for the current `schedule_version` |
+
+### Existing Pipeline API Integration
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/v1/pipeline/transitions` | Keep the existing endpoint; when `to_stage=offer`, run fairness gate before creating the transition |
+
+## Canonical Feedback Response Shape
+
+### Feedback Item
+- `feedback_id`
+- `interview_id`
+- `schedule_version`
+- `interviewer_staff_id`
+- `requirements_match_score`
+- `communication_score`
+- `problem_solving_score`
+- `collaboration_score`
+- `recommendation`
+- `strengths_note`
+- `concerns_note`
+- `evidence_note`
+- `submitted_at`
+- `updated_at`
+
+### Panel Summary
+- `interview_id`
+- `vacancy_id`
+- `candidate_id`
+- `schedule_version`
+- `required_interviewer_ids`
+- `submitted_interviewer_ids`
+- `missing_interviewer_ids`
+- `required_interviewer_count`
+- `submitted_count`
+- `gate_status`
+- `gate_reason_codes`
+- `recommendation_distribution`
+- `average_scores`
+- `items`
+
+## Error Contract Rules
+
+### Feedback APIs
+- `403`:
+  - caller lacks `interview:manage` for read;
+  - caller is not an assigned interviewer for `feedback/me`.
+- `404`:
+  - vacancy, interview, or current-version interview context not found.
+- `409`:
+  - interview is cancelled;
+  - interview window has not ended yet;
+  - feedback belongs to an old schedule version.
+- `422`:
+  - invalid score range;
+  - missing mandatory note field;
+  - malformed payload.
+
+### Pipeline Transition Gate
+- Keep the existing transition endpoint and stage matrix.
+- When `to_stage=offer`, return `409` with stable detail codes:
+  - `interview_feedback_window_not_open`
+  - `interview_feedback_missing`
+  - `interview_feedback_incomplete`
+  - `interview_feedback_stale`
+- Do not add a separate offer-decision endpoint in this slice.
+
+## Frontend Route and UX Model
+
+### HR Route
+- Keep the existing HR workspace on `/`.
+- Add an interview-feedback block that becomes active when:
+  - a vacancy is selected;
+  - a candidate is selected;
+  - the selected pair has an interview row.
+- Required HR UI elements:
+  - current fairness gate status;
+  - missing interviewer list when feedback is incomplete;
+  - recommendation distribution summary;
+  - rubric averages summary;
+  - current-user feedback form when the authenticated staff user is an assigned interviewer;
+  - read-only list of submitted feedback rows for authorized staff users.
+
+### Form Rules
+- Use one form for create/update on `feedback/me`.
+- Validate all rubric fields client-side before submit.
+- Validate that required qualitative fields are non-empty before submit.
+- Show localized `403`, `404`, `409`, `422`, and generic HTTP errors.
+
+### Offer Transition UX
+- Keep the current pipeline transition controls on `/`.
+- When the selected target stage is `offer`, surface the current fairness summary before submit.
+- If backend returns one of the fairness `409` codes, render a localized blocker message instead of a generic transition failure.
+
+### Candidate Route
+- Keep `/candidate` unchanged for this slice.
+- Do not expose interviewer feedback or fairness summary through public token endpoints.
+
+## Pipeline and Audit Boundaries
+- Feedback submission does not create a new pipeline stage.
+- Feedback APIs and fairness-gated transition attempts must emit audit events with correlation id and stable reason codes.
+- Feedback history is interview-domain data; pipeline transition history remains append-only in the vacancy domain.
+- The fairness gate may read interview-domain feedback state, but must not duplicate feedback data inside vacancy/pipeline tables.
+
+## Future Implementation Acceptance Baseline
+- Freeze OpenAPI and generate frontend types in the same change.
+- Do not change auth, CORS, route topology, or anonymous candidate transport.
+- Keep compose smoke green without adding feedback-specific browser automation.
+- Cover at minimum:
+  - interviewer feedback create/update happy path;
+  - non-interviewer submit deny path;
+  - stale feedback after reschedule;
+  - `interview -> offer` blocked when feedback is missing, incomplete, stale, or too early;
+  - `interview -> offer` success after complete current-version panel feedback;
+  - `/` route feedback form render, summary render, and localized fairness-gate blocker messages.
+
+## Explicit Deferrals
+- No automatic hiring recommendation engine beyond human-visible summary.
+- No interviewer reminder notifications or escalation workflow.
+- No dedicated manager workspace or mobile-specific feedback UX.
+- No candidate-facing visibility into internal interviewer rubric data.

--- a/docs/project/interview-planning-pass.md
+++ b/docs/project/interview-planning-pass.md
@@ -1,7 +1,7 @@
 # Interview Planning Pass (`TASK-11-08`, `TASK-05-01`, `TASK-05-02`)
 
 ## Last Updated
-- Date: 2026-03-09
+- Date: 2026-03-10
 - Updated by: architect + backend-engineer + frontend-engineer
 
 ## Purpose
@@ -20,7 +20,7 @@
 - New CORS or transport rewrites.
 - Email/SMS notification service rollout.
 - Multi-slot availability collection from candidates.
-- Structured interviewer feedback and fairness rubric enforcement (`TASK-05-03`, `TASK-05-04`).
+- Structured interviewer feedback and fairness rubric enforcement (`TASK-05-03`, `TASK-05-04`), now frozen separately in `docs/project/interview-feedback-fairness-pass.md`.
 - Manager-specific frontend workspace changes.
 
 ## Assumptions
@@ -249,6 +249,6 @@ One interview row represents one active interview process for a single `vacancy_
   - `/candidate?interviewToken=...` route-mode rendering and localized failures.
 
 ## Explicit Deferrals
-- `TASK-05-03` keeps structured feedback out of the scheduling slice.
-- `TASK-05-04` keeps fairness rubric enforcement out of the scheduling slice.
+- `TASK-05-03` keeps structured feedback out of the scheduling slice and is planned separately in `docs/project/interview-feedback-fairness-pass.md`.
+- `TASK-05-04` keeps fairness rubric enforcement out of the scheduling slice and is planned separately in `docs/project/interview-feedback-fairness-pass.md`.
 - Candidate notification automation remains a later platform slice.

--- a/docs/project/sprint-m1-plan.md
+++ b/docs/project/sprint-m1-plan.md
@@ -1,7 +1,7 @@
 # Sprint M1 Plan and Task Ownership
 
 ## Last Updated
-- Date: 2026-03-09
+- Date: 2026-03-10
 - Updated by: coordinator + architect
 
 ## Sprint Goal
@@ -52,6 +52,7 @@ Current sprint acceptance target is stable local end-to-end operation on the cur
 
 ## Approved Follow-On Constraint
 - `TASK-11-08` is now implemented from the planning baseline in `docs/project/interview-planning-pass.md`.
+- The next interview follow-on planning source of truth is `docs/project/interview-feedback-fairness-pass.md` for `TASK-05-03/04`.
 - The preserved slice rules remain:
   - keep HR interview controls on `/`;
   - keep candidate interview registration on `/candidate?interviewToken=<token>`;

--- a/docs/project/tasks.md
+++ b/docs/project/tasks.md
@@ -1,7 +1,7 @@
 # Epic Task Backlog
 
 ## Last Updated
-- Date: 2026-03-09
+- Date: 2026-03-10
 - Updated by: coordinator + architect
 
 ## Priority Model
@@ -43,6 +43,8 @@
 
 ## Active Queue After Planning Pass
 
+- Planning source of truth for the next interview follow-on slice:
+  `docs/project/interview-feedback-fairness-pass.md`.
 | Order | Task ID | Why Now |
 | --- | --- | --- |
 | A-1 | TASK-05-03/04 | Interview baseline scheduling/registration is in repo; the next interview follow-on work is structured feedback and fairness controls outside this slice |

--- a/docs/testing/strategy.md
+++ b/docs/testing/strategy.md
@@ -222,6 +222,35 @@ Operational assumptions for the current interview slice:
 - Free Google Calendar mode uses a service-account JSON key and calendars manually shared with that service account; missing calendar mapping returns `422 interviewer_calendar_not_configured`, while missing runtime calendar configuration returns `503 calendar_not_configured`.
 - Keep compose smoke green without adding nondeterministic Google Calendar browser automation.
 
+## Structured Interview Feedback and Fairness Verification (`TASK-05-03`, `TASK-05-04`)
+
+Implementation source of truth:
+- `docs/project/interview-feedback-fairness-pass.md`
+
+Future implementation coverage must include at minimum:
+
+| Capability | Unit Coverage | Integration/Smoke Coverage | Required Evidence |
+| --- | --- | --- | --- |
+| Feedback payload validation (score range, mandatory notes, recommendation enum) | `apps/backend/tests/unit/interviews/*` | `apps/backend/tests/integration/interviews/test_interview_api.py` or dedicated feedback integration module | invalid payload returns `422`; valid interviewer payload persists current-version feedback |
+| Assigned-interviewer-only submission rule | `apps/backend/tests/unit/interviews/*` | interview feedback integration suite | non-interviewer submit returns `403`; interviewer can create/update only their own row |
+| Reschedule invalidates old feedback for gate purposes | `apps/backend/tests/unit/interviews/*` | interview feedback integration suite | previous `schedule_version` feedback is readable as history but blocks `interview -> offer` |
+| Fairness gate on existing `interview -> offer` transition | `apps/backend/tests/unit/vacancies/*` or `apps/backend/tests/unit/interviews/*` | `apps/backend/tests/integration/vacancies/test_vacancy_pipeline_api.py` or dedicated transition suite | `409` detail codes for `interview_feedback_window_not_open`, `interview_feedback_missing`, `interview_feedback_incomplete`, and `interview_feedback_stale` |
+| Successful `interview -> offer` after complete current-version panel feedback | N/A | pipeline transition integration suite | transition succeeds without adding a new route or pipeline stage |
+| HR feedback UX on `/` | `apps/frontend/src/pages/HrDashboardPage.test.tsx` | backend integration above | summary, current-user form, and localized fairness blocker messages render correctly |
+
+Acceptance rules for the implementation slice:
+- Freeze OpenAPI and update generated frontend types in the same change.
+- Keep auth, CORS, route topology, and anonymous candidate transport unchanged.
+- Keep compose smoke green without adding feedback-specific browser automation.
+- Minimum verification set:
+  - `./scripts/check-docs-structure.sh`
+  - `./scripts/check-openapi-freeze.sh`
+  - `npm --prefix apps/frontend run api:types:check`
+  - `npm --prefix apps/frontend run lint`
+  - `npm --prefix apps/frontend run test -- --run`
+  - `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend pytest -q`
+  - `./scripts/smoke-compose.sh`
+
 ## Frontend Admin Verification (ADMIN-01)
 
 | Capability | Unit Coverage | Integration/Smoke Coverage | Required Evidence |


### PR DESCRIPTION
## Summary
- add a decision-complete planning baseline for `TASK-05-03/04` interview feedback and fairness gating
- link the new planning source into backlog/sprint docs and interview follow-on references
- record ADR-0030 and future verification expectations for the upcoming implementation slice

## Scope
- docs-only planning pass
- no runtime, API, auth, CORS, route, or compose changes

## Verification
- `./scripts/check-docs-structure.sh`

## Notes
- this PR is intentionally restacked on `main` so it stays independent from PR #80
- the implementation slice should start only after this planning pass is reviewed and merged