### PR TITLE
TASK-03-04: add recruiter candidate search filters

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -86,6 +86,19 @@
   - `GET /api/v1/candidates/{candidate_id}`
   - `PATCH /api/v1/candidates/{candidate_id}`
   - `GET /api/v1/candidates`
+    - Recruiter list contract is paginated: `items`, `total`, `limit`, `offset`.
+    - Supported optional query params:
+      `limit`, `offset`, `search`, `location`, `current_title`, `skill`,
+      `analysis_ready`, `min_years_experience`, `vacancy_id`, `in_pipeline_only`, `stage`.
+    - `search` performs case-insensitive contains across candidate base fields plus active parsed CV
+      `summary`, `skills`, workplace employer/position, and normalized titles.
+    - `analysis_ready=true` requires an active CV with both `parsed_profile_json` and `parsed_at`.
+      `analysis_ready=false` returns candidates with missing or incomplete parsed analysis.
+    - `vacancy_id` adds `vacancy_stage` from the latest transition for that vacancy.
+      `in_pipeline_only=true` and `stage` are valid only together with `vacancy_id`.
+    - List rows use an additive `CandidateListItemResponse` contract and include:
+      `analysis_ready`, `detected_language`, `parsed_at`, `years_experience`, `skills`,
+      and `vacancy_stage`.
   - `POST /api/v1/candidates/{candidate_id}/cv`
   - `GET /api/v1/candidates/{candidate_id}/cv`
   - `GET /api/v1/candidates/{candidate_id}/cv/parsing-status`

--- a/apps/backend/src/hrm_backend/candidates/dao/candidate_document_dao.py
+++ b/apps/backend/src/hrm_backend/candidates/dao/candidate_document_dao.py
@@ -90,6 +90,39 @@ class CandidateDocumentDAO:
             .first()
         )
 
+    def get_active_documents_by_candidate_ids(
+        self,
+        candidate_ids: list[str],
+    ) -> dict[str, CandidateDocument]:
+        """Batch-load active CV rows for multiple candidates.
+
+        Args:
+            candidate_ids: Candidate identifiers that should be resolved in one query.
+
+        Returns:
+            dict[str, CandidateDocument]: Mapping of `candidate_id -> latest active document`.
+        """
+        if not candidate_ids:
+            return {}
+
+        rows = (
+            self._session.query(CandidateDocument)
+            .filter(
+                CandidateDocument.candidate_id.in_(candidate_ids),
+                CandidateDocument.is_active.is_(True),
+            )
+            .order_by(
+                CandidateDocument.candidate_id.asc(),
+                CandidateDocument.created_at.desc(),
+                CandidateDocument.document_id.desc(),
+            )
+            .all()
+        )
+        documents: dict[str, CandidateDocument] = {}
+        for row in rows:
+            documents.setdefault(row.candidate_id, row)
+        return documents
+
     def get_by_id(self, document_id: str) -> CandidateDocument | None:
         """Fetch candidate document by identifier.
 

--- a/apps/backend/src/hrm_backend/candidates/dependencies/candidates.py
+++ b/apps/backend/src/hrm_backend/candidates/dependencies/candidates.py
@@ -20,6 +20,7 @@ from hrm_backend.candidates.services.candidate_service import CandidateService
 from hrm_backend.candidates.services.cv_parsing_worker_service import CVParsingWorkerService
 from hrm_backend.core.db.session import get_db_session
 from hrm_backend.settings import AppSettings, get_settings
+from hrm_backend.vacancies.infra.postgres import PipelineTransitionDAO
 
 SettingsDependency = Annotated[AppSettings, Depends(get_settings)]
 SessionDependency = Annotated[Session, Depends(get_db_session)]
@@ -91,6 +92,7 @@ def get_candidate_service(
         profile_dao=CandidateProfileDAO(session=session),
         document_dao=CandidateDocumentDAO(session=session),
         parsing_job_dao=CVParsingJobDAO(session=session),
+        transition_dao=PipelineTransitionDAO(session=session),
         storage=storage,
         audit_service=audit_service,
     )

--- a/apps/backend/src/hrm_backend/candidates/routers/v1.py
+++ b/apps/backend/src/hrm_backend/candidates/routers/v1.py
@@ -6,7 +6,7 @@ from io import BytesIO
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
+from fastapi import APIRouter, Depends, File, Form, Query, Request, UploadFile
 from fastapi.responses import StreamingResponse
 
 from hrm_backend.auth.dependencies.auth import get_current_auth_context
@@ -22,6 +22,7 @@ from hrm_backend.candidates.schemas.profile import (
 )
 from hrm_backend.candidates.services.candidate_service import CandidateService
 from hrm_backend.rbac import Role, require_permission
+from hrm_backend.vacancies.schemas.pipeline import PipelineStage
 
 router = APIRouter(prefix="/api/v1/candidates", tags=["candidates"])
 public_router = APIRouter(prefix="/api/v1/public/cv-parsing-jobs", tags=["candidates"])
@@ -34,6 +35,15 @@ CandidateListRole = Annotated[Role, Depends(require_permission("candidate_profil
 CandidateCVUploadRole = Annotated[Role, Depends(require_permission("candidate_cv:upload"))]
 CandidateCVReadRole = Annotated[Role, Depends(require_permission("candidate_cv:read"))]
 CandidateCVStatusRole = Annotated[Role, Depends(require_permission("candidate_cv:parsing_status"))]
+CandidateSearchQuery = Annotated[str | None, Query(min_length=1, max_length=256)]
+CandidateLocationQuery = Annotated[str | None, Query(min_length=1, max_length=256)]
+CandidateCurrentTitleQuery = Annotated[str | None, Query(min_length=1, max_length=256)]
+CandidateSkillQuery = Annotated[str | None, Query(min_length=1, max_length=256)]
+CandidateAnalysisReadyQuery = Annotated[bool | None, Query()]
+CandidateMinYearsExperienceQuery = Annotated[float | None, Query(ge=0)]
+CandidateVacancyQuery = Annotated[UUID | None, Query()]
+CandidateInPipelineOnlyQuery = Annotated[bool, Query()]
+CandidateStageQuery = Annotated[PipelineStage | None, Query()]
 
 
 @router.post("", response_model=CandidateResponse)
@@ -99,9 +109,34 @@ def list_candidate_profiles(
     _: CandidateListRole,
     auth_context: CurrentAuthContext,
     service: CandidateServiceDependency,
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    offset: Annotated[int, Query(ge=0)] = 0,
+    search: CandidateSearchQuery = None,
+    location: CandidateLocationQuery = None,
+    current_title: CandidateCurrentTitleQuery = None,
+    skill: CandidateSkillQuery = None,
+    analysis_ready: CandidateAnalysisReadyQuery = None,
+    min_years_experience: CandidateMinYearsExperienceQuery = None,
+    vacancy_id: CandidateVacancyQuery = None,
+    in_pipeline_only: CandidateInPipelineOnlyQuery = False,
+    stage: CandidateStageQuery = None,
 ) -> CandidateListResponse:
-    """List candidate profiles for authorized role."""
-    return service.list_profiles(auth_context=auth_context, request=request)
+    """List candidate profiles with recruiter-facing search, filter, and pagination."""
+    return service.list_profiles(
+        auth_context=auth_context,
+        request=request,
+        limit=limit,
+        offset=offset,
+        search=search,
+        location=location,
+        current_title=current_title,
+        skill=skill,
+        analysis_ready=analysis_ready,
+        min_years_experience=min_years_experience,
+        vacancy_id=vacancy_id,
+        in_pipeline_only=in_pipeline_only,
+        stage=stage,
+    )
 
 
 @router.post("/{candidate_id}/cv", response_model=CandidateCVUploadResponse)

--- a/apps/backend/src/hrm_backend/candidates/schemas/__init__.py
+++ b/apps/backend/src/hrm_backend/candidates/schemas/__init__.py
@@ -7,6 +7,7 @@ from hrm_backend.candidates.schemas.cv import (
 from hrm_backend.candidates.schemas.parsing import CVAnalysisResponse, CVParsingStatusResponse
 from hrm_backend.candidates.schemas.profile import (
     CandidateCreateRequest,
+    CandidateListItemResponse,
     CandidateListResponse,
     CandidateResponse,
     CandidateUpdateRequest,
@@ -16,6 +17,7 @@ __all__ = [
     "CandidateCreateRequest",
     "CandidateUpdateRequest",
     "CandidateResponse",
+    "CandidateListItemResponse",
     "CandidateListResponse",
     "CandidateCVUploadResponse",
     "CandidateCVDownloadPayload",

--- a/apps/backend/src/hrm_backend/candidates/schemas/profile.py
+++ b/apps/backend/src/hrm_backend/candidates/schemas/profile.py
@@ -8,6 +8,9 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from hrm_backend.candidates.schemas.parsing import DetectedCVLanguage
+from hrm_backend.vacancies.schemas.pipeline import PipelineStage
+
 
 class CandidateCreateRequest(BaseModel):
     """Input payload for candidate profile creation.
@@ -85,7 +88,32 @@ class CandidateResponse(BaseModel):
     updated_at: datetime
 
 
-class CandidateListResponse(BaseModel):
-    """Candidate profile list payload."""
+class CandidateListItemResponse(BaseModel):
+    """Candidate list row enriched with parsed CV and vacancy-context metadata."""
 
-    items: list[CandidateResponse]
+    candidate_id: UUID
+    owner_subject_id: str
+    first_name: str
+    last_name: str
+    email: str
+    phone: str | None
+    location: str | None
+    current_title: str | None
+    extra_data: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+    analysis_ready: bool
+    detected_language: DetectedCVLanguage
+    parsed_at: datetime | None
+    years_experience: float | None
+    skills: list[str] = Field(default_factory=list)
+    vacancy_stage: PipelineStage | None
+
+
+class CandidateListResponse(BaseModel):
+    """Paginated candidate profile list payload."""
+
+    items: list[CandidateListItemResponse]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)

--- a/apps/backend/src/hrm_backend/candidates/services/candidate_search.py
+++ b/apps/backend/src/hrm_backend/candidates/services/candidate_search.py
@@ -1,0 +1,431 @@
+"""Pure helpers for recruiter-facing candidate search, filtering, and list projections."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import HTTPException, status
+
+from hrm_backend.candidates.models.document import CandidateDocument
+from hrm_backend.candidates.models.profile import CandidateProfile
+from hrm_backend.candidates.schemas.parsing import DetectedCVLanguage
+from hrm_backend.candidates.schemas.profile import CandidateListItemResponse
+from hrm_backend.vacancies.schemas.pipeline import PipelineStage
+
+
+@dataclass(frozen=True)
+class CandidateListFilters:
+    """Normalized recruiter-facing candidate list filters.
+
+    Attributes:
+        limit: Maximum number of returned rows.
+        offset: Number of rows skipped after sorting.
+        search: Free-text search query across candidate and parsed CV fields.
+        location: Optional case-insensitive location filter.
+        current_title: Optional case-insensitive current-title filter.
+        skill: Optional case-insensitive skill filter.
+        analysis_ready: Optional parsed-analysis readiness filter.
+        min_years_experience: Optional minimum total experience threshold.
+        vacancy_id: Optional vacancy context used for latest-stage enrichment.
+        in_pipeline_only: Whether to keep only candidates that already have vacancy history.
+        stage: Optional latest vacancy stage filter.
+    """
+
+    limit: int
+    offset: int
+    search: str | None = None
+    location: str | None = None
+    current_title: str | None = None
+    skill: str | None = None
+    analysis_ready: bool | None = None
+    min_years_experience: float | None = None
+    vacancy_id: UUID | None = None
+    in_pipeline_only: bool = False
+    stage: PipelineStage | None = None
+
+
+@dataclass(frozen=True)
+class CandidateListProjection:
+    """Candidate row enriched with active-CV and vacancy-context fields.
+
+    Attributes:
+        profile: Candidate profile entity.
+        parsed_profile: Parsed active CV payload when analysis is ready.
+        analysis_ready: Whether parsed CV analysis is available for the active document.
+        detected_language: Normalized active-document language marker.
+        parsed_at: Active-document parsed timestamp when available.
+        years_experience: Total parsed experience in years.
+        skills: Parsed normalized skills from the active CV.
+        vacancy_stage: Latest stage for the requested vacancy, if any.
+    """
+
+    profile: CandidateProfile
+    parsed_profile: dict[str, object] | None
+    analysis_ready: bool
+    detected_language: DetectedCVLanguage
+    parsed_at: datetime | None
+    years_experience: float | None
+    skills: tuple[str, ...]
+    vacancy_stage: PipelineStage | None
+
+
+def normalize_candidate_search_value(value: str | None) -> str | None:
+    """Normalize one user-provided search/filter fragment for case-insensitive matching.
+
+    Args:
+        value: Raw user-provided query fragment.
+
+    Returns:
+        str | None: Collapsed, case-folded value or `None` for blank input.
+    """
+    if value is None:
+        return None
+    normalized = " ".join(value.split()).casefold()
+    return normalized or None
+
+
+def validate_candidate_list_filters(filters: CandidateListFilters) -> None:
+    """Validate cross-field candidate list filter semantics.
+
+    Args:
+        filters: Candidate list filter payload.
+
+    Raises:
+        HTTPException: If vacancy-scoped filters are used without `vacancy_id`.
+    """
+    if filters.stage is not None and filters.vacancy_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="stage_requires_vacancy_id",
+        )
+    if filters.in_pipeline_only and filters.vacancy_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="in_pipeline_only_requires_vacancy_id",
+        )
+
+
+def build_candidate_list_projection(
+    *,
+    profile: CandidateProfile,
+    active_document: CandidateDocument | None,
+    vacancy_stage: PipelineStage | None,
+) -> CandidateListProjection:
+    """Build one candidate list projection from profile, active document, and vacancy context.
+
+    Args:
+        profile: Candidate profile row.
+        active_document: Active candidate CV row, if any.
+        vacancy_stage: Latest vacancy stage for the current list context, if any.
+
+    Returns:
+        CandidateListProjection: Enriched candidate list projection for filtering
+            and response mapping.
+    """
+    analysis_ready = bool(
+        active_document is not None
+        and active_document.parsed_profile_json is not None
+        and active_document.parsed_at is not None
+    )
+    parsed_profile = (
+        active_document.parsed_profile_json
+        if analysis_ready and isinstance(active_document.parsed_profile_json, dict)
+        else None
+    )
+    return CandidateListProjection(
+        profile=profile,
+        parsed_profile=parsed_profile,
+        analysis_ready=analysis_ready,
+        detected_language=_normalize_detected_language(
+            None if active_document is None else active_document.detected_language
+        ),
+        parsed_at=None if active_document is None else active_document.parsed_at,
+        years_experience=_extract_years_experience(parsed_profile),
+        skills=_extract_skills(parsed_profile),
+        vacancy_stage=vacancy_stage,
+    )
+
+
+def matches_candidate_filters(
+    projection: CandidateListProjection,
+    filters: CandidateListFilters,
+) -> bool:
+    """Return whether one enriched candidate row satisfies all requested filters.
+
+    Args:
+        projection: Enriched candidate row.
+        filters: Requested candidate list filters.
+
+    Returns:
+        bool: `True` when the row matches all filters.
+    """
+    if filters.analysis_ready is not None and projection.analysis_ready != filters.analysis_ready:
+        return False
+
+    if filters.min_years_experience is not None:
+        if (
+            projection.years_experience is None
+            or projection.years_experience < filters.min_years_experience
+        ):
+            return False
+
+    if filters.in_pipeline_only and projection.vacancy_stage is None:
+        return False
+
+    if filters.stage is not None and projection.vacancy_stage != filters.stage:
+        return False
+
+    location_filter = normalize_candidate_search_value(filters.location)
+    if location_filter is not None and not _value_matches_filter(
+        projection.profile.location,
+        location_filter,
+    ):
+        return False
+
+    current_title_filter = normalize_candidate_search_value(filters.current_title)
+    if current_title_filter is not None and not any(
+        current_title_filter in candidate_value
+        for candidate_value in _current_title_values(projection)
+    ):
+        return False
+
+    skill_filter = normalize_candidate_search_value(filters.skill)
+    if skill_filter is not None and not any(
+        skill_filter in skill_value for skill_value in projection.skills
+    ):
+        return False
+
+    search_filter = normalize_candidate_search_value(filters.search)
+    if search_filter is not None and not any(
+        search_filter in candidate_value for candidate_value in _search_values(projection)
+    ):
+        return False
+
+    return True
+
+
+def sort_candidate_projections(
+    projections: list[CandidateListProjection],
+) -> list[CandidateListProjection]:
+    """Sort candidate list projections by `updated_at desc, candidate_id asc`.
+
+    Args:
+        projections: Candidate projections to order.
+
+    Returns:
+        list[CandidateListProjection]: Ordered projections.
+    """
+    ordered_by_id = sorted(projections, key=lambda item: item.profile.candidate_id)
+    return sorted(
+        ordered_by_id,
+        key=lambda item: item.profile.updated_at,
+        reverse=True,
+    )
+
+
+def to_candidate_list_item_response(
+    projection: CandidateListProjection,
+) -> CandidateListItemResponse:
+    """Map one enriched candidate projection to the public list response schema.
+
+    Args:
+        projection: Enriched candidate projection.
+
+    Returns:
+        CandidateListItemResponse: API response payload for one list row.
+    """
+    return CandidateListItemResponse(
+        candidate_id=UUID(projection.profile.candidate_id),
+        owner_subject_id=projection.profile.owner_subject_id,
+        first_name=projection.profile.first_name,
+        last_name=projection.profile.last_name,
+        email=projection.profile.email,
+        phone=projection.profile.phone,
+        location=projection.profile.location,
+        current_title=projection.profile.current_title,
+        extra_data=projection.profile.extra_data,
+        created_at=projection.profile.created_at,
+        updated_at=projection.profile.updated_at,
+        analysis_ready=projection.analysis_ready,
+        detected_language=projection.detected_language,
+        parsed_at=projection.parsed_at,
+        years_experience=projection.years_experience,
+        skills=list(projection.skills),
+        vacancy_stage=projection.vacancy_stage,
+    )
+
+
+def _normalize_detected_language(raw_value: str | None) -> DetectedCVLanguage:
+    """Normalize stored language markers to the supported API enum values."""
+    if raw_value is None:
+        return "unknown"
+    normalized = raw_value.strip().lower()
+    if normalized in {"ru", "en", "mixed", "unknown"}:
+        return normalized
+    return "unknown"
+
+
+def _value_matches_filter(candidate_value: str | None, normalized_filter: str) -> bool:
+    """Return whether one scalar candidate field matches a normalized filter fragment."""
+    normalized_candidate = normalize_candidate_search_value(candidate_value)
+    return normalized_candidate is not None and normalized_filter in normalized_candidate
+
+
+def _search_values(projection: CandidateListProjection) -> tuple[str, ...]:
+    """Collect all searchable normalized strings for one candidate projection."""
+    values: list[str] = []
+    values.extend(
+        value
+        for value in (
+            normalize_candidate_search_value(projection.profile.first_name),
+            normalize_candidate_search_value(projection.profile.last_name),
+            normalize_candidate_search_value(projection.profile.email),
+            normalize_candidate_search_value(projection.profile.phone),
+            normalize_candidate_search_value(projection.profile.location),
+            normalize_candidate_search_value(projection.profile.current_title),
+        )
+        if value is not None
+    )
+    values.extend(_parsed_profile_search_values(projection.parsed_profile))
+    return tuple(values)
+
+
+def _current_title_values(projection: CandidateListProjection) -> tuple[str, ...]:
+    """Collect candidate current-title values from profile and parsed active CV."""
+    values: list[str] = []
+    base_value = normalize_candidate_search_value(projection.profile.current_title)
+    if base_value is not None:
+        values.append(base_value)
+
+    titles = (
+        projection.parsed_profile.get("titles")
+        if isinstance(projection.parsed_profile, dict)
+        else None
+    )
+    if not isinstance(titles, dict):
+        return tuple(values)
+
+    current = titles.get("current")
+    if not isinstance(current, dict):
+        return tuple(values)
+
+    for field_name in ("raw", "normalized"):
+        normalized = normalize_candidate_search_value(_safe_string(current.get(field_name)))
+        if normalized is not None:
+            values.append(normalized)
+    return tuple(values)
+
+
+def _parsed_profile_search_values(parsed_profile: dict[str, object] | None) -> tuple[str, ...]:
+    """Collect searchable parsed-profile strings required by the list contract."""
+    if not isinstance(parsed_profile, dict):
+        return ()
+
+    values: list[str] = []
+    summary = normalize_candidate_search_value(_safe_string(parsed_profile.get("summary")))
+    if summary is not None:
+        values.append(summary)
+
+    values.extend(_extract_skills(parsed_profile))
+    values.extend(_workplace_search_values(parsed_profile))
+    values.extend(_title_search_values(parsed_profile))
+    return tuple(values)
+
+
+def _workplace_search_values(parsed_profile: dict[str, object]) -> tuple[str, ...]:
+    """Collect searchable employer and position values from parsed workplaces."""
+    workplaces = parsed_profile.get("workplaces")
+    if not isinstance(workplaces, dict):
+        return ()
+
+    entries = workplaces.get("entries")
+    if not isinstance(entries, list):
+        return ()
+
+    values: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        employer = normalize_candidate_search_value(_safe_string(entry.get("employer")))
+        if employer is not None:
+            values.append(employer)
+
+        position = entry.get("position")
+        if isinstance(position, dict):
+            for field_name in ("raw", "normalized"):
+                normalized = normalize_candidate_search_value(
+                    _safe_string(position.get(field_name))
+                )
+                if normalized is not None:
+                    values.append(normalized)
+    return tuple(values)
+
+
+def _title_search_values(parsed_profile: dict[str, object]) -> tuple[str, ...]:
+    """Collect searchable normalized title values from parsed titles."""
+    titles = parsed_profile.get("titles")
+    if not isinstance(titles, dict):
+        return ()
+
+    values: list[str] = []
+    current = titles.get("current")
+    if isinstance(current, dict):
+        for field_name in ("raw", "normalized"):
+            normalized = normalize_candidate_search_value(_safe_string(current.get(field_name)))
+            if normalized is not None:
+                values.append(normalized)
+
+    past = titles.get("past")
+    if isinstance(past, list):
+        for item in past:
+            if not isinstance(item, dict):
+                continue
+            for field_name in ("raw", "normalized"):
+                normalized = normalize_candidate_search_value(_safe_string(item.get(field_name)))
+                if normalized is not None:
+                    values.append(normalized)
+    return tuple(values)
+
+
+def _extract_skills(parsed_profile: dict[str, object] | None) -> tuple[str, ...]:
+    """Extract normalized parsed skills for matching and list responses."""
+    if not isinstance(parsed_profile, dict):
+        return ()
+    raw_skills = parsed_profile.get("skills")
+    if not isinstance(raw_skills, list):
+        return ()
+
+    skills: list[str] = []
+    for item in raw_skills:
+        normalized = normalize_candidate_search_value(_safe_string(item))
+        if normalized is not None:
+            skills.append(normalized)
+    return tuple(skills)
+
+
+def _extract_years_experience(parsed_profile: dict[str, object] | None) -> float | None:
+    """Extract parsed total years of experience from the active CV payload."""
+    if not isinstance(parsed_profile, dict):
+        return None
+    experience = parsed_profile.get("experience")
+    if not isinstance(experience, dict):
+        return None
+
+    years_total = experience.get("years_total")
+    if isinstance(years_total, bool):
+        return None
+    if isinstance(years_total, (int, float)):
+        return float(years_total)
+    if isinstance(years_total, str):
+        try:
+            return float(years_total.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _safe_string(value: object) -> str | None:
+    """Return a string value when the raw object already contains text."""
+    return value if isinstance(value, str) else None

--- a/apps/backend/src/hrm_backend/candidates/services/candidate_service.py
+++ b/apps/backend/src/hrm_backend/candidates/services/candidate_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import cast
 from uuid import UUID, uuid4
 
 from fastapi import HTTPException, Request, UploadFile, status
@@ -29,8 +30,18 @@ from hrm_backend.candidates.schemas.profile import (
     CandidateResponse,
     CandidateUpdateRequest,
 )
+from hrm_backend.candidates.services.candidate_search import (
+    CandidateListFilters,
+    build_candidate_list_projection,
+    matches_candidate_filters,
+    sort_candidate_projections,
+    to_candidate_list_item_response,
+    validate_candidate_list_filters,
+)
 from hrm_backend.candidates.utils.cv import validate_cv_payload
 from hrm_backend.settings import AppSettings
+from hrm_backend.vacancies.dao.pipeline_transition_dao import PipelineTransitionDAO
+from hrm_backend.vacancies.schemas.pipeline import PipelineStage
 
 
 @dataclass(frozen=True)
@@ -51,6 +62,7 @@ class CandidateService:
         profile_dao: CandidateProfileDAO,
         document_dao: CandidateDocumentDAO,
         parsing_job_dao: CVParsingJobDAO,
+        transition_dao: PipelineTransitionDAO,
         storage: CandidateStorage,
         audit_service: AuditService,
     ) -> None:
@@ -61,6 +73,7 @@ class CandidateService:
             profile_dao: Candidate profile DAO.
             document_dao: Candidate document DAO.
             parsing_job_dao: CV parsing job DAO.
+            transition_dao: Pipeline transition DAO used for vacancy-context enrichment.
             storage: Object storage adapter.
             audit_service: Audit service for success/failure traces.
         """
@@ -68,6 +81,7 @@ class CandidateService:
         self._profile_dao = profile_dao
         self._document_dao = document_dao
         self._parsing_job_dao = parsing_job_dao
+        self._transition_dao = transition_dao
         self._storage = storage
         self._audit_service = audit_service
 
@@ -146,18 +160,96 @@ class CandidateService:
         *,
         auth_context: AuthContext,
         request: Request,
+        limit: int = 20,
+        offset: int = 0,
+        search: str | None = None,
+        location: str | None = None,
+        current_title: str | None = None,
+        skill: str | None = None,
+        analysis_ready: bool | None = None,
+        min_years_experience: float | None = None,
+        vacancy_id: UUID | None = None,
+        in_pipeline_only: bool = False,
+        stage: PipelineStage | None = None,
     ) -> CandidateListResponse:
-        """List candidate profiles for authorized actors.
+        """List candidate profiles for authorized actors with recruiter-facing filters.
 
         Args:
             auth_context: Authenticated actor context.
             request: HTTP request context.
+            limit: Maximum number of returned rows.
+            offset: Number of skipped rows after sorting.
+            search: Optional free-text search query.
+            location: Optional location filter.
+            current_title: Optional current-title filter.
+            skill: Optional parsed-skill filter.
+            analysis_ready: Optional parsed-analysis readiness filter.
+            min_years_experience: Optional minimum total years of experience.
+            vacancy_id: Optional vacancy context for latest pipeline stage enrichment.
+            in_pipeline_only: Optional vacancy-scoped pipeline-presence filter.
+            stage: Optional vacancy-scoped latest-stage filter.
 
         Returns:
             CandidateListResponse: Candidate list payload.
         """
-        items = [_to_candidate_response(item) for item in self._profile_dao.list_profiles()]
         actor_sub, actor_role = actor_from_auth_context(auth_context)
+        filters = CandidateListFilters(
+            limit=limit,
+            offset=offset,
+            search=search,
+            location=location,
+            current_title=current_title,
+            skill=skill,
+            analysis_ready=analysis_ready,
+            min_years_experience=min_years_experience,
+            vacancy_id=vacancy_id,
+            in_pipeline_only=in_pipeline_only,
+            stage=stage,
+        )
+
+        try:
+            validate_candidate_list_filters(filters)
+            profiles = self._profile_dao.list_profiles()
+            candidate_ids = [item.candidate_id for item in profiles]
+            active_documents = self._document_dao.get_active_documents_by_candidate_ids(
+                candidate_ids,
+            )
+            vacancy_stages: dict[str, PipelineStage] = {}
+            if vacancy_id is not None:
+                latest_transitions = self._transition_dao.get_latest_transitions_by_vacancy(
+                    vacancy_id=str(vacancy_id),
+                    candidate_ids=candidate_ids,
+                )
+                vacancy_stages = {
+                    candidate_id: cast(PipelineStage, transition.to_stage)
+                    for candidate_id, transition in latest_transitions.items()
+                }
+            matched_items = sort_candidate_projections(
+                [
+                    projection
+                    for projection in [
+                        build_candidate_list_projection(
+                            profile=profile,
+                            active_document=active_documents.get(profile.candidate_id),
+                            vacancy_stage=vacancy_stages.get(profile.candidate_id),
+                        )
+                        for profile in profiles
+                    ]
+                    if matches_candidate_filters(projection, filters)
+                ]
+            )
+        except HTTPException as exc:
+            self._audit_service.record_api_event(
+                action="candidate_profile:list",
+                resource_type="candidate_profile",
+                result="failure",
+                request=request,
+                actor_sub=actor_sub,
+                actor_role=actor_role,
+                reason=str(exc.detail),
+            )
+            raise
+
         self._audit_service.record_api_event(
             action="candidate_profile:list",
             resource_type="candidate_profile",
@@ -166,7 +258,13 @@ class CandidateService:
             actor_sub=actor_sub,
             actor_role=actor_role,
         )
-        return CandidateListResponse(items=items)
+        page = matched_items[filters.offset : filters.offset + filters.limit]
+        return CandidateListResponse(
+            items=[to_candidate_list_item_response(item) for item in page],
+            total=len(matched_items),
+            limit=filters.limit,
+            offset=filters.offset,
+        )
 
     def update_profile(
         self,

--- a/apps/backend/src/hrm_backend/vacancies/dao/pipeline_transition_dao.py
+++ b/apps/backend/src/hrm_backend/vacancies/dao/pipeline_transition_dao.py
@@ -120,3 +120,39 @@ class PipelineTransitionDAO:
             )
             .all()
         )
+
+    def get_latest_transitions_by_vacancy(
+        self,
+        *,
+        vacancy_id: str,
+        candidate_ids: list[str],
+    ) -> dict[str, PipelineTransition]:
+        """Batch-load latest vacancy transitions for multiple candidates.
+
+        Args:
+            vacancy_id: Vacancy identifier that scopes the lookup.
+            candidate_ids: Candidate identifiers resolved in one query.
+
+        Returns:
+            dict[str, PipelineTransition]: Mapping of `candidate_id -> latest transition`.
+        """
+        if not candidate_ids:
+            return {}
+
+        rows = (
+            self._session.query(PipelineTransition)
+            .filter(
+                PipelineTransition.vacancy_id == vacancy_id,
+                PipelineTransition.candidate_id.in_(candidate_ids),
+            )
+            .order_by(
+                PipelineTransition.candidate_id.asc(),
+                PipelineTransition.transitioned_at.desc(),
+                PipelineTransition.transition_id.desc(),
+            )
+            .all()
+        )
+        transitions: dict[str, PipelineTransition] = {}
+        for row in rows:
+            transitions.setdefault(row.candidate_id, row)
+        return transitions

--- a/apps/backend/tests/integration/candidates/test_candidate_api.py
+++ b/apps/backend/tests/integration/candidates/test_candidate_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+from datetime import UTC, datetime
 from pathlib import Path
 from uuid import NAMESPACE_URL, uuid4, uuid5
 
@@ -15,9 +16,12 @@ from hrm_backend.audit.models.event import AuditEvent
 from hrm_backend.auth.dependencies.auth import get_current_auth_context
 from hrm_backend.auth.schemas.token_claims import AuthContext
 from hrm_backend.candidates.dependencies.candidates import get_candidate_storage
+from hrm_backend.candidates.models.document import CandidateDocument
+from hrm_backend.candidates.models.profile import CandidateProfile
 from hrm_backend.core.models.base import Base
 from hrm_backend.main import app
 from hrm_backend.settings import AppSettings, get_settings
+from hrm_backend.vacancies.models.pipeline_transition import PipelineTransition
 
 pytestmark = pytest.mark.anyio
 
@@ -107,6 +111,90 @@ def _load_events(database_url: str) -> list[AuditEvent]:
         engine.dispose()
 
 
+def _set_candidate_updated_at(
+    database_url: str,
+    *,
+    candidate_id: str,
+    updated_at: datetime,
+) -> None:
+    """Force deterministic candidate ordering for pagination assertions."""
+    engine = create_engine(database_url, future=True)
+    try:
+        with Session(engine) as session:
+            profile = session.get(CandidateProfile, candidate_id)
+            assert profile is not None
+            profile.updated_at = updated_at
+            session.add(profile)
+            session.commit()
+    finally:
+        engine.dispose()
+
+
+def _seed_candidate_document(
+    database_url: str,
+    *,
+    candidate_id: str,
+    parsed_profile_json: dict[str, object] | None,
+    detected_language: str = "en",
+    parsed_at: datetime | None = None,
+) -> None:
+    """Seed one active candidate document row for list API filtering tests."""
+    engine = create_engine(database_url, future=True)
+    try:
+        with Session(engine) as session:
+            session.add(
+                CandidateDocument(
+                    document_id=str(uuid4()),
+                    candidate_id=candidate_id,
+                    object_key=f"candidates/{candidate_id}/cv/{uuid4()}.pdf",
+                    filename="cv.pdf",
+                    mime_type="application/pdf",
+                    size_bytes=128,
+                    checksum_sha256=hashlib.sha256(candidate_id.encode("utf-8")).hexdigest(),
+                    is_active=True,
+                    parsed_profile_json=parsed_profile_json,
+                    evidence_json=None,
+                    detected_language=detected_language,
+                    parsed_at=parsed_at,
+                    created_at=parsed_at or datetime(2026, 3, 12, 9, 0, tzinfo=UTC),
+                )
+            )
+            session.commit()
+    finally:
+        engine.dispose()
+
+
+def _seed_pipeline_transition(
+    database_url: str,
+    *,
+    vacancy_id: str,
+    candidate_id: str,
+    from_stage: str | None,
+    to_stage: str,
+    transitioned_at: datetime,
+) -> None:
+    """Seed one append-only vacancy transition row for candidate list context tests."""
+    engine = create_engine(database_url, future=True)
+    try:
+        with Session(engine) as session:
+            session.add(
+                PipelineTransition(
+                    transition_id=str(uuid4()),
+                    vacancy_id=vacancy_id,
+                    candidate_id=candidate_id,
+                    from_stage=from_stage,
+                    to_stage=to_stage,
+                    reason="seeded-for-list-tests",
+                    changed_by_sub="hr",
+                    changed_by_role="hr",
+                    transitioned_at=transitioned_at,
+                )
+            )
+            session.commit()
+    finally:
+        engine.dispose()
+
+
 @pytest.fixture()
 async def api_client(configured_app) -> AsyncClient:
     """Provide async API client for candidate integration tests."""
@@ -177,6 +265,9 @@ async def test_candidate_crud_and_ownership_deny_are_enforced(
     list_response = await api_client.get("/api/v1/candidates")
     assert list_response.status_code == 200
     assert len(list_response.json()["items"]) == 1
+    assert list_response.json()["total"] == 1
+    assert list_response.json()["limit"] == 20
+    assert list_response.json()["offset"] == 0
 
     events = _load_events(database_url)
     permission_denials = [
@@ -294,3 +385,295 @@ async def test_candidate_uuid_boundaries_reject_invalid_ids(
 
     analysis_response = await api_client.get(f"/api/v1/candidates/{invalid_id}/cv/analysis")
     assert analysis_response.status_code == 422
+
+
+async def test_candidate_list_supports_search_filters_and_pagination(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
+    """Verify recruiter-facing candidate list filtering, enrichment, and pagination contract."""
+    _, _, _, database_url = configured_app
+
+    alpha_response = await api_client.post(
+        "/api/v1/candidates",
+        json={
+            "first_name": "Alice",
+            "last_name": "Miller",
+            "email": "alice@example.com",
+            "location": "Minsk",
+            "current_title": "Backend Recruiter",
+            "extra_data": {},
+        },
+    )
+    beta_response = await api_client.post(
+        "/api/v1/candidates",
+        json={
+            "first_name": "Boris",
+            "last_name": "Stone",
+            "email": "boris@example.com",
+            "location": "Minsk",
+            "current_title": "Backend Recruiter",
+            "extra_data": {},
+        },
+    )
+    gamma_response = await api_client.post(
+        "/api/v1/candidates",
+        json={
+            "first_name": "Carla",
+            "last_name": "West",
+            "email": "carla@example.com",
+            "location": "Warsaw",
+            "current_title": "Designer",
+            "extra_data": {},
+        },
+    )
+    alpha_id = alpha_response.json()["candidate_id"]
+    beta_id = beta_response.json()["candidate_id"]
+    gamma_id = gamma_response.json()["candidate_id"]
+
+    _seed_candidate_document(
+        database_url,
+        candidate_id=alpha_id,
+        parsed_profile_json={
+            "summary": "Leads Acme Logistics recruiting and warehouse staffing operations.",
+            "skills": ["python", "talent_sourcing"],
+            "experience": {"years_total": 6},
+            "workplaces": {
+                "entries": [
+                    {
+                        "employer": "Acme Logistics",
+                        "position": {
+                            "raw": "Warehouse Supervisor",
+                            "normalized": "warehouse supervisor",
+                        },
+                    }
+                ]
+            },
+            "titles": {
+                "current": {
+                    "raw": "Backend Recruiter",
+                    "normalized": "backend recruiter",
+                },
+                "past": [],
+            },
+        },
+        detected_language="en",
+        parsed_at=datetime(2026, 3, 12, 8, 30, tzinfo=UTC),
+    )
+    _seed_candidate_document(
+        database_url,
+        candidate_id=beta_id,
+        parsed_profile_json={
+            "summary": "Supports office hiring operations.",
+            "skills": ["python"],
+            "experience": {"years_total": 2},
+            "workplaces": {
+                "entries": [
+                    {
+                        "employer": "People Ops",
+                        "position": {
+                            "raw": "Recruiter",
+                            "normalized": "recruiter",
+                        },
+                    }
+                ]
+            },
+            "titles": {
+                "current": {"raw": "Backend Recruiter", "normalized": "backend recruiter"},
+                "past": [],
+            },
+        },
+        detected_language="en",
+        parsed_at=datetime(2026, 3, 12, 8, 0, tzinfo=UTC),
+    )
+    _seed_candidate_document(
+        database_url,
+        candidate_id=gamma_id,
+        parsed_profile_json=None,
+        detected_language="unknown",
+        parsed_at=None,
+    )
+
+    _set_candidate_updated_at(
+        database_url,
+        candidate_id=alpha_id,
+        updated_at=datetime(2026, 3, 12, 13, 0, tzinfo=UTC),
+    )
+    _set_candidate_updated_at(
+        database_url,
+        candidate_id=beta_id,
+        updated_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+    )
+    _set_candidate_updated_at(
+        database_url,
+        candidate_id=gamma_id,
+        updated_at=datetime(2026, 3, 12, 11, 0, tzinfo=UTC),
+    )
+
+    filtered_response = await api_client.get(
+        "/api/v1/candidates",
+        params={
+            "search": "acme logistics",
+            "location": "minsk",
+            "current_title": "backend recruit",
+            "skill": "python",
+            "analysis_ready": "true",
+            "min_years_experience": "5",
+            "limit": "20",
+            "offset": "0",
+        },
+    )
+    assert filtered_response.status_code == 200
+    filtered_payload = filtered_response.json()
+    assert filtered_payload["total"] == 1
+    assert filtered_payload["limit"] == 20
+    assert filtered_payload["offset"] == 0
+    assert [item["candidate_id"] for item in filtered_payload["items"]] == [alpha_id]
+    assert filtered_payload["items"][0]["analysis_ready"] is True
+    assert filtered_payload["items"][0]["detected_language"] == "en"
+    assert filtered_payload["items"][0]["years_experience"] == 6
+    assert filtered_payload["items"][0]["skills"] == ["python", "talent_sourcing"]
+    assert filtered_payload["items"][0]["vacancy_stage"] is None
+    assert filtered_payload["items"][0]["parsed_at"].startswith("2026-03-12T08:30:00")
+
+    pagination_response = await api_client.get(
+        "/api/v1/candidates",
+        params={"limit": "1", "offset": "1"},
+    )
+    assert pagination_response.status_code == 200
+    pagination_payload = pagination_response.json()
+    assert pagination_payload["total"] == 3
+    assert pagination_payload["limit"] == 1
+    assert pagination_payload["offset"] == 1
+    assert [item["candidate_id"] for item in pagination_payload["items"]] == [beta_id]
+
+
+async def test_candidate_list_supports_vacancy_context_stage_filters_and_pipeline_only(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
+    """Verify candidate list resolves latest vacancy stages and vacancy-scoped filters."""
+    _, _, _, database_url = configured_app
+
+    vacancy_response = await api_client.post(
+        "/api/v1/vacancies",
+        json={
+            "title": "Recruiter",
+            "description": "Own candidate screening and pipeline operations.",
+            "department": "HR",
+            "status": "open",
+        },
+    )
+    assert vacancy_response.status_code == 200
+    vacancy_id = vacancy_response.json()["vacancy_id"]
+
+    alpha_id = (
+        await api_client.post(
+            "/api/v1/candidates",
+            json={
+                "first_name": "Alice",
+                "last_name": "Stage",
+                "email": "alice.stage@example.com",
+                "extra_data": {},
+            },
+        )
+    ).json()["candidate_id"]
+    beta_id = (
+        await api_client.post(
+            "/api/v1/candidates",
+            json={
+                "first_name": "Boris",
+                "last_name": "Stage",
+                "email": "boris.stage@example.com",
+                "extra_data": {},
+            },
+        )
+    ).json()["candidate_id"]
+    gamma_id = (
+        await api_client.post(
+            "/api/v1/candidates",
+            json={
+                "first_name": "Carla",
+                "last_name": "Stage",
+                "email": "carla.stage@example.com",
+                "extra_data": {},
+            },
+        )
+    ).json()["candidate_id"]
+
+    _seed_pipeline_transition(
+        database_url,
+        vacancy_id=vacancy_id,
+        candidate_id=alpha_id,
+        from_stage=None,
+        to_stage="applied",
+        transitioned_at=datetime(2026, 3, 12, 8, 0, tzinfo=UTC),
+    )
+    _seed_pipeline_transition(
+        database_url,
+        vacancy_id=vacancy_id,
+        candidate_id=alpha_id,
+        from_stage="applied",
+        to_stage="shortlist",
+        transitioned_at=datetime(2026, 3, 12, 9, 0, tzinfo=UTC),
+    )
+    _seed_pipeline_transition(
+        database_url,
+        vacancy_id=vacancy_id,
+        candidate_id=beta_id,
+        from_stage=None,
+        to_stage="screening",
+        transitioned_at=datetime(2026, 3, 12, 8, 30, tzinfo=UTC),
+    )
+
+    context_response = await api_client.get(
+        "/api/v1/candidates",
+        params={"vacancy_id": vacancy_id},
+    )
+    assert context_response.status_code == 200
+    context_payload = context_response.json()
+    context_items = {
+        item["candidate_id"]: item["vacancy_stage"]
+        for item in context_payload["items"]
+    }
+    assert context_items[alpha_id] == "shortlist"
+    assert context_items[beta_id] == "screening"
+    assert context_items[gamma_id] is None
+
+    pipeline_only_response = await api_client.get(
+        "/api/v1/candidates",
+        params={"vacancy_id": vacancy_id, "in_pipeline_only": "true"},
+    )
+    assert pipeline_only_response.status_code == 200
+    assert {
+        item["candidate_id"] for item in pipeline_only_response.json()["items"]
+    } == {alpha_id, beta_id}
+
+    shortlist_response = await api_client.get(
+        "/api/v1/candidates",
+        params={"vacancy_id": vacancy_id, "stage": "shortlist"},
+    )
+    assert shortlist_response.status_code == 200
+    shortlist_payload = shortlist_response.json()
+    assert shortlist_payload["total"] == 1
+    assert [item["candidate_id"] for item in shortlist_payload["items"]] == [alpha_id]
+    assert shortlist_payload["items"][0]["vacancy_stage"] == "shortlist"
+
+
+async def test_candidate_list_rejects_vacancy_stage_filters_without_vacancy_context(
+    api_client: AsyncClient,
+) -> None:
+    """Verify vacancy-scoped stage filters return `422` without `vacancy_id`."""
+    stage_response = await api_client.get(
+        "/api/v1/candidates",
+        params={"stage": "screening"},
+    )
+    assert stage_response.status_code == 422
+    assert stage_response.json()["detail"] == "stage_requires_vacancy_id"
+
+    in_pipeline_response = await api_client.get(
+        "/api/v1/candidates",
+        params={"in_pipeline_only": "true"},
+    )
+    assert in_pipeline_response.status_code == 422
+    assert in_pipeline_response.json()["detail"] == "in_pipeline_only_requires_vacancy_id"

--- a/apps/backend/tests/unit/candidates/test_candidate_search.py
+++ b/apps/backend/tests/unit/candidates/test_candidate_search.py
@@ -1,0 +1,212 @@
+"""Unit tests for recruiter-facing candidate list search and filter helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from hrm_backend.candidates.models.document import CandidateDocument
+from hrm_backend.candidates.models.profile import CandidateProfile
+from hrm_backend.candidates.services.candidate_search import (
+    CandidateListFilters,
+    build_candidate_list_projection,
+    matches_candidate_filters,
+    normalize_candidate_search_value,
+    validate_candidate_list_filters,
+)
+
+NOW = datetime(2026, 3, 12, 9, 0, tzinfo=UTC)
+
+
+def test_normalize_candidate_search_value_collapses_whitespace_and_case() -> None:
+    """Verify free-text matching uses stable case-insensitive normalized fragments."""
+    assert normalize_candidate_search_value("  Senior   PYTHON  ") == "senior python"
+    assert normalize_candidate_search_value("   ") is None
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("acme logistics", True),
+        ("warehouse supervisor", True),
+        ("logistics lead", True),
+        ("python", True),
+        ("not-present", False),
+    ],
+)
+def test_matches_candidate_filters_searches_profile_and_parsed_cv_fields(
+    query: str,
+    expected: bool,
+) -> None:
+    """Verify free-text search spans base profile fields plus parsed CV enrichment fields."""
+    projection = _build_projection()
+
+    assert (
+        matches_candidate_filters(
+            projection,
+            CandidateListFilters(limit=20, offset=0, search=query),
+        )
+        is expected
+    )
+
+
+def test_matches_candidate_filters_supports_skill_contains_matching() -> None:
+    """Verify skill filter matches parsed skills with case-insensitive contains semantics."""
+    projection = _build_projection()
+
+    assert matches_candidate_filters(
+        projection,
+        CandidateListFilters(limit=20, offset=0, skill="machine"),
+    )
+    assert not matches_candidate_filters(
+        projection,
+        CandidateListFilters(limit=20, offset=0, skill="react"),
+    )
+
+
+def test_matches_candidate_filters_distinguishes_analysis_ready_states() -> None:
+    """Verify analysis-ready filter requires both parsed payload and parsed timestamp."""
+    ready_projection = _build_projection()
+    pending_projection = _build_projection(parsed_at=None)
+
+    assert matches_candidate_filters(
+        ready_projection,
+        CandidateListFilters(limit=20, offset=0, analysis_ready=True),
+    )
+    assert not matches_candidate_filters(
+        pending_projection,
+        CandidateListFilters(limit=20, offset=0, analysis_ready=True),
+    )
+    assert matches_candidate_filters(
+        pending_projection,
+        CandidateListFilters(limit=20, offset=0, analysis_ready=False),
+    )
+
+
+def test_matches_candidate_filters_applies_min_years_experience_only_when_present() -> None:
+    """Verify minimum experience excludes rows without parsed totals and rows below threshold."""
+    experienced_projection = _build_projection(years_total=5)
+    missing_experience_projection = _build_projection(
+        parsed_profile={"summary": "No years extracted."},
+    )
+
+    assert matches_candidate_filters(
+        experienced_projection,
+        CandidateListFilters(limit=20, offset=0, min_years_experience=4),
+    )
+    assert not matches_candidate_filters(
+        experienced_projection,
+        CandidateListFilters(limit=20, offset=0, min_years_experience=6),
+    )
+    assert not matches_candidate_filters(
+        missing_experience_projection,
+        CandidateListFilters(limit=20, offset=0, min_years_experience=1),
+    )
+
+
+def test_matches_candidate_filters_applies_vacancy_stage_filters() -> None:
+    """Verify vacancy-scoped filters use the latest resolved stage from the requested vacancy."""
+    projection = _build_projection(vacancy_stage="interview")
+    filters = CandidateListFilters(
+        limit=20,
+        offset=0,
+        vacancy_id=uuid4(),
+        in_pipeline_only=True,
+        stage="interview",
+    )
+
+    assert matches_candidate_filters(projection, filters)
+    assert not matches_candidate_filters(
+        projection,
+        CandidateListFilters(
+            limit=20,
+            offset=0,
+            vacancy_id=uuid4(),
+            in_pipeline_only=True,
+            stage="offer",
+        ),
+    )
+    assert not matches_candidate_filters(
+        _build_projection(vacancy_stage=None),
+        CandidateListFilters(limit=20, offset=0, vacancy_id=uuid4(), in_pipeline_only=True),
+    )
+
+
+def test_validate_candidate_list_filters_rejects_stage_without_vacancy() -> None:
+    """Verify `stage` cannot be used without a vacancy-scoped context."""
+    with pytest.raises(HTTPException) as error_info:
+        validate_candidate_list_filters(
+            CandidateListFilters(limit=20, offset=0, stage="screening"),
+        )
+
+    assert error_info.value.status_code == 422
+    assert error_info.value.detail == "stage_requires_vacancy_id"
+
+
+def _build_projection(
+    *,
+    parsed_profile: dict[str, object] | None = None,
+    parsed_at: datetime | None = NOW,
+    years_total: int | None = 5,
+    vacancy_stage: str | None = "screening",
+):
+    """Build one enriched candidate projection for pure helper tests."""
+    candidate_id = str(uuid4())
+    profile = CandidateProfile(
+        candidate_id=candidate_id,
+        owner_subject_id="public",
+        first_name="Alice",
+        last_name="Johnson",
+        email="alice@example.com",
+        phone="+375291112233",
+        location="Minsk",
+        current_title="Recruiter",
+        extra_data={},
+        created_at=NOW,
+        updated_at=NOW,
+    )
+    document = CandidateDocument(
+        document_id=str(uuid4()),
+        candidate_id=candidate_id,
+        object_key="candidates/test/cv.pdf",
+        filename="cv.pdf",
+        mime_type="application/pdf",
+        size_bytes=123,
+        checksum_sha256="0" * 64,
+        is_active=True,
+        parsed_profile_json=parsed_profile
+        or {
+            "summary": "Experienced logistics lead with strong warehouse hiring support.",
+            "skills": ["python", "machine_learning"],
+            "experience": {"years_total": years_total},
+            "workplaces": {
+                "entries": [
+                    {
+                        "employer": "Acme Logistics",
+                        "position": {
+                            "raw": "Warehouse Supervisor",
+                            "normalized": "warehouse supervisor",
+                        },
+                    }
+                ]
+            },
+            "titles": {
+                "current": {
+                    "raw": "Logistics Lead",
+                    "normalized": "logistics lead",
+                },
+                "past": [],
+            },
+        },
+        detected_language="en",
+        parsed_at=parsed_at,
+        created_at=NOW,
+    )
+    return build_candidate_list_projection(
+        profile=profile,
+        active_document=document,
+        vacancy_stage=vacancy_stage,  # type: ignore[arg-type]
+    )

--- a/apps/frontend/src/api/candidateProfiles.ts
+++ b/apps/frontend/src/api/candidateProfiles.ts
@@ -2,15 +2,52 @@ import type { components } from "./generated/openapi-types";
 import { typedApiClient } from "./typedClient";
 
 export type CandidateListResponse = components["schemas"]["CandidateListResponse"];
+export type CandidateListItemResponse = components["schemas"]["CandidateListItemResponse"];
 export type CandidateResponse = components["schemas"]["CandidateResponse"];
+export type CandidateListQuery = {
+  limit?: number;
+  offset?: number;
+  search?: string;
+  location?: string;
+  currentTitle?: string;
+  skill?: string;
+  analysisReady?: boolean;
+  minYearsExperience?: number;
+  vacancyId?: string;
+  inPipelineOnly?: boolean;
+  stage?: CandidateListItemResponse["vacancy_stage"];
+};
+
+function withAuth(accessToken: string): RequestInit {
+  return {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  };
+}
 
 /**
  * Load candidate profiles for authenticated HR/admin actors.
  */
-export function listCandidateProfiles(accessToken: string): Promise<CandidateListResponse> {
-  return typedApiClient.get<CandidateListResponse>("/api/v1/candidates", undefined, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
+export function listCandidateProfiles(
+  accessToken: string,
+  query: CandidateListQuery = {},
+): Promise<CandidateListResponse> {
+  return typedApiClient.get<CandidateListResponse>(
+    "/api/v1/candidates",
+    {
+      limit: query.limit,
+      offset: query.offset,
+      search: query.search,
+      location: query.location,
+      current_title: query.currentTitle,
+      skill: query.skill,
+      analysis_ready: query.analysisReady,
+      min_years_experience: query.minYearsExperience,
+      vacancy_id: query.vacancyId,
+      in_pipeline_only: query.inPipelineOnly,
+      stage: query.stage,
     },
-  });
+    withAuth(accessToken),
+  );
 }

--- a/apps/frontend/src/api/generated/openapi-types.ts
+++ b/apps/frontend/src/api/generated/openapi-types.ts
@@ -201,7 +201,7 @@ export interface paths {
         };
         /**
          * List Candidate Profiles
-         * @description List candidate profiles for authorized role.
+         * @description List candidate profiles with recruiter-facing search, filter, and pagination.
          */
         get: operations["list_candidate_profiles_api_v1_candidates_get"];
         put?: never;
@@ -1418,12 +1418,72 @@ export interface components {
             phone?: string | null;
         };
         /**
+         * CandidateListItemResponse
+         * @description Candidate list row enriched with parsed CV and vacancy-context metadata.
+         */
+        CandidateListItemResponse: {
+            /** Analysis Ready */
+            analysis_ready: boolean;
+            /**
+             * Candidate Id
+             * Format: uuid
+             */
+            candidate_id: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Current Title */
+            current_title: string | null;
+            /**
+             * Detected Language
+             * @enum {string}
+             */
+            detected_language: "ru" | "en" | "mixed" | "unknown";
+            /** Email */
+            email: string;
+            /** Extra Data */
+            extra_data: {
+                [key: string]: unknown;
+            };
+            /** First Name */
+            first_name: string;
+            /** Last Name */
+            last_name: string;
+            /** Location */
+            location: string | null;
+            /** Owner Subject Id */
+            owner_subject_id: string;
+            /** Parsed At */
+            parsed_at: string | null;
+            /** Phone */
+            phone: string | null;
+            /** Skills */
+            skills?: string[];
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** Vacancy Stage */
+            vacancy_stage: ("applied" | "screening" | "shortlist" | "interview" | "offer" | "hired" | "rejected") | null;
+            /** Years Experience */
+            years_experience: number | null;
+        };
+        /**
          * CandidateListResponse
-         * @description Candidate profile list payload.
+         * @description Paginated candidate profile list payload.
          */
         CandidateListResponse: {
             /** Items */
-            items: components["schemas"]["CandidateResponse"][];
+            items: components["schemas"]["CandidateListItemResponse"][];
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
+            /** Total */
+            total: number;
         };
         /**
          * CandidateResponse
@@ -3277,7 +3337,19 @@ export interface operations {
     };
     list_candidate_profiles_api_v1_candidates_get: {
         parameters: {
-            query?: never;
+            query?: {
+                limit?: number;
+                offset?: number;
+                search?: string | null;
+                location?: string | null;
+                current_title?: string | null;
+                skill?: string | null;
+                analysis_ready?: boolean | null;
+                min_years_experience?: number | null;
+                vacancy_id?: string | null;
+                in_pipeline_only?: boolean;
+                stage?: ("applied" | "screening" | "shortlist" | "interview" | "offer" | "hired" | "rejected") | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -3291,6 +3363,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CandidateListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/apps/frontend/src/api/index.ts
+++ b/apps/frontend/src/api/index.ts
@@ -82,7 +82,12 @@ export type {
   PublicVacancyApplicationRequest,
   PublicVacancyApplicationResponse,
 } from "./candidateApplications";
-export type { CandidateListResponse, CandidateResponse } from "./candidateProfiles";
+export type {
+  CandidateListItemResponse,
+  CandidateListQuery,
+  CandidateListResponse,
+  CandidateResponse,
+} from "./candidateProfiles";
 export type {
   CalendarSyncStatus,
   HRInterviewListResponse,

--- a/apps/frontend/src/app/i18n.ts
+++ b/apps/frontend/src/app/i18n.ts
@@ -243,6 +243,15 @@ const resources = {
           "Selected candidate: {{candidateName}} ({{candidateId}})",
         selectVacancyAction: "Select",
         selectCandidateAction: "Select candidate",
+        filters: {
+          candidateSearch: "Candidate search",
+          analysisReady: "Analysis ready only",
+          inPipelineOnly: "In pipeline only",
+          stage: "Latest stage",
+          anyStage: "Any stage",
+          apply: "Apply",
+          reset: "Reset",
+        },
         shortlist: {
           title: "Shortlist review",
           subtitle:
@@ -515,6 +524,10 @@ const resources = {
           matchScoreNotFound: "Match score was not found.",
           cvAnalysisNotReady:
             "CV analysis is not ready yet. Wait for parsing to finish and run score again.",
+          stageRequiresVacancy:
+            "Select a vacancy before filtering candidates by latest pipeline stage.",
+          inPipelineOnlyRequiresVacancy:
+            "Select a vacancy before limiting candidates to vacancy pipeline history.",
           invalidTransition:
             "The requested pipeline transition is not allowed from the current stage.",
           interviewFeedbackWindowNotOpen:
@@ -1031,6 +1044,15 @@ const resources = {
           "Выбран кандидат: {{candidateName}} ({{candidateId}})",
         selectVacancyAction: "Выбрать",
         selectCandidateAction: "Выбрать кандидата",
+        filters: {
+          candidateSearch: "Поиск кандидата",
+          analysisReady: "Только с готовым analysis",
+          inPipelineOnly: "Только из pipeline",
+          stage: "Последняя стадия",
+          anyStage: "Любая стадия",
+          apply: "Применить",
+          reset: "Сбросить",
+        },
         shortlist: {
           title: "Проверка шортлиста",
           subtitle:
@@ -1313,6 +1335,10 @@ const resources = {
           matchScoreNotFound: "Match score не найден.",
           cvAnalysisNotReady:
             "CV analysis ещё не готов. Дождитесь завершения parsing и повторите запуск score.",
+          stageRequiresVacancy:
+            "Выберите вакансию перед фильтрацией кандидатов по последней стадии pipeline.",
+          inPipelineOnlyRequiresVacancy:
+            "Выберите вакансию перед фильтрацией кандидатов только из vacancy pipeline history.",
           invalidTransition:
             "Запрошенный переход по pipeline недопустим из текущей стадии.",
           interviewFeedbackWindowNotOpen:

--- a/apps/frontend/src/pages/HrDashboardPage.test.tsx
+++ b/apps/frontend/src/pages/HrDashboardPage.test.tsx
@@ -14,6 +14,7 @@ const fetchMock = vi.fn();
 vi.stubGlobal("fetch", fetchMock);
 const VACANCY_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const CANDIDATE_ID = "11111111-1111-1111-1111-111111111111";
+const SECOND_CANDIDATE_ID = "22222222-2222-4222-8222-222222222222";
 const CURRENT_USER_ID = "33333333-3333-4333-8333-333333333333";
 const VACANCY_ITEM = {
   vacancy_id: VACANCY_ID,
@@ -36,6 +37,12 @@ const CANDIDATE_ITEM = {
   extra_data: {},
   created_at: "2026-03-06T10:00:00Z",
   updated_at: "2026-03-06T10:00:00Z",
+  analysis_ready: true,
+  detected_language: "en",
+  parsed_at: "2026-03-06T10:00:00Z",
+  years_experience: 5,
+  skills: ["python", "docker"],
+  vacancy_stage: null,
 };
 const SUCCESSFUL_MATCH_SCORE = {
   vacancy_id: VACANCY_ID,
@@ -156,6 +163,7 @@ function jsonResponse(payload: unknown, status = 200): Promise<Response> {
 }
 
 function installHrWorkspaceFetchMock({
+  candidateListGet,
   meGet,
   matchScoreGet,
   matchScorePost,
@@ -187,6 +195,7 @@ function installHrWorkspaceFetchMock({
     },
   ],
 }: {
+  candidateListGet?: (url: string, init?: RequestInit) => Promise<Response>;
   meGet?: (url: string, init?: RequestInit) => Promise<Response>;
   matchScoreGet?: (url: string, init?: RequestInit) => Promise<Response>;
   matchScorePost?: (url: string, init?: RequestInit) => Promise<Response>;
@@ -338,7 +347,15 @@ function installHrWorkspaceFetchMock({
       return jsonResponse({ items: [VACANCY_ITEM] });
     }
     if (url.includes("/api/v1/candidates")) {
-      return jsonResponse({ items: [CANDIDATE_ITEM] });
+      if (method === "GET" && candidateListGet) {
+        return candidateListGet(url, init);
+      }
+      return jsonResponse({
+        items: [CANDIDATE_ITEM],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      });
     }
     if (url.includes("/api/v1/pipeline/transitions?")) {
       return jsonResponse({ items: pipelineItems });
@@ -349,6 +366,7 @@ function installHrWorkspaceFetchMock({
 
 async function selectVacancyAndCandidate() {
   fireEvent.click(await screen.findByRole("button", { name: /^выбрать$/i }));
+  await screen.findByRole("option", { name: /john doe \(john@example.com\)/i });
   fireEvent.change(screen.getByRole("combobox", { name: /^кандидат$/i }), {
     target: { value: CANDIDATE_ID },
   });
@@ -376,6 +394,143 @@ describe("HrDashboardPage", () => {
 
     expect(await screen.findByText(/public_application/i)).toBeDefined();
     expect((await screen.findAllByRole("cell", { name: /отклик/i })).length).toBeGreaterThan(0);
+  });
+
+  it("applies and resets candidate filters while forwarding candidate query params", async () => {
+    window.localStorage.setItem("hrm_access_token", "access-token");
+    window.localStorage.setItem("hrm_user_role", "hr");
+
+    const secondCandidate = {
+      ...CANDIDATE_ITEM,
+      candidate_id: SECOND_CANDIDATE_ID,
+      first_name: "Jane",
+      last_name: "Roe",
+      email: "jane@example.com",
+      analysis_ready: false,
+      years_experience: null,
+      skills: ["react"],
+    };
+    const candidateUrls: string[] = [];
+
+    installHrWorkspaceFetchMock({
+      candidateListGet: (url) => {
+        candidateUrls.push(url);
+        const parsedUrl = new URL(url, "http://testserver");
+        const search = parsedUrl.searchParams.get("search");
+        const analysisReady = parsedUrl.searchParams.get("analysis_ready");
+        const vacancyId = parsedUrl.searchParams.get("vacancy_id");
+        const inPipelineOnly = parsedUrl.searchParams.get("in_pipeline_only");
+        const stage = parsedUrl.searchParams.get("stage");
+
+        if (
+          search === "john"
+          && analysisReady === "true"
+          && vacancyId === VACANCY_ID
+          && inPipelineOnly === "true"
+          && stage === "screening"
+        ) {
+          return jsonResponse({
+            items: [{ ...CANDIDATE_ITEM, vacancy_stage: "screening" }],
+            total: 1,
+            limit: 20,
+            offset: 0,
+          });
+        }
+
+        return jsonResponse({
+          items: [CANDIDATE_ITEM, secondCandidate],
+          total: 2,
+          limit: 20,
+          offset: 0,
+        });
+      },
+    });
+
+    renderHrDashboardPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: /^выбрать$/i }));
+    fireEvent.change(screen.getByLabelText(/поиск кандидата/i), {
+      target: { value: "john" },
+    });
+    fireEvent.click(screen.getByRole("checkbox", { name: /только с готовым analysis/i }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /только из pipeline/i }));
+    fireEvent.mouseDown(screen.getByLabelText(/последняя стадия/i));
+    fireEvent.click(await screen.findByRole("option", { name: /скрининг/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^применить$/i }));
+
+    await waitFor(() => {
+      expect(
+        candidateUrls.some(
+          (url) =>
+            url.includes("search=john")
+            && url.includes("analysis_ready=true")
+            && url.includes(`vacancy_id=${VACANCY_ID}`)
+            && url.includes("in_pipeline_only=true")
+            && url.includes("stage=screening"),
+        ),
+      ).toBe(true);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /^сбросить$/i }));
+
+    await waitFor(() => {
+      const latestUrl = candidateUrls[candidateUrls.length - 1] ?? "";
+      expect(latestUrl).toContain(`/api/v1/candidates?limit=20&offset=0&vacancy_id=${VACANCY_ID}`);
+      expect(latestUrl).not.toContain("search=john");
+      expect(latestUrl).not.toContain("analysis_ready=true");
+      expect(latestUrl).not.toContain("in_pipeline_only=true");
+      expect(latestUrl).not.toContain("stage=screening");
+    });
+  });
+
+  it("keeps the selected candidate context when candidate pagination changes pages", async () => {
+    window.localStorage.setItem("hrm_access_token", "access-token");
+    window.localStorage.setItem("hrm_user_role", "hr");
+
+    const pagedCandidate = {
+      ...CANDIDATE_ITEM,
+      candidate_id: SECOND_CANDIDATE_ID,
+      first_name: "Jane",
+      last_name: "Paged",
+      email: "jane.paged@example.com",
+    };
+
+    installHrWorkspaceFetchMock({
+      candidateListGet: (url) => {
+        const parsedUrl = new URL(url, "http://testserver");
+        const offset = parsedUrl.searchParams.get("offset") ?? "0";
+
+        if (offset === "20") {
+          return jsonResponse({
+            items: [pagedCandidate],
+            total: 21,
+            limit: 20,
+            offset: 20,
+          });
+        }
+
+        return jsonResponse({
+          items: [CANDIDATE_ITEM],
+          total: 21,
+          limit: 20,
+          offset: 0,
+        });
+      },
+    });
+
+    renderHrDashboardPage();
+
+    await selectVacancyAndCandidate();
+    expect(await screen.findByText(/выбран кандидат: john doe \(john@example.com\)/i)).toBeDefined();
+
+    fireEvent.click(screen.getByLabelText(/go to next page/i));
+
+    await waitFor(() => {
+      expect(screen.getByText(/выбран кандидат: john doe \(john@example.com\)/i)).toBeDefined();
+      expect(
+        (screen.getByRole("combobox", { name: /^кандидат$/i }) as HTMLSelectElement).value,
+      ).toBe(CANDIDATE_ID);
+    });
   });
 
   it("renders embedded onboarding progress dashboard for HR workspace", async () => {
@@ -905,7 +1060,7 @@ describe("HrDashboardPage", () => {
       expect(screen.getByText(/fairness gate пройден/i)).toBeDefined();
       expect(screen.getAllByText(/strong communication and ownership/i).length).toBeGreaterThan(0);
     });
-  }, 10000);
+  }, 15000);
 
   it("renders localized fairness blocker for interview to offer transition", async () => {
     window.localStorage.setItem("hrm_access_token", "access-token");
@@ -1066,7 +1221,7 @@ describe("HrDashboardPage", () => {
         screen.getByText(/теперь pipeline можно перевести в hired/i),
       ).toBeDefined();
     });
-  }, 10_000);
+  }, 20_000);
 
   it("renders localized blocker for offer to hired transition before acceptance", async () => {
     window.localStorage.setItem("hrm_access_token", "access-token");
@@ -1122,7 +1277,7 @@ describe("HrDashboardPage", () => {
         screen.getByText(/перед переводом pipeline в hired оффер должен быть отмечен как accepted/i),
       ).toBeDefined();
     });
-  });
+  }, 15000);
 
   it("renders localized interview calendar configuration errors", async () => {
     window.localStorage.setItem("hrm_access_token", "access-token");
@@ -1184,5 +1339,5 @@ describe("HrDashboardPage", () => {
           .some((item) => /синхронизация календаря/i.test(item.textContent ?? "")),
       ).toBe(true);
     });
-  });
+  }, 15000);
 });

--- a/apps/frontend/src/pages/HrDashboardPage.tsx
+++ b/apps/frontend/src/pages/HrDashboardPage.tsx
@@ -5,15 +5,22 @@ import {
   Button,
   Chip,
   Divider,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
   List,
   ListItem,
   ListItemText,
+  MenuItem,
   Paper,
+  Select,
   Stack,
+  Switch,
   Table,
   TableBody,
   TableCell,
   TableHead,
+  TablePagination,
   TableRow,
   TextField,
   Typography,
@@ -44,7 +51,8 @@ import {
   sendOffer,
   upsertOffer,
   updateVacancy,
-  type CandidateResponse,
+  type CandidateListItemResponse,
+  type CandidateListQuery,
   type HRInterviewListResponse,
   type InterviewFeedbackItemResponse,
   type InterviewFeedbackPanelSummaryResponse,
@@ -83,6 +91,7 @@ type FeedbackState = {
 };
 
 type VacancyDraft = VacancyCreateRequest;
+type CandidateStageFilterValue = PipelineTransitionCreateRequest["to_stage"] | "all";
 type MatchScoreStatus = MatchScoreResponse["status"];
 type InterviewDraft = {
   scheduledStartLocal: string;
@@ -117,6 +126,7 @@ const DEFAULT_VACANCY_DRAFT: VacancyDraft = {
   department: "",
   status: "open",
 };
+const DEFAULT_CANDIDATE_LIMIT = 20;
 const INTERVIEW_POLL_INTERVAL_MS = 1000;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const FEEDBACK_SCORE_OPTIONS = [1, 2, 3, 4, 5] as const;
@@ -153,12 +163,32 @@ export function HrDashboardPage() {
   const [feedbackDraft, setFeedbackDraft] =
     useState<InterviewerFeedbackDraft>(createEmptyInterviewerFeedbackDraft);
   const [offerDraft, setOfferDraft] = useState<OfferDraft>(createEmptyOfferDraft);
+  const [candidateSearchInput, setCandidateSearchInput] = useState("");
+  const [candidateAnalysisReadyOnly, setCandidateAnalysisReadyOnly] = useState(false);
+  const [candidateInPipelineOnly, setCandidateInPipelineOnly] = useState(false);
+  const [candidateStageFilter, setCandidateStageFilter] =
+    useState<CandidateStageFilterValue>("all");
+  const [candidateQuery, setCandidateQuery] = useState<CandidateListQuery>({
+    limit: DEFAULT_CANDIDATE_LIMIT,
+    offset: 0,
+  });
+  const [selectedCandidateSnapshot, setSelectedCandidateSnapshot] =
+    useState<CandidateListItemResponse | null>(null);
   const matchScoreQueryKey = [
     "hr-match-score",
     accessToken,
     selectedVacancyId,
     selectedCandidateId,
   ];
+  const effectiveCandidateQuery: CandidateListQuery = {
+    limit: candidateQuery.limit ?? DEFAULT_CANDIDATE_LIMIT,
+    offset: candidateQuery.offset ?? 0,
+    search: candidateQuery.search,
+    analysisReady: candidateQuery.analysisReady,
+    vacancyId: selectedVacancyId || undefined,
+    inPipelineOnly: selectedVacancyId ? candidateQuery.inPipelineOnly : undefined,
+    stage: selectedVacancyId ? candidateQuery.stage : undefined,
+  };
   const interviewsQueryKey = [
     "hr-interviews",
     accessToken,
@@ -174,8 +204,8 @@ export function HrDashboardPage() {
   });
 
   const candidatesQuery = useQuery({
-    queryKey: ["hr-candidates", accessToken],
-    queryFn: () => listCandidateProfiles(accessToken!),
+    queryKey: ["hr-candidates", accessToken, effectiveCandidateQuery],
+    queryFn: () => listCandidateProfiles(accessToken!, effectiveCandidateQuery),
     enabled: Boolean(accessToken),
   });
 
@@ -461,10 +491,18 @@ export function HrDashboardPage() {
 
   const vacancyItems = vacanciesQuery.data?.items ?? [];
   const candidateItems = candidatesQuery.data?.items ?? [];
+  const candidateTotal = candidatesQuery.data?.total ?? 0;
+  const candidatePage = Math.floor(
+    (effectiveCandidateQuery.offset ?? 0) / (effectiveCandidateQuery.limit ?? DEFAULT_CANDIDATE_LIMIT),
+  );
   const selectedVacancy =
     vacancyItems.find((item) => item.vacancy_id === selectedVacancyId) ?? null;
   const selectedCandidate =
-    candidateItems.find((item) => item.candidate_id === selectedCandidateId) ?? null;
+    candidateItems.find((item) => item.candidate_id === selectedCandidateId)
+    ?? (selectedCandidateSnapshot?.candidate_id === selectedCandidateId
+      ? selectedCandidateSnapshot
+      : null);
+  const candidateSelectItems = mergeCandidateSelectItems(candidateItems, selectedCandidate);
   const matchScore = matchScoreQuery.data ?? null;
   const matchedRequirements = matchScore?.matched_requirements ?? [];
   const missingRequirements = matchScore?.missing_requirements ?? [];
@@ -506,6 +544,9 @@ export function HrDashboardPage() {
       ? "warning"
       : "info";
   const offerStatusHint = buildOfferStatusHint(offerStatus, t);
+  const candidateListErrorMessage = candidatesQuery.error
+    ? resolveRecruitmentApiError(candidatesQuery.error, t)
+    : "";
 
   useEffect(() => {
     if (!latestInterview) {
@@ -526,6 +567,18 @@ export function HrDashboardPage() {
   useEffect(() => {
     setOfferDraft(buildOfferDraftFromResponse(offer));
   }, [offer]);
+
+  useEffect(() => {
+    if (!selectedCandidateId) {
+      setSelectedCandidateSnapshot(null);
+      return;
+    }
+    const nextSelectedCandidate =
+      candidateItems.find((item) => item.candidate_id === selectedCandidateId) ?? null;
+    if (nextSelectedCandidate) {
+      setSelectedCandidateSnapshot(nextSelectedCandidate);
+    }
+  }, [candidateItems, selectedCandidateId]);
 
   const handleSelectVacancy = (vacancy: VacancyResponse) => {
     setSelectedVacancyId(vacancy.vacancy_id);
@@ -573,10 +626,44 @@ export function HrDashboardPage() {
 
   const handleSelectCandidate = (candidateId: string) => {
     setSelectedCandidateId(candidateId);
+    setSelectedCandidateSnapshot(
+      candidateSelectItems.find((item) => item.candidate_id === candidateId) ?? null,
+    );
     setScoreFeedback(null);
     setInterviewFeedback(null);
     setFeedbackPanelState(null);
     setOfferPanelState(null);
+  };
+
+  const handleApplyCandidateFilters = () => {
+    setFeedback(null);
+    setCandidateQuery((prev) => ({
+      ...prev,
+      offset: 0,
+      search: normalizeCandidateFilterValue(candidateSearchInput),
+      analysisReady: candidateAnalysisReadyOnly ? true : undefined,
+      inPipelineOnly: selectedVacancyId && candidateInPipelineOnly ? true : undefined,
+      stage:
+        selectedVacancyId && candidateStageFilter !== "all"
+          ? candidateStageFilter
+          : undefined,
+    }));
+  };
+
+  const handleResetCandidateFilters = () => {
+    setCandidateSearchInput("");
+    setCandidateAnalysisReadyOnly(false);
+    setCandidateInPipelineOnly(false);
+    setCandidateStageFilter("all");
+    setFeedback(null);
+    setCandidateQuery((prev) => ({
+      ...prev,
+      offset: 0,
+      search: undefined,
+      analysisReady: undefined,
+      inPipelineOnly: undefined,
+      stage: undefined,
+    }));
   };
 
   const handleRunScore = () => {
@@ -873,6 +960,66 @@ export function HrDashboardPage() {
       <Paper sx={{ p: 2 }}>
         <Stack spacing={2}>
           <Typography variant="h6">{t("hrDashboard.pipelineTitle")}</Typography>
+          <Stack direction={{ xs: "column", md: "row" }} spacing={2} alignItems="center">
+            <TextField
+              size="small"
+              label={t("hrDashboard.filters.candidateSearch")}
+              value={candidateSearchInput}
+              onChange={(event) => setCandidateSearchInput(event.target.value)}
+              sx={{ minWidth: 220 }}
+            />
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={candidateAnalysisReadyOnly}
+                  onChange={(event) => setCandidateAnalysisReadyOnly(event.target.checked)}
+                />
+              }
+              label={t("hrDashboard.filters.analysisReady")}
+            />
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={candidateInPipelineOnly}
+                  onChange={(event) => setCandidateInPipelineOnly(event.target.checked)}
+                  disabled={!selectedVacancyId}
+                />
+              }
+              label={t("hrDashboard.filters.inPipelineOnly")}
+            />
+            <FormControl size="small" sx={{ minWidth: 180 }}>
+              <InputLabel id="hr-dashboard-stage-filter-label">
+                {t("hrDashboard.filters.stage")}
+              </InputLabel>
+              <Select
+                labelId="hr-dashboard-stage-filter-label"
+                value={candidateStageFilter}
+                label={t("hrDashboard.filters.stage")}
+                disabled={!selectedVacancyId}
+                onChange={(event) =>
+                  setCandidateStageFilter(event.target.value as CandidateStageFilterValue)
+                }
+              >
+                <MenuItem value="all">{t("hrDashboard.filters.anyStage")}</MenuItem>
+                {PIPELINE_STAGE_OPTIONS.map((stage) => (
+                  <MenuItem key={stage} value={stage}>
+                    {t(`hrDashboard.stages.${stage}`)}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <Button variant="contained" onClick={handleApplyCandidateFilters}>
+              {t("hrDashboard.filters.apply")}
+            </Button>
+            <Button variant="outlined" onClick={handleResetCandidateFilters}>
+              {t("hrDashboard.filters.reset")}
+            </Button>
+          </Stack>
+
+          {candidatesQuery.error ? (
+            <Alert severity="error">{candidateListErrorMessage}</Alert>
+          ) : null}
+
           <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
             <TextField
               select
@@ -883,7 +1030,7 @@ export function HrDashboardPage() {
               SelectProps={{ native: true }}
             >
               <option value="">{t("hrDashboard.selectCandidateAction")}</option>
-              {candidateItems.map((candidate) => (
+              {candidateSelectItems.map((candidate) => (
                 <option key={candidate.candidate_id} value={candidate.candidate_id}>
                   {formatCandidateLabel(candidate)}
                 </option>
@@ -906,6 +1053,27 @@ export function HrDashboardPage() {
               ))}
             </TextField>
           </Stack>
+          <TablePagination
+            component="div"
+            count={candidateTotal}
+            page={candidatePage}
+            rowsPerPage={effectiveCandidateQuery.limit ?? DEFAULT_CANDIDATE_LIMIT}
+            onPageChange={(_, nextPage) => {
+              setCandidateQuery((prev) => ({
+                ...prev,
+                offset: nextPage * (prev.limit ?? DEFAULT_CANDIDATE_LIMIT),
+              }));
+            }}
+            onRowsPerPageChange={(event) => {
+              const nextLimit = Number.parseInt(event.target.value, 10);
+              setCandidateQuery((prev) => ({
+                ...prev,
+                limit: nextLimit,
+                offset: 0,
+              }));
+            }}
+            rowsPerPageOptions={[10, 20, 50, 100]}
+          />
           <TextField
             label={t("hrDashboard.fields.transitionReason")}
             value={transitionReason}
@@ -2080,7 +2248,25 @@ function buildVacancyPatchPayload(
   return payload;
 }
 
-function formatCandidateLabel(candidate: CandidateResponse): string {
+function normalizeCandidateFilterValue(value: string): string | undefined {
+  const normalized = value.trim();
+  return normalized ? normalized : undefined;
+}
+
+function mergeCandidateSelectItems(
+  items: CandidateListItemResponse[],
+  selectedCandidate: CandidateListItemResponse | null,
+): CandidateListItemResponse[] {
+  if (!selectedCandidate) {
+    return items;
+  }
+  if (items.some((item) => item.candidate_id === selectedCandidate.candidate_id)) {
+    return items;
+  }
+  return [selectedCandidate, ...items];
+}
+
+function formatCandidateLabel(candidate: CandidateListItemResponse): string {
   return `${candidate.first_name} ${candidate.last_name} (${candidate.email})`;
 }
 
@@ -2526,6 +2712,12 @@ function resolveRecruitmentApiError(
     }
     if (detail.includes("cv analysis is not ready")) {
       return t("hrDashboard.errors.cvAnalysisNotReady");
+    }
+    if (detail.includes("stage_requires_vacancy_id")) {
+      return t("hrDashboard.errors.stageRequiresVacancy");
+    }
+    if (detail.includes("in_pipeline_only_requires_vacancy_id")) {
+      return t("hrDashboard.errors.inPipelineOnlyRequiresVacancy");
     }
     if (detail.includes("match score not found")) {
       return t("hrDashboard.errors.matchScoreNotFound");

--- a/docs/api/openapi.frozen.json
+++ b/docs/api/openapi.frozen.json
@@ -773,19 +773,195 @@
         "title": "CandidateCreateRequest",
         "type": "object"
       },
-      "CandidateListResponse": {
-        "description": "Candidate profile list payload.",
+      "CandidateListItemResponse": {
+        "description": "Candidate list row enriched with parsed CV and vacancy-context metadata.",
         "properties": {
-          "items": {
+          "analysis_ready": {
+            "title": "Analysis Ready",
+            "type": "boolean"
+          },
+          "candidate_id": {
+            "format": "uuid",
+            "title": "Candidate Id",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "current_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Title"
+          },
+          "detected_language": {
+            "enum": [
+              "ru",
+              "en",
+              "mixed",
+              "unknown"
+            ],
+            "title": "Detected Language",
+            "type": "string"
+          },
+          "email": {
+            "title": "Email",
+            "type": "string"
+          },
+          "extra_data": {
+            "additionalProperties": true,
+            "title": "Extra Data",
+            "type": "object"
+          },
+          "first_name": {
+            "title": "First Name",
+            "type": "string"
+          },
+          "last_name": {
+            "title": "Last Name",
+            "type": "string"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "owner_subject_id": {
+            "title": "Owner Subject Id",
+            "type": "string"
+          },
+          "parsed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parsed At"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "skills": {
             "items": {
-              "$ref": "#/components/schemas/CandidateResponse"
+              "type": "string"
             },
-            "title": "Items",
+            "title": "Skills",
             "type": "array"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "vacancy_stage": {
+            "anyOf": [
+              {
+                "enum": [
+                  "applied",
+                  "screening",
+                  "shortlist",
+                  "interview",
+                  "offer",
+                  "hired",
+                  "rejected"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vacancy Stage"
+          },
+          "years_experience": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Years Experience"
           }
         },
         "required": [
-          "items"
+          "candidate_id",
+          "owner_subject_id",
+          "first_name",
+          "last_name",
+          "email",
+          "phone",
+          "location",
+          "current_title",
+          "extra_data",
+          "created_at",
+          "updated_at",
+          "analysis_ready",
+          "detected_language",
+          "parsed_at",
+          "years_experience",
+          "vacancy_stage"
+        ],
+        "title": "CandidateListItemResponse",
+        "type": "object"
+      },
+      "CandidateListResponse": {
+        "description": "Paginated candidate profile list payload.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CandidateListItemResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "minimum": 1.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "minimum": 0.0,
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "minimum": 0.0,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
         ],
         "title": "CandidateListResponse",
         "type": "object"
@@ -5019,8 +5195,190 @@
     },
     "/api/v1/candidates": {
       "get": {
-        "description": "List candidate profiles for authorized role.",
+        "description": "List candidate profiles with recruiter-facing search, filter, and pagination.",
         "operationId": "list_candidate_profiles_api_v1_candidates_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 256,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          },
+          {
+            "in": "query",
+            "name": "location",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 256,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Location"
+            }
+          },
+          {
+            "in": "query",
+            "name": "current_title",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 256,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Current Title"
+            }
+          },
+          {
+            "in": "query",
+            "name": "skill",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 256,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Skill"
+            }
+          },
+          {
+            "in": "query",
+            "name": "analysis_ready",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Analysis Ready"
+            }
+          },
+          {
+            "in": "query",
+            "name": "min_years_experience",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Min Years Experience"
+            }
+          },
+          {
+            "in": "query",
+            "name": "vacancy_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Vacancy Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "in_pipeline_only",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "In Pipeline Only",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "applied",
+                    "screening",
+                    "shortlist",
+                    "interview",
+                    "offer",
+                    "hired",
+                    "rejected"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Stage"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -5031,6 +5389,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "security": [

--- a/docs/project/tasks.md
+++ b/docs/project/tasks.md
@@ -24,6 +24,7 @@
 | TASK-12-02 | done/closed | GitHub issue #85 closed; merged in `main` via PR #105 (`a67bb8c`) with Linux-safe host-gateway wiring for external-host Ollama, optional compose profile `ai-local` (`ollama` + `ollama-init` + persistent volume), and operator-facing `./scripts/smoke-scoring-compose.sh` while keeping baseline compose/browser smoke and scoring/public contracts unchanged |
 | TASK-11-01/02/03/04 | done/closed | GitHub issues #25, #26, #27, and #28 were closed during backlog normalization; the current repo remains the source of truth for the implemented frontend foundation |
 | TASK-03-01/02/03/05/06/07/08 | implemented/local-universal-profile-enrichment-slice | GitHub issue #90 is now closed; backend candidate profile, public apply, async parsing, native PDF/DOCX text extraction, RU/EN normalization, profession-agnostic structured CV enrichment (workplaces with held positions, education, normalized titles/dates, generic skills), evidence traceability, and public tracking endpoints are present in repo with unit/integration coverage |
+| TASK-03-04 | implemented/local-candidate-search-slice | `GET /api/v1/candidates` now supports recruiter-facing search/filter/pagination, active-CV enrichment, and vacancy-context latest-stage filters, while `/` consumes the server-filtered list with apply/reset controls and pagination; GitHub issue `#91` remains open until the merge-driven closeout step |
 | TASK-02-01/02/03 | implemented/local-baseline | Backend vacancy CRUD, pipeline transitions, and ordered transition history endpoint are present in repo with integration coverage |
 | TASK-11-06 | implemented/local-baseline | `/candidate` now supports public deep-link apply, checksum-based upload, sessionStorage tracking context, and job-based parsing/analysis polling |
 | TASK-11-05 | implemented/local-baseline | `/` now exposes staff vacancy CRUD, vacancy editing, candidate selection, pipeline transition append, and history timeline UX |
@@ -61,6 +62,11 @@
   are enriched additively with profession-agnostic workplace history, held positions, education,
   normalized titles/dates, and generic skills while keeping parsing/analysis/scoring contracts
   stable.
+- `TASK-03-04` is now implemented in this delivery branch as one recruiter-facing slice: the
+  existing `GET /api/v1/candidates` route exposes server filtering, pagination, active-CV
+  enrichment, and vacancy-scoped latest-stage context, while the existing HR workspace on `/`
+  now applies those filters without adding a new route tree; post-merge issue `#91` closeout is
+  still pending and must be verified after merge before marking the task fully delivered.
 - The scoring/shortlist-review slice (`TASK-04-01/02/03 + TASK-11-07`) is now implemented in repo as one vertical delivery unit.
 - Scoring explainability (`TASK-04-05`) is now implemented in the same slice; remaining AI backlog is the low-confidence fallback and the quality harness.
 - The compliance follow-on slice (`TASK-13-01/02`) is now implemented in repo as documentation and evidence-model work only; no runtime/API/routing changes were introduced.
@@ -90,25 +96,24 @@
 - `TASK-07-02` is no longer active queue work; the implemented source of truth is the repo-backed onboarding task generation/backfill/update API on `/api/v1/onboarding/runs/{onboarding_id}/tasks`.
 - `TASK-07-03` is no longer active queue work; the implemented source of truth is the repo-backed employee self-service onboarding portal on `/employee` plus `/api/v1/employees/me/onboarding*`.
 - `TASK-07-04` is no longer active queue work; the implemented source of truth is the repo-backed onboarding progress dashboard on `/api/v1/onboarding/runs*`, embedded for HR on `/` and rendered as the manager workspace on the existing `/` route.
-- The remaining candidate-domain follow-on work after `TASK-03-08` is limited to search/filtering
-  (`TASK-03-04`) and later AI quality/fallback work, not baseline parsed-profile structure.
+- The remaining candidate-domain follow-on work after `TASK-03-08` is limited to later AI
+  quality/fallback work, not baseline parsed-profile structure.
 
 ## Normalized Open Backlog Snapshot
 
-- Normalized open backlog count: `21` tasks.
+- Normalized open backlog count: `20` tasks.
 - This count excludes tasks already implemented in repo but retained in the historical planning tables below for lineage.
 - Repo backlog state now excludes `TASK-12-02`, and GitHub issue `#85` is closed following PR #105 (`a67bb8c`).
-- Issue `#58` remains an umbrella `COMPLIANCE-01` tracking issue and is not included in the normalized `21`-task count.
+- Issue `#58` remains an umbrella `COMPLIANCE-01` tracking issue and is not included in the normalized `20`-task count.
 - Current open backlog by delivery wave:
-  - Wave 1 product gaps: `TASK-03-04`, `TASK-04-04`, `TASK-04-06`
+  - Wave 1 product gaps: `TASK-04-04`, `TASK-04-06`
   - Wave 2 platform/ops/reporting: `TASK-02-04`, `ADMIN-04`, `ADMIN-05`, `TASK-08-01`, `TASK-08-02`, `TASK-08-03`, `TASK-08-04`, `TASK-10-01`, `TASK-10-02`, `TASK-10-03`, `TASK-10-04`, `TASK-13-03`, `TASK-13-04`
   - Wave 3 phase-2 workspaces: `TASK-09-01`, `TASK-09-02`, `TASK-09-03`, `TASK-09-04`, `TASK-11-12`
 
 | Order | Task ID | Why Now |
 | --- | --- | --- |
-| A-1 | TASK-03-04 | Needed to turn the enriched universal candidate profile into recruiter-facing search/filter productivity |
-| A-2 | TASK-04-04 | Needed to define low-confidence scoring fallback behavior now that runtime verification is self-contained and shortlist scoring is operational locally |
-| A-3 | TASK-09-01 | Full manager workspace is now the next dependent slice because manager users currently see only the onboarding-progress dashboard on `/`, while broader team hiring/onboarding visibility remains deferred |
+| A-1 | TASK-04-04 | Needed to define low-confidence scoring fallback behavior now that runtime verification is self-contained and shortlist scoring is operational locally |
+| A-2 | TASK-09-01 | Full manager workspace is now the next dependent slice because manager users currently see only the onboarding-progress dashboard on `/`, while broader team hiring/onboarding visibility remains deferred |
 
 - Execution rule for follow-on interview work: keep the implemented `/` and `/candidate?interviewToken=...` topology, candidate-auth exclusion, and token-based public transport unchanged unless a separate ADR reopens that scope.
 

--- a/docs/testing/strategy.md
+++ b/docs/testing/strategy.md
@@ -156,7 +156,7 @@ apps/backend/tests/
 | Swagger bearer security scheme | N/A | OpenAPI contract check in auth integration suite | Swagger UI contains `Authorize` flow |
 | Admin APIs and audit hooks | `tests/unit/rbac/test_rbac.py` | `tests/integration/security/test_audit_enforcement.py` | `admin.staff:create` and `admin.employee_key:create` success/failure events |
 
-## Recruitment Domain Verification (TASK-03-01, TASK-03-02, TASK-02-01, TASK-02-02, TASK-03-03)
+## Recruitment Domain Verification (TASK-03-01, TASK-03-02, TASK-02-01, TASK-02-02, TASK-03-03, TASK-03-04)
 
 | Capability | Unit Coverage | Integration Coverage | Required Evidence |
 | --- | --- | --- | --- |
@@ -168,6 +168,7 @@ apps/backend/tests/
 | Async CV parsing lifecycle and retry-safe behavior (Celery executor) | `tests/unit/candidates/test_cv_parsing_worker.py` | `tests/integration/candidates/test_cv_parsing_jobs.py` | `queued/running/succeeded/failed` with bounded retries and public tracking-by-job-id contract |
 | Native PDF/DOCX text extraction before normalization (`TASK-03-07`) | `tests/unit/candidates/test_cv_text_extraction.py` + `tests/unit/candidates/test_cv_parsing_normalization.py` | `tests/integration/candidates/test_cv_parsing_jobs.py` + `tests/integration/scoring/test_match_scoring_api.py` | Real PDF/DOCX fixtures are extracted before normalization, broken/empty documents fail closed, and scoring preconditions stay unchanged |
 | Profession-agnostic parsed-profile enrichment (`TASK-03-08`) | `tests/unit/candidates/test_cv_profile_enrichment.py` + `tests/unit/candidates/test_cv_parsing_normalization.py` | `tests/integration/candidates/test_cv_parsing_jobs.py` + `tests/integration/scoring/test_match_scoring_api.py` | Parsed CV profile includes workplace history with held positions, education, normalized titles/dates, generic skills, indexed evidence, and scoring stays compatible with the richer payload |
+| Candidate search/filter list contract (`TASK-03-04`) | `tests/unit/candidates/test_candidate_search.py` | `tests/integration/candidates/test_candidate_api.py` | `GET /api/v1/candidates` supports recruiter-facing search, `analysis_ready`, skill/experience filters, pagination, vacancy-context latest stage enrichment, `in_pipeline_only`, and `422` for vacancy-scoped filters without `vacancy_id` |
 | RU/EN CV normalization and language detection (`TASK-03-05`) | `tests/unit/candidates/test_cv_parsing_normalization.py` | `tests/integration/candidates/test_cv_parsing_jobs.py` | `detected_language` and canonical profile fields are persisted after worker success |
 | Evidence traceability + analysis read contract (`TASK-03-06`) | `tests/unit/candidates/test_cv_parsing_normalization.py` (field-level evidence snippets/offsets) | `tests/integration/candidates/test_candidate_api.py` + `tests/integration/candidates/test_cv_parsing_jobs.py` | `GET /api/v1/candidates/{candidate_id}/cv/analysis` and `GET /api/v1/public/cv-parsing-jobs/{job_id}/analysis` return structured profile + evidence; pre-ready path returns `409` |
 | RBAC + audit coverage for recruitment endpoints | `tests/unit/rbac/test_rbac.py` | `tests/integration/security/test_audit_enforcement.py` + recruitment integration suites | `allowed/denied/success/failure` audit records in `audit_events` |
@@ -202,6 +203,7 @@ apps/backend/tests/
 | Capability | Unit Coverage | Integration/Smoke Coverage | Required Evidence |
 | --- | --- | --- | --- |
 | Vacancy list/create/edit UI on `/` | `apps/frontend/src/pages/HrDashboardPage.test.tsx` | `./scripts/smoke-compose.sh` creates vacancy through staff API for downstream browser use | staff user can create and update vacancy through typed API wrappers |
+| Server-filtered candidate selector, apply/reset filters, and pagination on `/` (`TASK-03-04`) | `apps/frontend/src/pages/HrDashboardPage.test.tsx` | backend integration: `apps/backend/tests/integration/candidates/test_candidate_api.py` | HR candidate selector uses server query params (`search`, `analysis_ready`, vacancy-scoped filters, `limit/offset`) and preserves selected-candidate context across pagination |
 | Candidate selection and pipeline transition append | `apps/frontend/src/pages/HrDashboardPage.test.tsx` | backend integration: `apps/backend/tests/integration/vacancies/test_vacancy_pipeline_api.py` | valid transition appends and invalid transition returns localized `422` |
 | Ordered transition history/timeline render | `apps/frontend/src/pages/HrDashboardPage.test.tsx` | backend integration: `apps/backend/tests/integration/vacancies/test_vacancy_pipeline_api.py` | timeline reflects append-only transition history for selected vacancy + candidate |
 | Offer lifecycle block on `/` | `apps/frontend/src/pages/HrDashboardPage.test.tsx` | backend offer/pipeline integration below | HR can save draft, mark sent, record accepted/declined, and see localized blockers in the existing workspace |


### PR DESCRIPTION
## Summary
- extend GET /api/v1/candidates with recruiter search/filter/pagination and vacancy-aware latest-stage context
- wire HrDashboardPage to server-filtered candidate queries with apply/reset controls and pagination
- regenerate OpenAPI freeze/types and update docs plus backend/frontend coverage

## Verification
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend ruff check .
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend pytest -q apps/backend/tests/unit/candidates apps/backend/tests/integration/candidates/test_candidate_api.py
- ./scripts/generate-openapi-frozen.sh
- ./scripts/check-openapi-freeze.sh
- npm --prefix apps/frontend run api:types:generate
- npm --prefix apps/frontend run api:types:check
- npm --prefix apps/frontend run test -- --run HrDashboardPage
- ./scripts/check-docs-structure.sh

Closes #91