### PR TITLE
feat(scoring): add low-confidence manual review fallback

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -49,6 +49,7 @@
 - `CV_MAX_SIZE_BYTES`
 - `CV_PARSING_MAX_ATTEMPTS`
 - `MATCH_SCORING_MAX_ATTEMPTS`
+- `SCORING_LOW_CONFIDENCE_THRESHOLD`
 - `MATCH_SCORING_MODEL_NAME`
 - `MATCH_SCORING_REQUEST_TIMEOUT_SECONDS`
 - `MATCH_SCORING_QUEUE_NAME`
@@ -108,3 +109,16 @@
   - `GET /api/v1/vacancies/{vacancy_id}`
   - `PATCH /api/v1/vacancies/{vacancy_id}`
   - `POST /api/v1/pipeline/transitions`
+- Match scoring:
+  - `POST /api/v1/vacancies/{vacancy_id}/match-scores`
+  - `GET /api/v1/vacancies/{vacancy_id}/match-scores`
+  - `GET /api/v1/vacancies/{vacancy_id}/match-scores/{candidate_id}`
+  - `MatchScoreResponse` remains additive and now includes:
+    `requires_manual_review`, `manual_review_reason`, and `confidence_threshold`.
+  - Manual-review semantics:
+    `requires_manual_review=true` only when `status="succeeded"` and persisted
+    `confidence < SCORING_LOW_CONFIDENCE_THRESHOLD`.
+  - Current fallback reason code:
+    `manual_review_reason="low_confidence"`.
+  - `confidence_threshold` is echoed only for succeeded score responses so the frontend can explain
+    why a score is treated as assistive-only.

--- a/apps/backend/src/hrm_backend/scoring/dependencies/scoring.py
+++ b/apps/backend/src/hrm_backend/scoring/dependencies/scoring.py
@@ -50,6 +50,7 @@ def get_match_scoring_adapter(settings: SettingsDependency) -> MatchScoringAdapt
 
 
 def get_match_scoring_service(
+    settings: SettingsDependency,
     session: SessionDependency,
     audit_service: AuditDependency,
 ) -> MatchScoringService:
@@ -61,6 +62,7 @@ def get_match_scoring_service(
         scoring_job_dao=MatchScoringJobDAO(session=session),
         score_artifact_dao=MatchScoreArtifactDAO(session=session),
         audit_service=audit_service,
+        low_confidence_threshold=settings.scoring_low_confidence_threshold,
     )
 
 
@@ -81,4 +83,3 @@ def get_match_scoring_worker_service(
         adapter=adapter,
         audit_service=audit_service,
     )
-

--- a/apps/backend/src/hrm_backend/scoring/schemas/match_scoring.py
+++ b/apps/backend/src/hrm_backend/scoring/schemas/match_scoring.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field
 
 MatchScoringStatus = Literal["queued", "running", "succeeded", "failed"]
+MatchScoreManualReviewReason = Literal["low_confidence"]
 
 
 class MatchScoreCreateRequest(BaseModel):
@@ -39,6 +40,9 @@ class MatchScoreResponse(BaseModel):
     status: MatchScoringStatus
     score: float | None = Field(default=None)
     confidence: float | None = Field(default=None)
+    requires_manual_review: bool = Field(default=False)
+    manual_review_reason: MatchScoreManualReviewReason | None = Field(default=None)
+    confidence_threshold: float | None = Field(default=None)
     summary: str | None = Field(default=None)
     matched_requirements: list[str] = Field(default_factory=list)
     missing_requirements: list[str] = Field(default_factory=list)
@@ -54,4 +58,3 @@ class MatchScoreListResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     items: list[MatchScoreResponse]
-

--- a/apps/backend/src/hrm_backend/scoring/services/manual_review_policy.py
+++ b/apps/backend/src/hrm_backend/scoring/services/manual_review_policy.py
@@ -1,0 +1,82 @@
+"""Policy helpers for recruiter-facing match score fallback decisions.
+
+This module evaluates whether a successful score should be treated only as an
+assistive signal and echoed back with additive manual-review metadata.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from hrm_backend.scoring.schemas.match_scoring import (
+    MatchScoreManualReviewReason,
+    MatchScoringStatus,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ManualReviewDecision:
+    """Immutable result of low-confidence fallback evaluation.
+
+    Attributes:
+        requires_manual_review:
+            Whether the recruiter should treat the score as assistive only.
+        manual_review_reason:
+            Stable reason code returned to API clients when manual review is required.
+        confidence_threshold:
+            Configured confidence threshold echoed only for succeeded responses.
+
+    Side Effects:
+        None.
+    """
+
+    requires_manual_review: bool
+    manual_review_reason: MatchScoreManualReviewReason | None
+    confidence_threshold: float | None
+
+
+def evaluate_manual_review_requirement(
+    *,
+    status: MatchScoringStatus,
+    confidence: float | None,
+    threshold: float,
+) -> ManualReviewDecision:
+    """Evaluate whether one score response requires manual review.
+
+    Args:
+        status:
+            Current persisted scoring lifecycle state.
+        confidence:
+            Optional model confidence stored on the score artifact.
+        threshold:
+            Configured strict low-confidence cutoff in the inclusive 0..1 range.
+
+    Returns:
+        ManualReviewDecision carrying API-ready manual-review flags and threshold echo.
+
+    Raises:
+        Does not raise exceptions.
+
+    Side Effects:
+        None.
+    """
+
+    if status != "succeeded":
+        return ManualReviewDecision(
+            requires_manual_review=False,
+            manual_review_reason=None,
+            confidence_threshold=None,
+        )
+
+    if confidence is None or confidence >= threshold:
+        return ManualReviewDecision(
+            requires_manual_review=False,
+            manual_review_reason=None,
+            confidence_threshold=threshold,
+        )
+
+    return ManualReviewDecision(
+        requires_manual_review=True,
+        manual_review_reason="low_confidence",
+        confidence_threshold=threshold,
+    )

--- a/apps/backend/src/hrm_backend/scoring/services/match_scoring_service.py
+++ b/apps/backend/src/hrm_backend/scoring/services/match_scoring_service.py
@@ -21,6 +21,9 @@ from hrm_backend.scoring.schemas.match_scoring import (
     MatchScoreListResponse,
     MatchScoreResponse,
 )
+from hrm_backend.scoring.services.manual_review_policy import (
+    evaluate_manual_review_requirement,
+)
 from hrm_backend.vacancies.dao.vacancy_dao import VacancyDAO
 
 
@@ -36,6 +39,7 @@ class MatchScoringService:
         scoring_job_dao: MatchScoringJobDAO,
         score_artifact_dao: MatchScoreArtifactDAO,
         audit_service: AuditService,
+        low_confidence_threshold: float,
     ) -> None:
         """Initialize scoring service dependencies."""
         self._vacancy_dao = vacancy_dao
@@ -44,6 +48,7 @@ class MatchScoringService:
         self._scoring_job_dao = scoring_job_dao
         self._score_artifact_dao = score_artifact_dao
         self._audit_service = audit_service
+        self._low_confidence_threshold = low_confidence_threshold
 
     def request_score(
         self,
@@ -158,12 +163,21 @@ class MatchScoringService:
     def _build_response(self, job: MatchScoringJob) -> MatchScoreResponse:
         """Map one job row and optional artifact into the UI contract."""
         artifact = self._score_artifact_dao.get_by_job_id(job.job_id)
+        confidence = None if artifact is None else artifact.confidence
+        decision = evaluate_manual_review_requirement(
+            status=job.status,  # type: ignore[arg-type]
+            confidence=confidence,
+            threshold=self._low_confidence_threshold,
+        )
         return MatchScoreResponse(
             vacancy_id=UUID(job.vacancy_id),
             candidate_id=UUID(job.candidate_id),
             status=job.status,  # type: ignore[arg-type]
             score=None if artifact is None else artifact.score,
-            confidence=None if artifact is None else artifact.confidence,
+            confidence=confidence,
+            requires_manual_review=decision.requires_manual_review,
+            manual_review_reason=decision.manual_review_reason,
+            confidence_threshold=decision.confidence_threshold,
             summary=None if artifact is None else artifact.summary,
             matched_requirements=[]
             if artifact is None
@@ -231,4 +245,3 @@ class MatchScoringService:
                 detail="CV analysis is not ready",
             )
         return document
-

--- a/apps/backend/src/hrm_backend/settings.py
+++ b/apps/backend/src/hrm_backend/settings.py
@@ -41,6 +41,8 @@ class AppSettings(BaseSettings):
         object_storage_sse_enabled: Whether uploads use SSE-S3 headers.
         cv_parsing_max_attempts: Maximum worker retries for CV parsing.
         match_scoring_max_attempts: Maximum worker retries for match scoring.
+        scoring_low_confidence_threshold:
+            Strict confidence cutoff below which succeeded scores require manual review.
         match_scoring_model_name: Ollama model identifier used for match scoring.
         match_scoring_request_timeout_seconds: Timeout for one Ollama scoring request.
         match_scoring_queue_name: Celery queue name used for match scoring tasks.
@@ -123,6 +125,12 @@ class AppSettings(BaseSettings):
     object_storage_sse_enabled: bool = Field(default=True, env="OBJECT_STORAGE_SSE_ENABLED")
     cv_parsing_max_attempts: int = Field(default=3, env="CV_PARSING_MAX_ATTEMPTS", gt=0)
     match_scoring_max_attempts: int = Field(default=3, env="MATCH_SCORING_MAX_ATTEMPTS", gt=0)
+    scoring_low_confidence_threshold: float = Field(
+        default=0.7,
+        env="SCORING_LOW_CONFIDENCE_THRESHOLD",
+        ge=0,
+        le=1,
+    )
     match_scoring_model_name: str = Field(
         default="llama3.2:latest",
         env="MATCH_SCORING_MODEL_NAME",

--- a/apps/backend/tests/integration/scoring/test_match_scoring_api.py
+++ b/apps/backend/tests/integration/scoring/test_match_scoring_api.py
@@ -155,6 +155,7 @@ def configured_app(sqlite_database_url: str):
         cv_max_size_bytes=4096,
         cv_parsing_max_attempts=2,
         match_scoring_max_attempts=2,
+        scoring_low_confidence_threshold=0.7,
     )
     storage = InMemoryCandidateStorage()
     adapter = FakeMatchScoringAdapter()
@@ -449,6 +450,17 @@ async def test_match_scoring_payload_propagates_evidence_and_can_list_latest_ent
         candidate_id=candidate_id,
     ) == "succeeded"
 
+    latest_create_response = await api_client.post(
+        f"/api/v1/vacancies/{vacancy_id}/match-scores",
+        json={"candidate_id": candidate_id},
+    )
+    assert latest_create_response.status_code == 200
+    latest_create_payload = latest_create_response.json()
+    assert latest_create_payload["status"] == "succeeded"
+    assert latest_create_payload["requires_manual_review"] is False
+    assert latest_create_payload["manual_review_reason"] is None
+    assert latest_create_payload["confidence_threshold"] == 0.7
+
     get_response = await api_client.get(
         f"/api/v1/vacancies/{vacancy_id}/match-scores/{candidate_id}"
     )
@@ -458,6 +470,9 @@ async def test_match_scoring_payload_propagates_evidence_and_can_list_latest_ent
     assert payload["candidate_id"] == candidate_id
     assert payload["status"] == "succeeded"
     assert payload["confidence"] == 0.84
+    assert payload["requires_manual_review"] is False
+    assert payload["manual_review_reason"] is None
+    assert payload["confidence_threshold"] == 0.7
     assert payload["summary"]
     assert payload["matched_requirements"] == ["Python", "REST APIs", "Docker"]
     assert payload["missing_requirements"] == ["Kubernetes"]
@@ -472,6 +487,55 @@ async def test_match_scoring_payload_propagates_evidence_and_can_list_latest_ent
     items = list_response.json()["items"]
     assert len(items) == 1
     assert items[0]["candidate_id"] == candidate_id
+    assert items[0]["requires_manual_review"] is False
+    assert items[0]["confidence_threshold"] == 0.7
+
+
+async def test_match_scoring_low_confidence_success_returns_manual_review_metadata(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
+    """Verify low-confidence succeeded scores return additive manual-review flags."""
+    _, settings, _, storage, adapter, database_url = configured_app
+    adapter.payload = adapter.payload.model_copy(update={"confidence": 0.69})
+    vacancy_id, candidate_id = await _create_scoring_fixture(api_client)
+    assert _run_parsing_worker_once(database_url, settings, storage) == "succeeded"
+
+    create_response = await api_client.post(
+        f"/api/v1/vacancies/{vacancy_id}/match-scores",
+        json={"candidate_id": candidate_id},
+    )
+    assert create_response.status_code == 200
+    assert create_response.json()["status"] == "queued"
+    assert _run_scoring_worker_once(
+        database_url,
+        settings,
+        adapter,
+        vacancy_id=vacancy_id,
+        candidate_id=candidate_id,
+    ) == "succeeded"
+
+    latest_create_response = await api_client.post(
+        f"/api/v1/vacancies/{vacancy_id}/match-scores",
+        json={"candidate_id": candidate_id},
+    )
+    assert latest_create_response.status_code == 200
+    latest_create_payload = latest_create_response.json()
+    assert latest_create_payload["status"] == "succeeded"
+    assert latest_create_payload["requires_manual_review"] is True
+    assert latest_create_payload["manual_review_reason"] == "low_confidence"
+    assert latest_create_payload["confidence_threshold"] == 0.7
+
+    get_response = await api_client.get(
+        f"/api/v1/vacancies/{vacancy_id}/match-scores/{candidate_id}"
+    )
+    assert get_response.status_code == 200
+    payload = get_response.json()
+    assert payload["status"] == "succeeded"
+    assert payload["confidence"] == 0.69
+    assert payload["requires_manual_review"] is True
+    assert payload["manual_review_reason"] == "low_confidence"
+    assert payload["confidence_threshold"] == 0.7
 
 
 async def test_match_scoring_accepts_enriched_parsed_profile_without_contract_changes(

--- a/apps/backend/tests/unit/scoring/test_manual_review_policy.py
+++ b/apps/backend/tests/unit/scoring/test_manual_review_policy.py
@@ -1,0 +1,71 @@
+"""Unit tests for low-confidence manual review scoring policy."""
+
+from hrm_backend.scoring.services.manual_review_policy import (
+    evaluate_manual_review_requirement,
+)
+
+
+def test_policy_requires_manual_review_below_threshold() -> None:
+    """Verify succeeded scores below the threshold require manual review."""
+    decision = evaluate_manual_review_requirement(
+        status="succeeded",
+        confidence=0.69,
+        threshold=0.7,
+    )
+
+    assert decision.requires_manual_review is True
+    assert decision.manual_review_reason == "low_confidence"
+    assert decision.confidence_threshold == 0.7
+
+
+def test_policy_does_not_require_manual_review_at_threshold() -> None:
+    """Verify threshold equality does not trigger the strict less-than fallback."""
+    decision = evaluate_manual_review_requirement(
+        status="succeeded",
+        confidence=0.7,
+        threshold=0.7,
+    )
+
+    assert decision.requires_manual_review is False
+    assert decision.manual_review_reason is None
+    assert decision.confidence_threshold == 0.7
+
+
+def test_policy_does_not_require_manual_review_above_threshold() -> None:
+    """Verify succeeded scores above the threshold remain on the normal path."""
+    decision = evaluate_manual_review_requirement(
+        status="succeeded",
+        confidence=0.84,
+        threshold=0.7,
+    )
+
+    assert decision.requires_manual_review is False
+    assert decision.manual_review_reason is None
+    assert decision.confidence_threshold == 0.7
+
+
+def test_policy_does_not_require_manual_review_for_non_succeeded_statuses() -> None:
+    """Verify queued/running/failed statuses never expose fallback metadata."""
+    for status in ("queued", "running", "failed"):
+        decision = evaluate_manual_review_requirement(
+            status=status,
+            confidence=0.1,
+            threshold=0.7,
+        )
+
+        assert decision.requires_manual_review is False
+        assert decision.manual_review_reason is None
+        assert decision.confidence_threshold is None
+
+
+def test_policy_does_not_require_manual_review_when_confidence_is_missing() -> None:
+    """Verify missing confidence on succeeded responses stays non-blocking."""
+    decision = evaluate_manual_review_requirement(
+        status="succeeded",
+        confidence=None,
+        threshold=0.7,
+    )
+
+    assert decision.requires_manual_review is False
+    assert decision.manual_review_reason is None
+    assert decision.confidence_threshold == 0.7

--- a/apps/frontend/src/api/generated/openapi-types.ts
+++ b/apps/frontend/src/api/generated/openapi-types.ts
@@ -2131,8 +2131,12 @@ export interface components {
             candidate_id: string;
             /** Confidence */
             confidence?: number | null;
+            /** Confidence Threshold */
+            confidence_threshold?: number | null;
             /** Evidence */
             evidence?: components["schemas"]["MatchScoreEvidenceResponse"][];
+            /** Manual Review Reason */
+            manual_review_reason?: "low_confidence" | null;
             /** Matched Requirements */
             matched_requirements?: string[];
             /** Missing Requirements */
@@ -2141,6 +2145,11 @@ export interface components {
             model_name?: string | null;
             /** Model Version */
             model_version?: string | null;
+            /**
+             * Requires Manual Review
+             * @default false
+             */
+            requires_manual_review: boolean;
             /** Score */
             score?: number | null;
             /** Scored At */

--- a/apps/frontend/src/app/i18n.ts
+++ b/apps/frontend/src/app/i18n.ts
@@ -274,6 +274,15 @@ const resources = {
           noEvidence: "No evidence snippets available.",
           noSummary: "No summary is available yet.",
           notAvailable: "n/a",
+          manualReview: {
+            title: "Manual review required",
+            generic:
+              "Treat this score as an assistive signal and complete manual review before making shortlist decisions.",
+            lowConfidence:
+              "AI confidence is low ({{confidence}}). Treat this score as an assistive signal and complete manual review.",
+            lowConfidenceWithThreshold:
+              "AI confidence {{confidence}} is below the review threshold {{threshold}}. Treat this score as an assistive signal and complete manual review.",
+          },
           failedHint:
             "Scoring failed. Run score again after checking worker health and Ollama availability.",
           status: {
@@ -1076,6 +1085,15 @@ const resources = {
           noEvidence: "Evidence snippets пока отсутствуют.",
           noSummary: "Summary пока недоступен.",
           notAvailable: "н/д",
+          manualReview: {
+            title: "Требуется ручная проверка",
+            generic:
+              "Используйте этот score только как вспомогательный сигнал и завершите ручную проверку перед решением по шортлисту.",
+            lowConfidence:
+              "Уверенность AI низкая ({{confidence}}). Используйте этот score только как вспомогательный сигнал и завершите ручную проверку.",
+            lowConfidenceWithThreshold:
+              "Уверенность AI {{confidence}} ниже порога проверки {{threshold}}. Используйте этот score только как вспомогательный сигнал и завершите ручную проверку.",
+          },
           failedHint:
             "Scoring завершился ошибкой. Повторите запуск после проверки worker и доступности Ollama.",
           status: {

--- a/apps/frontend/src/pages/HrDashboardPage.test.tsx
+++ b/apps/frontend/src/pages/HrDashboardPage.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import i18n from "i18next";
 
 import "../app/i18n";
 import type {
@@ -50,6 +51,9 @@ const SUCCESSFUL_MATCH_SCORE = {
   status: "succeeded",
   score: 91,
   confidence: 0.84,
+  requires_manual_review: false,
+  manual_review_reason: null,
+  confidence_threshold: 0.7,
   summary: "Strong shortlist fit based on Python, APIs, and Docker evidence.",
   matched_requirements: ["Python", "REST APIs", "Docker"],
   missing_requirements: ["Kubernetes"],
@@ -373,9 +377,10 @@ async function selectVacancyAndCandidate() {
 }
 
 describe("HrDashboardPage", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     fetchMock.mockReset();
     window.localStorage.clear();
+    await i18n.changeLanguage("ru");
   });
 
   afterEach(() => {
@@ -668,6 +673,9 @@ describe("HrDashboardPage", () => {
             status: "queued",
             score: null,
             confidence: null,
+            requires_manual_review: false,
+            manual_review_reason: null,
+            confidence_threshold: null,
             summary: null,
             matched_requirements: [],
             missing_requirements: [],
@@ -686,6 +694,9 @@ describe("HrDashboardPage", () => {
           status: "queued",
           score: null,
           confidence: null,
+          requires_manual_review: false,
+          manual_review_reason: null,
+          confidence_threshold: null,
           summary: null,
           matched_requirements: [],
           missing_requirements: [],
@@ -729,6 +740,9 @@ describe("HrDashboardPage", () => {
           status: "failed",
           score: null,
           confidence: null,
+          requires_manual_review: false,
+          manual_review_reason: null,
+          confidence_threshold: null,
           summary: null,
           matched_requirements: [],
           missing_requirements: [],
@@ -770,6 +784,33 @@ describe("HrDashboardPage", () => {
     });
   });
 
+  it("renders low-confidence manual review warning in russian without hiding score details", async () => {
+    window.localStorage.setItem("hrm_access_token", "access-token");
+    window.localStorage.setItem("hrm_user_role", "hr");
+
+    installHrWorkspaceFetchMock({
+      matchScoreGet: () =>
+        jsonResponse({
+          ...SUCCESSFUL_MATCH_SCORE,
+          confidence: 0.62,
+          requires_manual_review: true,
+          manual_review_reason: "low_confidence",
+          confidence_threshold: 0.7,
+        }),
+    });
+
+    renderHrDashboardPage();
+
+    await selectVacancyAndCandidate();
+
+    expect(await screen.findByText(/требуется ручная проверка/i)).toBeDefined();
+    expect(
+      screen.getByText(/уверенность ai 62% ниже порога проверки 70%/i),
+    ).toBeDefined();
+    expect(screen.getByText("91")).toBeDefined();
+    expect(screen.getByText("62%")).toBeDefined();
+  });
+
   it("renders confidence and explanation for an existing successful score", async () => {
     window.localStorage.setItem("hrm_access_token", "access-token");
     window.localStorage.setItem("hrm_user_role", "hr");
@@ -787,6 +828,37 @@ describe("HrDashboardPage", () => {
       screen.getByText(/strong shortlist fit based on python, apis, and docker evidence/i),
     ).toBeDefined();
     expect(screen.getByText(/model: llama3.2 \(latest\)/i)).toBeDefined();
+    expect(screen.queryByText(/требуется ручная проверка/i)).toBeNull();
+  });
+
+  it("renders low-confidence manual review warning in english", async () => {
+    window.localStorage.setItem("hrm_access_token", "access-token");
+    window.localStorage.setItem("hrm_user_role", "hr");
+    await i18n.changeLanguage("en");
+
+    installHrWorkspaceFetchMock({
+      matchScoreGet: () =>
+        jsonResponse({
+          ...SUCCESSFUL_MATCH_SCORE,
+          confidence: 0.62,
+          requires_manual_review: true,
+          manual_review_reason: "low_confidence",
+          confidence_threshold: 0.7,
+        }),
+    });
+
+    renderHrDashboardPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: /^select$/i }));
+    await screen.findByRole("option", { name: /john doe \(john@example.com\)/i });
+    fireEvent.change(screen.getByRole("combobox", { name: /^candidate$/i }), {
+      target: { value: CANDIDATE_ID },
+    });
+
+    expect(await screen.findByText(/manual review required/i)).toBeDefined();
+    expect(
+      screen.getByText(/ai confidence 62% is below the review threshold 70%/i),
+    ).toBeDefined();
   });
 
   it("creates an interview and renders queued then synced state with invite URL", async () => {

--- a/apps/frontend/src/pages/HrDashboardPage.tsx
+++ b/apps/frontend/src/pages/HrDashboardPage.tsx
@@ -1229,6 +1229,17 @@ export function HrDashboardPage() {
                     ) : null}
                   </Stack>
 
+                  {matchScore.status === "succeeded" && matchScore.requires_manual_review ? (
+                    <Alert severity="warning">
+                      <Typography variant="subtitle2">
+                        {t("hrDashboard.shortlist.manualReview.title")}
+                      </Typography>
+                      <Typography variant="body2">
+                        {buildMatchScoreManualReviewMessage(matchScore, t)}
+                      </Typography>
+                    </Alert>
+                  ) : null}
+
                   {matchScore.status === "failed" ? (
                     <Alert severity="warning">{t("hrDashboard.shortlist.failedHint")}</Alert>
                   ) : null}
@@ -2292,6 +2303,28 @@ function formatConfidence(
     return t("hrDashboard.shortlist.notAvailable");
   }
   return `${Math.round(value * 100)}%`;
+}
+
+function buildMatchScoreManualReviewMessage(
+  matchScore: MatchScoreResponse,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): string {
+  if (matchScore.manual_review_reason === "low_confidence") {
+    if (
+      matchScore.confidence_threshold !== null
+      && matchScore.confidence_threshold !== undefined
+    ) {
+      return t("hrDashboard.shortlist.manualReview.lowConfidenceWithThreshold", {
+        confidence: formatConfidence(matchScore.confidence, t),
+        threshold: formatConfidence(matchScore.confidence_threshold, t),
+      });
+    }
+    return t("hrDashboard.shortlist.manualReview.lowConfidence", {
+      confidence: formatConfidence(matchScore.confidence, t),
+    });
+  }
+
+  return t("hrDashboard.shortlist.manualReview.generic");
 }
 
 function formatAverageScore(

--- a/docs/api/openapi.frozen.json
+++ b/docs/api/openapi.frozen.json
@@ -2522,12 +2522,35 @@
             ],
             "title": "Confidence"
           },
+          "confidence_threshold": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence Threshold"
+          },
           "evidence": {
             "items": {
               "$ref": "#/components/schemas/MatchScoreEvidenceResponse"
             },
             "title": "Evidence",
             "type": "array"
+          },
+          "manual_review_reason": {
+            "anyOf": [
+              {
+                "const": "low_confidence",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Manual Review Reason"
           },
           "matched_requirements": {
             "items": {
@@ -2564,6 +2587,11 @@
               }
             ],
             "title": "Model Version"
+          },
+          "requires_manual_review": {
+            "default": false,
+            "title": "Requires Manual Review",
+            "type": "boolean"
           },
           "score": {
             "anyOf": [

--- a/docs/project/tasks.md
+++ b/docs/project/tasks.md
@@ -32,6 +32,7 @@
 | TASK-11-11 | implemented/local-baseline | Compose browser smoke covers both staff login and public candidate apply journeys through headless Chrome |
 | TASK-04-01/02/03 | implemented/local-scoring-slice | Dedicated `hrm_backend/scoring` package, Ollama adapter, async scoring jobs/artifacts, and frozen scoring API contract are present in repo with unit and integration coverage |
 | TASK-04-05 | implemented/local-scoring-slice | Score payloads and HR shortlist review now expose matched requirements, missing competencies, and evidence snippets from parsed CV analysis |
+| TASK-04-04 | implemented/local-low-confidence-fallback-slice | Scoring responses now expose additive manual-review metadata driven by configurable `SCORING_LOW_CONFIDENCE_THRESHOLD`, and `/` renders a localized warning while preserving score details |
 | TASK-11-07 | implemented/local-scoring-slice | `/` now includes shortlist review with `Run score`, polling, confidence/summary card, requirements delta, evidence, and localized `409/403/404/422` errors |
 | TASK-11-10 | implemented/local-observability-slice | Frontend Sentry now tags `/`, `/candidate`, `/login`, `/admin`, `/admin/staff`, and `/admin/employee-keys`; shared HTTP capture, render boundary, and release/env tracing config are present in repo with frontend unit coverage |
 | TASK-13-01/02 | implemented/local-compliance-slice | Legal-controls matrix now maps article-level obligations to current repo-backed controls and evidence registry entries with owners, verification sources, and update triggers |
@@ -66,7 +67,8 @@
   #107 (`0d9c787`), and this backlog snapshot is synchronized to the merged `main` state while
   keeping the existing route tree and runtime topology unchanged.
 - The scoring/shortlist-review slice (`TASK-04-01/02/03 + TASK-11-07`) is now implemented in repo as one vertical delivery unit.
-- Scoring explainability (`TASK-04-05`) is now implemented in the same slice; remaining AI backlog is the low-confidence fallback and the quality harness.
+- `TASK-04-04` is now implemented in repo as an additive fallback slice: succeeded scores below `SCORING_LOW_CONFIDENCE_THRESHOLD` return manual-review metadata, and the existing shortlist review on `/` surfaces a localized warning without hiding score artifacts.
+- Scoring explainability (`TASK-04-05`) is now implemented in the same slice; the remaining scoring-specific AI backlog is the quality harness (`TASK-04-06`).
 - The compliance follow-on slice (`TASK-13-01/02`) is now implemented in repo as documentation and evidence-model work only; no runtime/API/routing changes were introduced.
 - The dedicated planning pass for `TASK-11-08` is implemented in repo as one backend+frontend interview slice without reopening auth, CORS, or the public candidate transport model.
 - Interview planning and Google Calendar sync baseline (`TASK-05-01/02`) are now implemented in repo; remaining interview backlog starts after the already-landed scheduling/registration and fairness slices.

--- a/docs/testing/strategy.md
+++ b/docs/testing/strategy.md
@@ -219,6 +219,7 @@ apps/backend/tests/
 | Prompt compatibility with enriched parsed CV profile | `apps/backend/tests/unit/scoring/test_prompt.py` | `apps/backend/tests/integration/scoring/test_match_scoring_api.py` | scoring prompt/build flow stays stable when parsed CV JSON includes workplaces, education, titles, dates, and generic skills |
 | Reject scoring when parsed CV analysis is not ready | N/A | `apps/backend/tests/integration/scoring/test_match_scoring_api.py` | `POST /api/v1/vacancies/{vacancy_id}/match-scores` returns `409` without silent fallback |
 | Score payload shape and evidence propagation | `apps/backend/tests/unit/scoring/test_ollama_adapter.py` | `apps/backend/tests/integration/scoring/test_match_scoring_api.py` | latest score response includes `score`, `confidence`, `summary`, requirements, evidence, model metadata, and `scored_at` |
+| Low-confidence fallback policy and threshold boundary (`TASK-04-04`) | `apps/backend/tests/unit/scoring/test_manual_review_policy.py` | `apps/backend/tests/integration/scoring/test_match_scoring_api.py` | succeeded scores below threshold return `requires_manual_review=true`, `manual_review_reason="low_confidence"`, and echoed `confidence_threshold`, while `confidence == threshold`, non-succeeded states, and missing confidence do not fallback |
 
 ### Frontend
 | Capability | Unit Coverage | Integration/Smoke Coverage | Required Evidence |
@@ -227,6 +228,7 @@ apps/backend/tests/
 | Failed scoring job render | `apps/frontend/src/pages/HrDashboardPage.test.tsx` | backend integration above | failed state is visible and recoverable in UI |
 | Localized `409` when CV analysis is not ready | `apps/frontend/src/pages/HrDashboardPage.test.tsx` | backend integration above | RU/EN-readable not-ready error is rendered |
 | Confidence/explanation rendering | `apps/frontend/src/pages/HrDashboardPage.test.tsx` | backend integration above | confidence, summary, matched requirements, missing requirements, and evidence sections are rendered |
+| Low-confidence manual-review warning (`TASK-04-04`) | `apps/frontend/src/pages/HrDashboardPage.test.tsx` | backend integration above | localized RU/EN warning renders for low-confidence succeeded scores without hiding score cards, while high-confidence responses do not show the warning |
 
 ### Acceptance Rules
 - Freeze OpenAPI and update generated frontend types in the same change.


### PR DESCRIPTION
## Summary
- add backend low-confidence fallback policy for scoring responses
- expose additive manual-review fields in the scoring API contract and frozen OpenAPI
- render localized warning state in the existing HR shortlist review without hiding score details

## Linked Tasks
- TASK-04-04
- Closes #92

## Verification
- [x] Backend lint passed (UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend ruff check .)
- [x] Backend tests passed (UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend pytest -q apps/backend/tests/unit/scoring apps/backend/tests/integration/scoring/test_match_scoring_api.py)
- [x] Frontend tests passed (npm --prefix apps/frontend run test -- --run HrDashboardPage)
- [x] Docs check passed (./scripts/check-docs-structure.sh)
- [x] OpenAPI freeze and frontend type generation passed
- [x] docker compose up -d --build completed with local UI and Swagger availability checks

## Definition of Done
- [x] Acceptance criteria for linked TASK-* are met.
- [x] Tests updated for new and changed behavior.
- [x] Public APIs, modules, classes, and functions include detailed docstrings.
- [x] Only essential non-obvious comments are added.
- [x] Architecture or flow diagrams did not require changes for this additive slice.
- [x] Documentation updated in the same PR.
- [x] Security and compliance impact assessed.
- [x] Best practices from docs/engineering/best-practices.md followed.

## Risks and Follow-ups
- Risk: the default threshold is set to 0.7 and may need product calibration later.
- Follow-up: after merge, verify issue auto-close and sync docs/project/tasks.md to final merged evidence.