### PR TITLE
feat(compose): add optional ai-local ollama profile

### DIFF
--- a/.ai/team/workflow.md
+++ b/.ai/team/workflow.md
@@ -25,6 +25,7 @@
 - Documentation updates are prepared using `docs/llm/docs-update-checklist.md`.
 - Architect confirms diagram consistency and best-practice alignment.
 - Coordinator merges outputs into one final delivery.
+- After merge, coordinator checks linked GitHub issues, closes the issues actually resolved by the merged task, and syncs any backlog status change in `docs/project/tasks.md`.
 
 ## 6. Done Criteria
 - Acceptance criteria are explicitly satisfied.
@@ -36,4 +37,5 @@
 - Architecture diagrams are updated for relevant changes.
 - Best practices from `docs/engineering/best-practices.md` are explicitly followed.
 - Latest application version is started locally via Docker (`docker compose up -d --build`) after implementation.
+- Post-merge issue closeout is complete: linked GitHub issues are reviewed, resolved issues are closed, and `docs/project/tasks.md` is synced before the task is considered fully delivered.
 - Final handoff includes a concise operator note: what changed and how to use/verify the updated functionality.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,17 @@ Every behavior change must update code and documentation in the same task.
 ## Docker Bootstrap
 1. `cp .env.example .env`
 2. `docker compose up -d --build`
-3. Frontend: `http://localhost:5173`, Backend health: `http://localhost:8000/health`
+3. `./scripts/smoke-compose.sh`
+4. Frontend: `http://localhost:5173`, Backend health: `http://localhost:8000/health`
+
+Compose runtime notes:
+- Default scoring path is unchanged: `OLLAMA_BASE_URL` still defaults to `http://host.docker.internal:11434`.
+- `backend` and `backend-worker` now inject `host.docker.internal:host-gateway` so the external-host Ollama path is Linux-safe without changing the default compose command.
+- Optional self-contained AI scoring runtime:
+  `OLLAMA_BASE_URL=http://ollama:11434 docker compose --profile ai-local up -d --build`
+- Optional operator-facing real scoring verification:
+  `./scripts/smoke-scoring-compose.sh`
+- The canonical compose/browser smoke baseline remains `./scripts/smoke-compose.sh`; it does not start compose-local Ollama and it does not verify real scoring.
 
 Shortcut commands:
 - `make up`, `make rebuild`, `make clean-orphans`, `make down`, `make ps`, `make logs`, `make smoke`

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -13,6 +13,13 @@
 ## Docker
 - Built by root compose stack using `docker/backend.Dockerfile`.
 - Container health endpoint: `GET /health`.
+- Default compose scoring path stays external-host compatible:
+  `OLLAMA_BASE_URL=http://host.docker.internal:11434`.
+- `backend` and `backend-worker` now include `host.docker.internal:host-gateway` for Linux-safe access to host Ollama without changing the default compose command.
+- Optional self-contained AI runtime:
+  `OLLAMA_BASE_URL=http://ollama:11434 docker compose --profile ai-local up -d --build`
+- Optional operator-facing compose scoring smoke:
+  `./scripts/smoke-scoring-compose.sh`
 
 ## Authentication Baseline (TASK-01-02)
 - Auth endpoints:
@@ -41,6 +48,10 @@
 - `CV_ALLOWED_MIME_TYPES`
 - `CV_MAX_SIZE_BYTES`
 - `CV_PARSING_MAX_ATTEMPTS`
+- `MATCH_SCORING_MAX_ATTEMPTS`
+- `MATCH_SCORING_MODEL_NAME`
+- `MATCH_SCORING_REQUEST_TIMEOUT_SECONDS`
+- `MATCH_SCORING_QUEUE_NAME`
 - `OLLAMA_BASE_URL`
 - `GOOGLE_CALENDAR_ENABLED`
 - `HRM_JWT_SECRET`
@@ -48,6 +59,10 @@
 - `HRM_ACCESS_TOKEN_TTL_SECONDS`
 - `HRM_REFRESH_TOKEN_TTL_SECONDS`
 - `HRM_AUTH_REDIS_PREFIX`
+- `CELERY_BROKER_URL`
+- `CELERY_RESULT_BACKEND`
+- `CELERY_TASK_DEFAULT_QUEUE`
+- `CELERY_TASK_TIME_LIMIT_SECONDS`
 - Settings loading policy:
   - Use `pydantic BaseSettings` models for all runtime config.
   - Canonical settings module: `hrm_backend/settings.py` (`AppSettings`, `get_settings`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       GOOGLE_CALENDAR_ENABLED: ${GOOGLE_CALENDAR_ENABLED:-false}
     ports:
       - "${BACKEND_PORT:-8000}:8000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./secrets:/run/hrm-secrets:ro
     depends_on:
@@ -114,6 +116,8 @@ services:
       - worker
       - --loglevel=INFO
       - --queues=cv_parsing,match_scoring,interview_sync
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./secrets:/run/hrm-secrets:ro
     depends_on:
@@ -241,7 +245,50 @@ services:
         mc anonymous set none local/${OBJECT_STORAGE_BUCKET:-hrm-documents}
     restart: "no"
 
+  ollama:
+    image: ollama/ollama:latest
+    profiles:
+      - ai-local
+    environment:
+      OLLAMA_HOST: 0.0.0.0:11434
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test:
+        - CMD
+        - bash
+        - -lc
+        - |
+          exec 3<>/dev/tcp/127.0.0.1/11434
+          printf 'GET /api/tags HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3
+          grep -q '200 OK' <&3
+      interval: 15s
+      timeout: 10s
+      retries: 20
+      start_period: 20s
+    restart: unless-stopped
+
+  ollama-init:
+    image: curlimages/curl:8.12.1
+    profiles:
+      - ai-local
+    environment:
+      MATCH_SCORING_MODEL_NAME: ${MATCH_SCORING_MODEL_NAME:-llama3.2:latest}
+    depends_on:
+      ollama:
+        condition: service_healthy
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        curl -fsS http://ollama:11434/api/pull \
+          -H 'Content-Type: application/json' \
+          -d "{\"name\":\"$${MATCH_SCORING_MODEL_NAME}\",\"stream\":false}" >/dev/null
+    restart: "no"
+
 volumes:
   postgres_data:
   redis_data:
   minio_data:
+  ollama_data:

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -44,6 +44,7 @@ Use this log for decisions that change interfaces, data models, deployment topol
 | ADR-0037 | 2026-03-11 | accepted | Expose onboarding progress dashboards on the existing `/` route and keep manager visibility read-only and assignment-scoped | architect + backend-engineer + frontend-engineer | onboarding progress read model, manager visibility policy, frontend route topology, RBAC |
 | ADR-0038 | 2026-03-11 | accepted | Perform native PDF/DOCX text extraction before CV normalization while keeping parsing and scoring contracts stable | architect + backend-engineer | candidate parsing pipeline, evidence traceability, worker/runtime dependencies, scoring preconditions |
 | ADR-0039 | 2026-03-11 | accepted | Enrich parsed CV profiles with profession-agnostic workplaces, held positions, education, normalized titles/dates, and generic skills | architect + backend-engineer | candidate parsing pipeline, parsed-profile semantics, evidence mapping, product framing |
+| ADR-0040 | 2026-03-12 | accepted | Keep default Ollama runtime external-host compatible while adding an opt-in compose-local `ai-local` profile and separate scoring smoke | architect + backend-engineer | compose topology, scoring runtime, operator verification |
 
 ## ADR-0001
 - Context: Project is at bootstrap stage and lacks durable knowledge artifacts.
@@ -773,3 +774,31 @@ Use this log for decisions that change interfaces, data models, deployment topol
   - Existing parsing status, analysis response envelope, and scoring preconditions remain stable.
   - Later search/ranking slices can build on richer workplace and education data without reopening
     storage or route topology.
+
+## ADR-0040
+- Context: `TASK-12-02` needed a self-contained local AI verification path, but the existing
+  compose baseline and scoring/public contracts were already stable and could not regress. The
+  repository also had to stay compatible with host-installed Ollama instances and Linux hosts.
+- Decision:
+  - Keep the default backend scoring target unchanged:
+    `OLLAMA_BASE_URL=http://host.docker.internal:11434`.
+  - Add `extra_hosts: ["host.docker.internal:host-gateway"]` to `backend` and `backend-worker`
+    so the external-host Ollama path remains Linux-safe.
+  - Add an optional compose profile `ai-local` with:
+    - `ollama` service using a persistent volume and `/api/tags` healthcheck;
+    - `ollama-init` one-shot bootstrap that pulls `MATCH_SCORING_MODEL_NAME` and exits `0`.
+  - Do not publish the Ollama port in compose, so the profile does not conflict with an existing
+    host Ollama runtime.
+  - Keep API routes, score payload contracts, route topology, and the baseline compose smoke
+    unchanged.
+  - Add a separate operator-facing verification path:
+    `OLLAMA_BASE_URL=http://ollama:11434 docker compose --profile ai-local up -d --build`
+    followed by `./scripts/smoke-scoring-compose.sh`.
+- Consequences:
+  - Default local development and CI keep the existing compose/browser smoke behavior.
+  - Linux users no longer depend on Docker Desktop-style `host.docker.internal` handling for the
+    external-host scoring path.
+  - Real compose-local scoring verification becomes reproducible without widening mandatory CI or
+    browser smoke scope.
+  - First `ai-local` bootstrap can take longer and consume persistent disk because the model pull is
+    explicit and cached in `ollama_data`.

--- a/docs/architecture/diagrams.md
+++ b/docs/architecture/diagrams.md
@@ -1,7 +1,7 @@
 # Architecture Diagrams
 
 ## Last Updated
-- Date: 2026-03-11
+- Date: 2026-03-12
 - Updated by: architect + backend-engineer + frontend-engineer
 
 This file is the canonical diagram set for the system. Update diagrams whenever architecture, data flow, or critical business flow changes.
@@ -508,7 +508,8 @@ flowchart LR
   OAPI --> MERGE
   FECG --> MERGE
   BSMOKE --> MERGE
-  MERGE --> MAIN[Protected main]
+  MERGE --> CLOSEOUT[Post-merge closeout\ncheck linked issues\nclose resolved issues\nsync docs/project/tasks.md]
+  CLOSEOUT --> MAIN[Protected main]
 ```
 
 ## Diagram 13: Docker Compose Runtime Topology (Phase 1)
@@ -525,6 +526,10 @@ flowchart TB
     DBINIT[postgres-init one-shot job]
     MIG[backend-migrate one-shot job]
     MINIT[minio-init one-shot job]
+    subgraph AILOC[optional ai-local profile]
+      OLL[ollama container\ninternal :11434\npersistent ollama_data]
+      OINIT[ollama-init one-shot\npull MATCH_SCORING_MODEL_NAME]
+    end
   end
 
   USER[Chrome Browser] --> FE
@@ -538,11 +543,18 @@ flowchart TB
   WKR --> DB
   WKR --> MQ
   WKR --> OBJ
-  BE --> OLL[Ollama]
-  WKR --> OLL
+  OINIT --> OLL
+  BE -. ai-local only .-> OLL
+  WKR -. ai-local only .-> OLL
+  BE --> EXOLL[External host Ollama default\nhost.docker.internal:11434]
+  WKR --> EXOLL
   BE <--> GCAL[Google Calendar]
   WKR <--> GCAL
 ```
+
+Default compose startup keeps the external-host Ollama path, while the optional `ai-local`
+profile switches `backend` and `backend-worker` to compose-local Ollama without publishing the
+Ollama port on the host.
 
 ## Diagram 14: Authentication and Session Lifecycle Sequence
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,7 +1,7 @@
 # Architecture Overview
 
 ## Last Updated
-- Date: 2026-03-11
+- Date: 2026-03-12
 - Updated by: architect + backend-engineer + frontend-engineer
 
 ## System Context
@@ -58,7 +58,8 @@ flowchart LR
    candidate profile + CV -> native PDF/DOCX text extraction -> RU/EN normalization + universal
    workplace/education/title/date/skills enrichment + evidence extraction ->
    recruiter selects vacancy + candidate in `/` -> explicit scoring request ->
-   `409` if parsed CV analysis is not ready, otherwise async scoring via Ollama ->
+   `409` if parsed CV analysis is not ready, otherwise async scoring via Ollama
+   (external host by default; compose-local only when `ai-local` profile is enabled explicitly) ->
    persisted score artifact -> recruiter review -> shortlist.
 2. Interview Scheduling Flow:
    recruiter selects vacancy + candidate in `/` -> interview create/reschedule ->
@@ -173,6 +174,15 @@ flowchart LR
 - Environment baseline: Docker + Docker Compose for deterministic local/dev and CI-aligned stack startup.
 - Compose baseline services: `frontend`, `backend`, `backend-worker`, `postgres`, `postgres-init`, `backend-migrate`, `redis`, `minio`, `minio-init`.
 - Compose bootstrap baseline: `postgres-init`, `backend-migrate`, and `minio-init` are one-shot prerequisites before steady-state services are considered ready.
+- Compose scoring default remains external-host compatible:
+  `OLLAMA_BASE_URL=http://host.docker.internal:11434`.
+- Linux-safe external-host scoring baseline:
+  `backend` and `backend-worker` inject `host.docker.internal:host-gateway`.
+- Optional compose-local AI runtime:
+  `OLLAMA_BASE_URL=http://ollama:11434 docker compose --profile ai-local up -d --build`
+  adds `ollama`, `ollama-init`, and persistent `ollama_data` without changing the default startup path.
+- Compose smoke baseline remains unchanged:
+  `./scripts/smoke-compose.sh` still validates login + public apply only, while real scoring verification lives in opt-in `./scripts/smoke-scoring-compose.sh`.
 - Async runtime baseline: dedicated `backend-worker` (Celery) processing DB-backed jobs on
   `cv_parsing`, `match_scoring`, and `interview_sync` queues.
 - Frontend style: React.js + TypeScript SPA with role-based route guards and shared component system.
@@ -219,6 +229,7 @@ flowchart LR
   `employee_profiles.staff_account_id` is still null; ambiguous duplicate e-mail data fails closed
   with an identity-conflict error until HR cleans the source records.
 - Integration instability risk with calendar sync edge cases.
+- Optional compose-local Ollama verification now removes the external-host dependency for real scoring checks, but first-run bootstrap can be slower because the model pull is explicit and persistent-volume backed.
 - Compliance risk if country-specific legal acts are not mapped early.
 
 ## Delivery Phases

--- a/docs/operations/github-workflow.md
+++ b/docs/operations/github-workflow.md
@@ -1,8 +1,8 @@
 # GitHub Workflow and Branch Protection
 
 ## Last Updated
-- Date: 2026-03-05
-- Updated by: coordinator
+- Date: 2026-03-12
+- Updated by: coordinator + architect
 
 ## Branching Model
 - `main`: protected release-ready branch.
@@ -43,6 +43,12 @@
 - Commit scope: one concern per commit.
 - Commit message style: `type(scope): summary`.
 - PR description must include verification commands and risks.
+
+## Post-Merge Closeout
+- After merge, review all GitHub issues linked to the task/PR.
+- Close only the issues that are actually resolved by the merged change.
+- If the merge changes backlog status, update `docs/project/tasks.md` in the same closeout step.
+- Task delivery is not complete until issue closeout and `docs/project/tasks.md` synchronization are finished.
 
 ## GitHub CLI Operations (`gh`)
 - Always check auth state before PR automation: `gh auth status`.

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -1,8 +1,8 @@
 # Operations Runbook
 
 ## Last Updated
-- Date: 2026-03-11
-- Updated by: devops-engineer + backend-engineer
+- Date: 2026-03-12
+- Updated by: devops-engineer + backend-engineer + architect
 
 ## Local Environment (Docker Compose)
 ### Prerequisites
@@ -17,11 +17,24 @@
 4. Verify status: `docker compose ps`
 5. Run smoke suite: `./scripts/smoke-compose.sh`
 
+Optional self-contained AI runtime:
+1. Override scoring runtime target:
+   `OLLAMA_BASE_URL=http://ollama:11434 docker compose --profile ai-local up -d --build`
+2. Verify real scoring lifecycle:
+   `./scripts/smoke-scoring-compose.sh`
+
 Compose bootstrap notes:
 - `postgres-init` ensures `${POSTGRES_DB}` exists even when reusing an old data volume.
 - `backend-migrate` runs `alembic upgrade head` before backend starts.
 - `backend-worker` runs one Celery worker process for `cv_parsing`, `match_scoring`, and `interview_sync` against the same compose dependencies as `backend`.
 - Backend container starts only after DB bootstrap and migrations complete successfully.
+- Default compose startup remains external-host compatible for scoring:
+  `OLLAMA_BASE_URL` stays `http://host.docker.internal:11434`.
+- `backend` and `backend-worker` inject `host.docker.internal:host-gateway` so the external-host Ollama path is Linux-safe.
+- Optional `ai-local` compose profile adds:
+  - `ollama` with persistent model storage in `ollama_data`;
+  - `ollama-init` one-shot bootstrap that pulls `MATCH_SCORING_MODEL_NAME`;
+  - no published Ollama port, so the profile does not conflict with a host-installed Ollama.
 
 Shortcut wrappers:
 - `make up` / `just up`
@@ -101,6 +114,12 @@ Runtime auth/browser integration settings:
   - `MATCH_SCORING_REQUEST_TIMEOUT_SECONDS`
   - `MATCH_SCORING_QUEUE_NAME`
   - `OLLAMA_BASE_URL`
+- Compose runtime modes:
+  - default: external-host Ollama via `http://host.docker.internal:11434`;
+  - opt-in self-contained: `OLLAMA_BASE_URL=http://ollama:11434 docker compose --profile ai-local up -d --build`.
+- Optional compose-local AI services:
+  - `ollama` exposes `11434` only inside the compose network and stores models in `ollama_data`;
+  - `ollama-init` waits for `ollama`, pulls `MATCH_SCORING_MODEL_NAME`, and exits with code `0`.
 - API endpoints:
   - `POST /api/v1/vacancies/{vacancy_id}/match-scores`
   - `GET /api/v1/vacancies/{vacancy_id}/match-scores`
@@ -145,6 +164,19 @@ Runtime auth/browser integration settings:
    - `docker compose down`
    - `docker compose up -d --build`
    - `./scripts/smoke-compose.sh`
+
+### Optional AI-Local Scoring Smoke
+1. Start the opt-in runtime:
+   `OLLAMA_BASE_URL=http://ollama:11434 docker compose --profile ai-local up -d --build`
+2. Run the operator-facing verification:
+   `./scripts/smoke-scoring-compose.sh`
+3. Script validation scope:
+   - `docker compose ps` reports `ollama=healthy` and `ollama-init` exited `0`;
+   - `backend` and `backend-worker` both expose `OLLAMA_BASE_URL=http://ollama:11434`;
+   - the pulled model matches `MATCH_SCORING_MODEL_NAME`;
+   - one real candidate CV reaches `analysis_ready=true`;
+   - scoring reaches `succeeded` through the canonical API lifecycle and returns the canonical score payload keys.
+4. This smoke is opt-in and operator-facing; do not treat it as a mandatory CI/browser smoke gate.
 
 ### Login Browser Integration Diagnostics (`/login`)
 - Symptoms:
@@ -210,6 +242,7 @@ Runtime auth/browser integration settings:
   4. If status remains `queued`, inspect `backend-worker` logs and confirm it listens on `match_scoring`.
   5. If status becomes `failed`, verify `OLLAMA_BASE_URL` reachability and model availability for `MATCH_SCORING_MODEL_NAME`.
   6. Confirm the latest `match_score_artifacts` row contains `score`, `confidence`, `summary`, requirements, evidence, and model metadata.
+  7. For compose-local diagnosis, rerun `./scripts/smoke-scoring-compose.sh` after confirming `ollama` is healthy and `ollama-init` has exited `0`.
 
 ### Auth Denylist Failure Policy
 - Auth validation is fail-closed when Redis denylist is unavailable.

--- a/docs/project/tasks.md
+++ b/docs/project/tasks.md
@@ -1,7 +1,7 @@
 # Epic Task Backlog
 
 ## Last Updated
-- Date: 2026-03-11
+- Date: 2026-03-12
 - Updated by: coordinator + architect + backend-engineer + frontend-engineer
 
 ## Priority Model
@@ -21,6 +21,7 @@
 | TASK-01-01/02/03/04/05 | done/closed | GitHub issues #1, #2, #3, #4, and #24 were closed during backlog normalization; current repo/docs remain the source of truth for the implemented security foundation |
 | TASK-11-13 | done/closed | GitHub issue #67 closed; merged in `main` via PR #68 and PR #69 (`d8ea39e`) |
 | TASK-12-01 | implemented/local-compose-baseline | `docker-compose.yml`, Dockerfiles, `./scripts/smoke-compose.sh`, and CI compose browser smoke already verify the local stack (`frontend`, `backend`, `backend-worker`, `postgres`, `redis`, `minio`) plus bootstrap jobs |
+| TASK-12-02 | implemented/local-ai-local-compose | Repo now includes Linux-safe host-gateway wiring for external-host Ollama, optional compose profile `ai-local` (`ollama` + `ollama-init` + persistent volume), and operator-facing `./scripts/smoke-scoring-compose.sh` while keeping baseline compose/browser smoke and scoring/public contracts unchanged; GitHub issue `#85` still needs authenticated closeout because the current local `gh` token is invalid |
 | TASK-11-01/02/03/04 | done/closed | GitHub issues #25, #26, #27, and #28 were closed during backlog normalization; the current repo remains the source of truth for the implemented frontend foundation |
 | TASK-03-01/02/03/05/06/07/08 | implemented/local-universal-profile-enrichment-slice | GitHub issue #90 is now closed; backend candidate profile, public apply, async parsing, native PDF/DOCX text extraction, RU/EN normalization, profession-agnostic structured CV enrichment (workplaces with held positions, education, normalized titles/dates, generic skills), evidence traceability, and public tracking endpoints are present in repo with unit/integration coverage |
 | TASK-02-01/02/03 | implemented/local-baseline | Backend vacancy CRUD, pipeline transitions, and ordered transition history endpoint are present in repo with integration coverage |
@@ -46,9 +47,11 @@
 | TASK-07-04 | implemented/local-onboarding-dashboard-slice | `GET /api/v1/onboarding/runs*` now exposes HR/admin read-all plus manager-scoped onboarding progress visibility, with the dashboard embedded on `/` for HR and rendered as the standalone manager workspace on the existing `/` route |
 | COMPLIANCE-01 | planned | EPIC-13 article-level legal mapping and evidence pack track |
 
-## 2026-03-11 Delivery Control Notes
+## 2026-03-12 Delivery Control Notes
 - `TASK-12-01` containerized platform baseline is already implemented in repo: `docker compose config`, `docker compose up -d --build`, and `./scripts/smoke-compose.sh` pass against the current stack, and CI reuses the same compose browser smoke baseline.
-- `TASK-12-02` is now tracked as the Ollama infra follow-up: scoring works against external `OLLAMA_BASE_URL`, but local compose is not yet self-contained for AI runtime verification.
+- `TASK-12-02` is now implemented in repo as an opt-in runtime hardening slice: default compose still targets external-host Ollama via `OLLAMA_BASE_URL`, Linux hosts now get `host.docker.internal:host-gateway`, and self-contained AI verification runs through `OLLAMA_BASE_URL=http://ollama:11434 docker compose --profile ai-local up -d --build` plus `./scripts/smoke-scoring-compose.sh`.
+- Baseline compose acceptance remains unchanged after `TASK-12-02`: `./scripts/smoke-compose.sh` still verifies login + public apply only and does not require compose-local Ollama.
+- GitHub issue closeout for `TASK-12-02` is blocked locally because `gh auth status` reports an invalid token; remote issue `#85` must be closed during the mandatory post-merge closeout step once authenticated GitHub access is restored.
 - Security foundation work (`TASK-01-01/02/03/04/05`) is materially implemented in repo and supporting docs; this backlog normalization removes it from the effective open count.
 - Frontend foundation work (`TASK-11-01/02/03/04`) is materially implemented in repo and supporting tests; remaining frontend backlog is follow-on admin/reporting and phase-2 role UX.
 - GitHub issue sync is normalized to the current backlog state: stale implemented-task issues were closed, and missing normalized-open tasks were added as issues #85-#100.
@@ -87,25 +90,24 @@
 - `TASK-07-02` is no longer active queue work; the implemented source of truth is the repo-backed onboarding task generation/backfill/update API on `/api/v1/onboarding/runs/{onboarding_id}/tasks`.
 - `TASK-07-03` is no longer active queue work; the implemented source of truth is the repo-backed employee self-service onboarding portal on `/employee` plus `/api/v1/employees/me/onboarding*`.
 - `TASK-07-04` is no longer active queue work; the implemented source of truth is the repo-backed onboarding progress dashboard on `/api/v1/onboarding/runs*`, embedded for HR on `/` and rendered as the manager workspace on the existing `/` route.
-- `TASK-12-02` is now active infra gap work because Ollama scoring depends on an external host runtime and the current compose stack does not provide a self-contained AI path for local verification.
 - The remaining candidate-domain follow-on work after `TASK-03-08` is limited to search/filtering
   (`TASK-03-04`) and later AI quality/fallback work, not baseline parsed-profile structure.
 
 ## Normalized Open Backlog Snapshot
 
-- Normalized open backlog count: `22` tasks.
+- Normalized open backlog count: `21` tasks.
 - This count excludes tasks already implemented in repo but retained in the historical planning tables below for lineage.
-- GitHub tracking for the normalized open backlog currently lives in issues `#18-#23`, `#61-#62`, `#85-#88`, and `#91-#100`.
-- Issue `#58` remains an umbrella `COMPLIANCE-01` tracking issue and is not included in the normalized `22`-task count.
+- Repo backlog state now excludes `TASK-12-02`; GitHub issue `#85` still needs authenticated closeout before the remote tracker list shrinks accordingly.
+- Issue `#58` remains an umbrella `COMPLIANCE-01` tracking issue and is not included in the normalized `21`-task count.
 - Current open backlog by delivery wave:
-  - Wave 1 product gaps: `TASK-12-02`, `TASK-03-04`, `TASK-04-04`, `TASK-04-06`
+  - Wave 1 product gaps: `TASK-03-04`, `TASK-04-04`, `TASK-04-06`
   - Wave 2 platform/ops/reporting: `TASK-02-04`, `ADMIN-04`, `ADMIN-05`, `TASK-08-01`, `TASK-08-02`, `TASK-08-03`, `TASK-08-04`, `TASK-10-01`, `TASK-10-02`, `TASK-10-03`, `TASK-10-04`, `TASK-13-03`, `TASK-13-04`
   - Wave 3 phase-2 workspaces: `TASK-09-01`, `TASK-09-02`, `TASK-09-03`, `TASK-09-04`, `TASK-11-12`
 
 | Order | Task ID | Why Now |
 | --- | --- | --- |
-| A-1 | TASK-12-02 | Needed to make local AI scoring verification self-contained instead of depending on an external host Ollama runtime |
-| A-2 | TASK-03-04 | Needed to turn the enriched universal candidate profile into recruiter-facing search/filter productivity |
+| A-1 | TASK-03-04 | Needed to turn the enriched universal candidate profile into recruiter-facing search/filter productivity |
+| A-2 | TASK-04-04 | Needed to define low-confidence scoring fallback behavior now that runtime verification is self-contained and shortlist scoring is operational locally |
 | A-3 | TASK-09-01 | Full manager workspace is now the next dependent slice because manager users currently see only the onboarding-progress dashboard on `/`, while broader team hiring/onboarding visibility remains deferred |
 
 - Execution rule for follow-on interview work: keep the implemented `/` and `/candidate?interviewToken=...` topology, candidate-auth exclusion, and token-based public transport unchanged unless a separate ADR reopens that scope.

--- a/docs/testing/strategy.md
+++ b/docs/testing/strategy.md
@@ -17,6 +17,7 @@
 | Unit | Validate isolated logic | Mandatory for all changed logic |
 | Integration/E2E | Validate boundaries and user/system paths | Mandatory for all changed logic and interfaces |
 | Infrastructure Smoke | Validate Docker Compose runtime readiness | Mandatory for container/runtime baseline changes (`TASK-12-01`) |
+| Operator-Facing AI Smoke | Validate opt-in compose-local Ollama scoring lifecycle | Mandatory when `TASK-12-02` changes the `ai-local` runtime path |
 
 ## Test Package Layout (Backend)
 - Keep test tree aligned with application package boundaries and split by level.
@@ -108,6 +109,27 @@ apps/backend/tests/
   - browser public candidate requests use `VITE_API_BASE_URL` backend origin rather than relative frontend origin;
   - smoke passes when the public tracking status reaches at least `queued`/`running`; `analysis_ready=true` is preferred but not mandatory for compose success.
   - Google Calendar and Ollama integrations are intentionally excluded from compose smoke; their reachability is not required for local compose baseline acceptance.
+
+## Optional AI-Local Compose Verification (`TASK-12-02`)
+- Canonical self-contained runtime command:
+  `OLLAMA_BASE_URL=http://ollama:11434 docker compose --profile ai-local up -d --build`
+- Operator-facing verification command:
+  `./scripts/smoke-scoring-compose.sh`
+- Required supporting checks when `ai-local` runtime behavior changes:
+  - `docker compose config`
+  - `uv run --project apps/backend ruff check .`
+  - `uv run --project apps/backend pytest -q tests/unit/scoring tests/integration/scoring/test_match_scoring_api.py`
+  - `./scripts/check-docs-structure.sh`
+- Verification scope for `./scripts/smoke-scoring-compose.sh`:
+  - `ollama` is `healthy` and `ollama-init` completes successfully;
+  - `backend` and `backend-worker` both see `OLLAMA_BASE_URL=http://ollama:11434`;
+  - one real vacancy/candidate/CV path reaches `analysis_ready=true`;
+  - real scoring runs through the existing API and reaches canonical lifecycle states;
+  - final score payload contains canonical keys without asserting specific score values.
+- Acceptance rules:
+  - Keep `./scripts/smoke-compose.sh` unchanged as the mandatory baseline smoke.
+  - Do not add `./scripts/smoke-scoring-compose.sh` to required CI or browser smoke jobs.
+  - Keep scoring/public API routes and payload contracts unchanged while expanding only runtime-level verification.
 
 ## Evidence Format
 - Command
@@ -209,6 +231,7 @@ apps/backend/tests/
 - Keep the current compose smoke green.
 - Do not regress auth or CORS behavior.
 - Keep scoring verification at unit/integration level; do not extend compose browser smoke to scoring until runtime nondeterminism is addressed.
+- Use `./scripts/smoke-scoring-compose.sh` only as an opt-in operator/runtime verification for the compose-local Ollama profile.
 - Shortlist review must work against the real backend scoring contract, not mock-only placeholder data.
 
 ## Interview Scheduling and Candidate Registration Verification (`TASK-11-08`, `TASK-05-01`, `TASK-05-02`)

--- a/scripts/smoke-scoring-compose.sh
+++ b/scripts/smoke-scoring-compose.sh
@@ -1,0 +1,512 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+EXPECTED_OLLAMA_BASE_URL="${EXPECTED_OLLAMA_BASE_URL:-http://ollama:11434}"
+FIXTURE_PATH="${FIXTURE_PATH:-apps/backend/tests/fixtures/candidates/sample_cv_en.pdf}"
+
+wait_http() {
+  local url="$1"
+  local attempts="${2:-60}"
+  local delay_seconds="${3:-2}"
+  local try
+
+  for try in $(seq 1 "${attempts}"); do
+    if curl -fsS "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep "${delay_seconds}"
+  done
+
+  echo "endpoint did not become ready: ${url}" >&2
+  return 1
+}
+
+post_json_with_retry() {
+  local url="$1"
+  local body="$2"
+  local attempts="${3:-30}"
+  local delay_seconds="${4:-2}"
+  local try
+
+  for try in $(seq 1 "${attempts}"); do
+    if response="$(curl -fsS -X POST "${url}" -H 'Content-Type: application/json' -d "${body}" 2>/dev/null)"; then
+      printf '%s' "${response}"
+      return 0
+    fi
+    sleep "${delay_seconds}"
+  done
+
+  echo "POST endpoint did not become ready: ${url}" >&2
+  return 1
+}
+
+post_json_with_auth_retry() {
+  local url="$1"
+  local body="$2"
+  local bearer_token="$3"
+  local attempts="${4:-30}"
+  local delay_seconds="${5:-2}"
+  local try
+
+  for try in $(seq 1 "${attempts}"); do
+    if response="$(curl -fsS -X POST "${url}" \
+      -H 'Content-Type: application/json' \
+      -H "Authorization: Bearer ${bearer_token}" \
+      -d "${body}" 2>/dev/null)"; then
+      printf '%s' "${response}"
+      return 0
+    fi
+    sleep "${delay_seconds}"
+  done
+
+  echo "POST endpoint did not become ready: ${url}" >&2
+  return 1
+}
+
+create_smoke_admin() {
+  local login="$1"
+  local email="$2"
+  local password="$3"
+
+  docker compose exec -T backend \
+    uv run --no-dev python -m hrm_backend.auth.cli.create_admin \
+    --login "${login}" \
+    --email "${email}" \
+    --password "${password}" >/dev/null
+}
+
+container_env() {
+  local service="$1"
+  local variable_name="$2"
+
+  docker compose exec -T "${service}" python -c \
+    "import os; print(os.environ.get('${variable_name}', ''))"
+}
+
+if [[ ! -f "${FIXTURE_PATH}" ]]; then
+  echo "fixture file does not exist: ${FIXTURE_PATH}" >&2
+  exit 1
+fi
+
+echo "[ai-smoke] validating ai-local compose service status..."
+COMPOSE_PS_JSON="$(docker compose ps --all --format json)"
+python3 - "${COMPOSE_PS_JSON}" <<'PY'
+import json
+import sys
+
+healthy_services = ("backend", "postgres", "redis", "minio", "ollama")
+running_services = ("frontend", "backend-worker")
+bootstrap_services = ("postgres-init", "backend-migrate", "minio-init", "ollama-init")
+raw = sys.argv[1].strip()
+
+if not raw:
+    raise SystemExit("docker compose ps returned empty output")
+
+if raw.startswith("["):
+    payload = json.loads(raw)
+else:
+    payload = [json.loads(line) for line in raw.splitlines() if line.strip()]
+
+services = {row.get("Service"): row for row in payload if isinstance(row, dict)}
+missing = [
+    service
+    for service in (*healthy_services, *running_services, *bootstrap_services)
+    if service not in services
+]
+if missing:
+    raise SystemExit(
+        "missing services in compose status: "
+        + ", ".join(missing)
+        + " (run `OLLAMA_BASE_URL=http://ollama:11434 docker compose --profile ai-local up -d --build` first)"
+    )
+
+for service in healthy_services:
+    row = services[service]
+    state = (row.get("State") or "").lower()
+    health = (row.get("Health") or "").lower()
+    if state != "running":
+        raise SystemExit(f"{service} must be running, got state={state or 'unknown'}")
+    if health != "healthy":
+        raise SystemExit(f"{service} must be healthy, got health={health or 'unknown'}")
+
+for service in running_services:
+    row = services[service]
+    state = (row.get("State") or "").lower()
+    if state != "running":
+        raise SystemExit(f"{service} must be running, got state={state or 'unknown'}")
+
+for service in bootstrap_services:
+    row = services[service]
+    state = (row.get("State") or "").lower()
+    if state not in ("exited", "stopped"):
+        raise SystemExit(f"{service} must complete and exit, got state={state or 'unknown'}")
+
+    exit_code = row.get("ExitCode")
+    if str(exit_code) != "0":
+        raise SystemExit(f"{service} must exit with code 0, got {exit_code!r}")
+PY
+
+echo "[ai-smoke] verifying backend and worker Ollama runtime wiring..."
+BACKEND_OLLAMA_BASE_URL="$(container_env backend OLLAMA_BASE_URL)"
+WORKER_OLLAMA_BASE_URL="$(container_env backend-worker OLLAMA_BASE_URL)"
+if [[ "${BACKEND_OLLAMA_BASE_URL}" != "${EXPECTED_OLLAMA_BASE_URL}" ]]; then
+  echo "backend OLLAMA_BASE_URL mismatch: expected ${EXPECTED_OLLAMA_BASE_URL}, got ${BACKEND_OLLAMA_BASE_URL}" >&2
+  exit 1
+fi
+if [[ "${WORKER_OLLAMA_BASE_URL}" != "${EXPECTED_OLLAMA_BASE_URL}" ]]; then
+  echo "backend-worker OLLAMA_BASE_URL mismatch: expected ${EXPECTED_OLLAMA_BASE_URL}, got ${WORKER_OLLAMA_BASE_URL}" >&2
+  exit 1
+fi
+
+MATCH_SCORING_MODEL_NAME="$(container_env backend MATCH_SCORING_MODEL_NAME)"
+if [[ -z "${MATCH_SCORING_MODEL_NAME}" ]]; then
+  echo "backend MATCH_SCORING_MODEL_NAME is empty" >&2
+  exit 1
+fi
+
+echo "[ai-smoke] verifying Ollama model bootstrap..."
+OLLAMA_MODELS="$(docker compose exec -T ollama bash -lc 'OLLAMA_HOST=http://127.0.0.1:11434 ollama list')"
+python3 - "${OLLAMA_MODELS}" "${MATCH_SCORING_MODEL_NAME}" <<'PY'
+import sys
+
+models_output = sys.argv[1]
+expected_model = sys.argv[2]
+lines = [line.strip() for line in models_output.splitlines() if line.strip()]
+available_names = {line.split()[0] for line in lines[1:] if line}
+if expected_model not in available_names:
+    raise SystemExit(f"expected Ollama model not found: {expected_model}; available={sorted(available_names)}")
+PY
+
+echo "[ai-smoke] checking backend health endpoint..."
+wait_http "http://localhost:8000/health"
+
+echo "[ai-smoke] authenticating smoke admin..."
+SMOKE_ADMIN_LOGIN="smoke-scoring-admin-$(date +%s)-$RANDOM"
+SMOKE_ADMIN_EMAIL="${SMOKE_ADMIN_LOGIN}@local.test"
+SMOKE_ADMIN_PASSWORD="SmokePassword!123"
+create_smoke_admin "${SMOKE_ADMIN_LOGIN}" "${SMOKE_ADMIN_EMAIL}" "${SMOKE_ADMIN_PASSWORD}"
+
+LOGIN_REQUEST_BODY="$(python3 - "${SMOKE_ADMIN_LOGIN}" "${SMOKE_ADMIN_PASSWORD}" <<'PY'
+import json
+import sys
+
+print(json.dumps({"identifier": sys.argv[1], "password": sys.argv[2]}))
+PY
+)"
+LOGIN_PAYLOAD="$(post_json_with_retry \
+  "http://localhost:8000/api/v1/auth/login" \
+  "${LOGIN_REQUEST_BODY}")"
+ACCESS_TOKEN="$(python3 - "${LOGIN_PAYLOAD}" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+required_keys = {
+    "access_token",
+    "refresh_token",
+    "token_type",
+    "expires_in",
+    "session_id",
+}
+missing = sorted(required_keys - payload.keys())
+if missing:
+    raise SystemExit(f"login response missing keys: {', '.join(missing)}")
+if payload.get("token_type") != "bearer":
+    raise SystemExit(f"unexpected token_type: {payload.get('token_type')}")
+print(payload["access_token"])
+PY
+)"
+
+echo "[ai-smoke] creating vacancy and candidate fixtures..."
+SMOKE_VACANCY_TITLE="Compose AI Smoke Vacancy"
+SMOKE_CANDIDATE_SUFFIX="$(date +%s)-$RANDOM"
+VACANCY_REQUEST_BODY="$(python3 - "${SMOKE_VACANCY_TITLE}" <<'PY'
+import json
+import sys
+
+print(
+    json.dumps(
+        {
+            "title": sys.argv[1],
+            "description": "Operator-facing compose AI smoke vacancy for real scoring verification.",
+            "department": "QA",
+            "status": "open",
+        }
+    )
+)
+PY
+)"
+VACANCY_PAYLOAD="$(post_json_with_auth_retry \
+  "http://localhost:8000/api/v1/vacancies" \
+  "${VACANCY_REQUEST_BODY}" \
+  "${ACCESS_TOKEN}")"
+VACANCY_ID="$(python3 - "${VACANCY_PAYLOAD}" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+required_keys = {"vacancy_id", "title", "status"}
+missing = sorted(required_keys - payload.keys())
+if missing:
+    raise SystemExit(f"vacancy create response missing keys: {', '.join(missing)}")
+if payload.get("status") != "open":
+    raise SystemExit(f"unexpected vacancy status: {payload.get('status')}")
+print(payload["vacancy_id"])
+PY
+)"
+
+CANDIDATE_REQUEST_BODY="$(python3 - "${SMOKE_CANDIDATE_SUFFIX}" <<'PY'
+import json
+import sys
+
+suffix = sys.argv[1]
+print(
+    json.dumps(
+        {
+            "first_name": "AI",
+            "last_name": "Smoke",
+            "email": f"ai-smoke-{suffix}@example.com",
+            "phone": "+375291112233",
+            "location": "Minsk",
+            "current_title": "Backend Engineer",
+            "extra_data": {},
+        }
+    )
+)
+PY
+)"
+CANDIDATE_PAYLOAD="$(post_json_with_auth_retry \
+  "http://localhost:8000/api/v1/candidates" \
+  "${CANDIDATE_REQUEST_BODY}" \
+  "${ACCESS_TOKEN}")"
+CANDIDATE_ID="$(python3 - "${CANDIDATE_PAYLOAD}" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+required_keys = {"candidate_id", "email", "first_name", "last_name"}
+missing = sorted(required_keys - payload.keys())
+if missing:
+    raise SystemExit(f"candidate create response missing keys: {', '.join(missing)}")
+print(payload["candidate_id"])
+PY
+)"
+
+FILE_CHECKSUM="$(python3 - "${FIXTURE_PATH}" <<'PY'
+import hashlib
+import pathlib
+import sys
+
+print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())
+PY
+)"
+UPLOAD_PAYLOAD="$(curl -fsS -X POST \
+  "http://localhost:8000/api/v1/candidates/${CANDIDATE_ID}/cv" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -F "checksum_sha256=${FILE_CHECKSUM}" \
+  -F "file=@${FIXTURE_PATH};type=application/pdf")"
+python3 - "${UPLOAD_PAYLOAD}" "${CANDIDATE_ID}" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+expected_candidate_id = sys.argv[2]
+required_keys = {
+    "document_id",
+    "candidate_id",
+    "filename",
+    "mime_type",
+    "size_bytes",
+    "checksum_sha256",
+    "uploaded_at",
+}
+missing = sorted(required_keys - payload.keys())
+if missing:
+    raise SystemExit(f"CV upload response missing keys: {', '.join(missing)}")
+if payload.get("candidate_id") != expected_candidate_id:
+    raise SystemExit(
+        f"unexpected candidate_id in upload response: {payload.get('candidate_id')}"
+    )
+PY
+
+echo "[ai-smoke] waiting for parsed CV analysis readiness..."
+PARSING_STATUS=""
+for _ in $(seq 1 90); do
+  PARSING_STATUS="$(curl -fsS "http://localhost:8000/api/v1/candidates/${CANDIDATE_ID}/cv/parsing-status" \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}")"
+  status_outcome="$(python3 - "${PARSING_STATUS}" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+status = payload.get("status")
+analysis_ready = payload.get("analysis_ready")
+last_error = payload.get("last_error")
+
+if status == "failed":
+    raise SystemExit(f"failed:{last_error or 'unknown'}")
+if analysis_ready is True:
+    print("ready")
+else:
+    print("waiting")
+PY
+)" || {
+    echo "CV parsing failed: ${PARSING_STATUS}" >&2
+    exit 1
+  }
+  if [[ "${status_outcome}" == "ready" ]]; then
+    break
+  fi
+  sleep 2
+done
+
+python3 - "${PARSING_STATUS}" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+required_keys = {
+    "candidate_id",
+    "document_id",
+    "job_id",
+    "status",
+    "attempt_count",
+    "queued_at",
+    "updated_at",
+    "analysis_ready",
+    "detected_language",
+}
+missing = sorted(required_keys - payload.keys())
+if missing:
+    raise SystemExit(f"parsing status missing keys: {', '.join(missing)}")
+if payload.get("analysis_ready") is not True:
+    raise SystemExit(f"parsed profile did not become ready: {payload}")
+PY
+
+ANALYSIS_PAYLOAD="$(curl -fsS "http://localhost:8000/api/v1/candidates/${CANDIDATE_ID}/cv/analysis" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}")"
+python3 - "${ANALYSIS_PAYLOAD}" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+required_keys = {"candidate_id", "document_id", "detected_language", "parsed_at", "parsed_profile", "evidence"}
+missing = sorted(required_keys - payload.keys())
+if missing:
+    raise SystemExit(f"analysis response missing keys: {', '.join(missing)}")
+if not isinstance(payload.get("parsed_profile"), dict):
+    raise SystemExit("analysis parsed_profile must be an object")
+if not isinstance(payload.get("evidence"), list):
+    raise SystemExit("analysis evidence must be a list")
+PY
+
+echo "[ai-smoke] requesting real match scoring job..."
+SCORING_REQUEST_BODY="$(python3 - "${CANDIDATE_ID}" <<'PY'
+import json
+import sys
+
+print(json.dumps({"candidate_id": sys.argv[1]}))
+PY
+)"
+INITIAL_SCORE_PAYLOAD="$(post_json_with_auth_retry \
+  "http://localhost:8000/api/v1/vacancies/${VACANCY_ID}/match-scores" \
+  "${SCORING_REQUEST_BODY}" \
+  "${ACCESS_TOKEN}")"
+SEEN_STATUSES="$(python3 - "${INITIAL_SCORE_PAYLOAD}" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+status = payload.get("status")
+if status not in {"queued", "running", "succeeded"}:
+    raise SystemExit(f"unexpected initial scoring status: {status}")
+print(status)
+PY
+)"
+
+FINAL_SCORE_PAYLOAD="${INITIAL_SCORE_PAYLOAD}"
+FINAL_SCORE_STATUS="${SEEN_STATUSES}"
+for _ in $(seq 1 120); do
+  FINAL_SCORE_PAYLOAD="$(curl -fsS "http://localhost:8000/api/v1/vacancies/${VACANCY_ID}/match-scores/${CANDIDATE_ID}" \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}")"
+  CURRENT_SCORE_STATUS="$(python3 - "${FINAL_SCORE_PAYLOAD}" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+status = payload.get("status")
+if status not in {"queued", "running", "succeeded", "failed"}:
+    raise SystemExit(f"unexpected scoring status: {status}")
+print(status)
+PY
+)"
+  case "${CURRENT_SCORE_STATUS}" in
+    queued|running)
+      if [[ ",${SEEN_STATUSES}," != *",${CURRENT_SCORE_STATUS},"* ]]; then
+        SEEN_STATUSES="${SEEN_STATUSES},${CURRENT_SCORE_STATUS}"
+      fi
+      sleep 2
+      ;;
+    succeeded)
+      if [[ ",${SEEN_STATUSES}," != *",succeeded,"* ]]; then
+        SEEN_STATUSES="${SEEN_STATUSES},succeeded"
+      fi
+      FINAL_SCORE_STATUS="succeeded"
+      break
+      ;;
+    failed)
+      echo "match scoring failed: ${FINAL_SCORE_PAYLOAD}" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${FINAL_SCORE_STATUS}" != "succeeded" ]]; then
+  echo "match scoring did not reach succeeded state: ${FINAL_SCORE_PAYLOAD}" >&2
+  exit 1
+fi
+
+python3 - "${FINAL_SCORE_PAYLOAD}" "${VACANCY_ID}" "${CANDIDATE_ID}" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+expected_vacancy_id = sys.argv[2]
+expected_candidate_id = sys.argv[3]
+required_keys = {
+    "vacancy_id",
+    "candidate_id",
+    "status",
+    "score",
+    "confidence",
+    "summary",
+    "matched_requirements",
+    "missing_requirements",
+    "evidence",
+    "scored_at",
+    "model_name",
+    "model_version",
+}
+missing = sorted(required_keys - payload.keys())
+if missing:
+    raise SystemExit(f"score response missing keys: {', '.join(missing)}")
+if payload.get("vacancy_id") != expected_vacancy_id:
+    raise SystemExit(f"unexpected vacancy_id: {payload.get('vacancy_id')}")
+if payload.get("candidate_id") != expected_candidate_id:
+    raise SystemExit(f"unexpected candidate_id: {payload.get('candidate_id')}")
+if payload.get("status") != "succeeded":
+    raise SystemExit(f"unexpected final scoring status: {payload.get('status')}")
+if not isinstance(payload.get("matched_requirements"), list):
+    raise SystemExit("matched_requirements must be a list")
+if not isinstance(payload.get("missing_requirements"), list):
+    raise SystemExit("missing_requirements must be a list")
+if not isinstance(payload.get("evidence"), list):
+    raise SystemExit("evidence must be a list")
+PY
+
+echo "[ai-smoke] scoring lifecycle states observed: ${SEEN_STATUSES}"
+echo "[ai-smoke] all ai-local compose scoring checks passed."


### PR DESCRIPTION
## Summary
- deliver `TASK-12-02` on `feature/TASK-12-02-local-ollama-compose`
- keep the default external-host path unchanged with `OLLAMA_BASE_URL=http://host.docker.internal:11434`
- add Linux-safe `host.docker.internal:host-gateway` wiring for `backend` and `backend-worker`
- add optional compose profile `ai-local` with `ollama`, persistent model volume, `/api/tags` healthcheck, and one-shot `ollama-init` bootstrap for `MATCH_SCORING_MODEL_NAME`
- add operator-facing `./scripts/smoke-scoring-compose.sh` for real scoring lifecycle verification without widening mandatory compose/browser smoke
- keep scoring/public route topology and payload contracts unchanged
- keep baseline `docker compose up -d --build` plus `./scripts/smoke-compose.sh` unchanged; the AI verification path remains explicit opt-in via `OLLAMA_BASE_URL=http://ollama:11434 docker compose --profile ai-local up -d --build`

Closes #85

## Verification
- `docker compose config`
- `docker compose --profile ai-local config`
- `apps/backend/.venv/bin/ruff check apps/backend`
- `apps/backend/.venv/bin/pytest -q apps/backend/tests/unit/scoring apps/backend/tests/integration/scoring/test_match_scoring_api.py`
- `./scripts/check-docs-structure.sh`
- `docker compose up -d --build`
- `./scripts/smoke-compose.sh`
- `env OLLAMA_BASE_URL=http://ollama:11434 docker compose --profile ai-local up -d --build`
- `./scripts/smoke-scoring-compose.sh`
