### PR TITLE
docs(project): sync TASK-04-04 closeout evidence

### DIFF
--- a/docs/project/tasks.md
+++ b/docs/project/tasks.md
@@ -32,7 +32,7 @@
 | TASK-11-11 | implemented/local-baseline | Compose browser smoke covers both staff login and public candidate apply journeys through headless Chrome |
 | TASK-04-01/02/03 | implemented/local-scoring-slice | Dedicated `hrm_backend/scoring` package, Ollama adapter, async scoring jobs/artifacts, and frozen scoring API contract are present in repo with unit and integration coverage |
 | TASK-04-05 | implemented/local-scoring-slice | Score payloads and HR shortlist review now expose matched requirements, missing competencies, and evidence snippets from parsed CV analysis |
-| TASK-04-04 | implemented/local-low-confidence-fallback-slice | Scoring responses now expose additive manual-review metadata driven by configurable `SCORING_LOW_CONFIDENCE_THRESHOLD`, and `/` renders a localized warning while preserving score details |
+| TASK-04-04 | done/closed | GitHub issue #92 closed; merged in `main` via PR #109 (`c60b48b`) with additive low-confidence manual-review metadata, configurable `SCORING_LOW_CONFIDENCE_THRESHOLD`, and localized shortlist warning UX that preserves score details |
 | TASK-11-07 | implemented/local-scoring-slice | `/` now includes shortlist review with `Run score`, polling, confidence/summary card, requirements delta, evidence, and localized `409/403/404/422` errors |
 | TASK-11-10 | implemented/local-observability-slice | Frontend Sentry now tags `/`, `/candidate`, `/login`, `/admin`, `/admin/staff`, and `/admin/employee-keys`; shared HTTP capture, render boundary, and release/env tracing config are present in repo with frontend unit coverage |
 | TASK-13-01/02 | implemented/local-compliance-slice | Legal-controls matrix now maps article-level obligations to current repo-backed controls and evidence registry entries with owners, verification sources, and update triggers |
@@ -67,7 +67,7 @@
   #107 (`0d9c787`), and this backlog snapshot is synchronized to the merged `main` state while
   keeping the existing route tree and runtime topology unchanged.
 - The scoring/shortlist-review slice (`TASK-04-01/02/03 + TASK-11-07`) is now implemented in repo as one vertical delivery unit.
-- `TASK-04-04` is now implemented in repo as an additive fallback slice: succeeded scores below `SCORING_LOW_CONFIDENCE_THRESHOLD` return manual-review metadata, and the existing shortlist review on `/` surfaces a localized warning without hiding score artifacts.
+- `TASK-04-04` post-merge closeout is complete: GitHub issue `#92` closed automatically from PR #109 (`c60b48b`), and this backlog snapshot is synchronized to the merged `main` state while keeping the existing route tree and runtime topology unchanged.
 - Scoring explainability (`TASK-04-05`) is now implemented in the same slice; the remaining scoring-specific AI backlog is the quality harness (`TASK-04-06`).
 - The compliance follow-on slice (`TASK-13-01/02`) is now implemented in repo as documentation and evidence-model work only; no runtime/API/routing changes were introduced.
 - The dedicated planning pass for `TASK-11-08` is implemented in repo as one backend+frontend interview slice without reopening auth, CORS, or the public candidate transport model.
@@ -101,19 +101,18 @@
 
 ## Normalized Open Backlog Snapshot
 
-- Normalized open backlog count: `20` tasks.
+- Normalized open backlog count: `19` tasks.
 - This count excludes tasks already implemented in repo but retained in the historical planning tables below for lineage.
 - Repo backlog state now excludes `TASK-12-02`, and GitHub issue `#85` is closed following PR #105 (`a67bb8c`).
-- Issue `#58` remains an umbrella `COMPLIANCE-01` tracking issue and is not included in the normalized `20`-task count.
+- Issue `#58` remains an umbrella `COMPLIANCE-01` tracking issue and is not included in the normalized `19`-task count.
 - Current open backlog by delivery wave:
-  - Wave 1 product gaps: `TASK-04-04`, `TASK-04-06`
+  - Wave 1 product gaps: `TASK-04-06`
   - Wave 2 platform/ops/reporting: `TASK-02-04`, `ADMIN-04`, `ADMIN-05`, `TASK-08-01`, `TASK-08-02`, `TASK-08-03`, `TASK-08-04`, `TASK-10-01`, `TASK-10-02`, `TASK-10-03`, `TASK-10-04`, `TASK-13-03`, `TASK-13-04`
   - Wave 3 phase-2 workspaces: `TASK-09-01`, `TASK-09-02`, `TASK-09-03`, `TASK-09-04`, `TASK-11-12`
 
 | Order | Task ID | Why Now |
 | --- | --- | --- |
-| A-1 | TASK-04-04 | Needed to define low-confidence scoring fallback behavior now that runtime verification is self-contained and shortlist scoring is operational locally |
-| A-2 | TASK-09-01 | Full manager workspace is now the next dependent slice because manager users currently see only the onboarding-progress dashboard on `/`, while broader team hiring/onboarding visibility remains deferred |
+| A-1 | TASK-09-01 | Full manager workspace is now the next dependent slice because manager users currently see only the onboarding-progress dashboard on `/`, while broader team hiring/onboarding visibility remains deferred |
 
 - Execution rule for follow-on interview work: keep the implemented `/` and `/candidate?interviewToken=...` topology, candidate-auth exclusion, and token-based public transport unchanged unless a separate ADR reopens that scope.
 


### PR DESCRIPTION
## Summary
- sync docs/project/tasks.md after PR #109 merge
- record final TASK-04-04 status as done/closed with issue and merge evidence
- remove TASK-04-04 from the normalized open backlog snapshot

## Linked Tasks
- TASK-04-04

## Verification
- [x] Docs check passed (./scripts/check-docs-structure.sh)
- [x] GitHub verification completed for PR #109 merge commit and issue #92 auto-close

## Definition of Done
- [x] Post-merge closeout is reflected in docs/project/tasks.md.
- [x] No architecture, API, or runtime behavior changed.
- [x] Documentation remains internally consistent.

## Risks and Follow-ups
- Risk: none beyond normal docs drift if future backlog updates skip the same snapshot section.
- Follow-up: after this PR merges, run the required docker compose refresh one more time and confirm UI and Swagger are reachable.