### PR TITLE
TASK-09-04: add role-specific in-app notifications and digests

### DIFF
--- a/apps/backend/alembic/env.py
+++ b/apps/backend/alembic/env.py
@@ -25,6 +25,7 @@ from hrm_backend.employee.models.template import (  # noqa: F401
 from hrm_backend.interviews.models.calendar_binding import InterviewCalendarBinding  # noqa: F401
 from hrm_backend.interviews.models.feedback import InterviewFeedback  # noqa: F401
 from hrm_backend.interviews.models.interview import Interview  # noqa: F401
+from hrm_backend.notifications.models.notification import Notification  # noqa: F401
 from hrm_backend.scoring.models.score_artifact import MatchScoreArtifact  # noqa: F401
 from hrm_backend.scoring.models.scoring_job import MatchScoringJob  # noqa: F401
 from hrm_backend.vacancies.models.offer import Offer  # noqa: F401

--- a/apps/backend/alembic/versions/20260313_000020_notifications.py
+++ b/apps/backend/alembic/versions/20260313_000020_notifications.py
@@ -1,0 +1,61 @@
+"""Create recipient-scoped in-app notifications table."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260313000020"
+down_revision = "20260312000019"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the notifications table and supporting indexes."""
+    op.create_table(
+        "notifications",
+        sa.Column("notification_id", sa.String(length=36), nullable=False),
+        sa.Column("recipient_staff_id", sa.Uuid(as_uuid=False), nullable=False),
+        sa.Column("recipient_role", sa.String(length=32), nullable=False),
+        sa.Column("kind", sa.String(length=64), nullable=False),
+        sa.Column("source_type", sa.String(length=64), nullable=False),
+        sa.Column("source_id", sa.String(length=36), nullable=False),
+        sa.Column("dedupe_key", sa.String(length=255), nullable=False),
+        sa.Column("title", sa.String(length=256), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("payload_json", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("read_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["recipient_staff_id"],
+            ["staff_accounts.staff_id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("notification_id"),
+        sa.UniqueConstraint(
+            "recipient_staff_id",
+            "dedupe_key",
+            name="ux_notifications_recipient_dedupe",
+        ),
+    )
+    op.create_index(
+        "ix_notifications_recipient_created_at",
+        "notifications",
+        ["recipient_staff_id", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_notifications_recipient_read_at",
+        "notifications",
+        ["recipient_staff_id", "read_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop the notifications table and supporting indexes."""
+    op.drop_index("ix_notifications_recipient_read_at", table_name="notifications")
+    op.drop_index("ix_notifications_recipient_created_at", table_name="notifications")
+    op.drop_table("notifications")

--- a/apps/backend/src/hrm_backend/auth/infra/postgres/staff_account_dao.py
+++ b/apps/backend/src/hrm_backend/auth/infra/postgres/staff_account_dao.py
@@ -76,3 +76,22 @@ class StaffAccountDAO:
             .all()
         )
         return {row.staff_id: row for row in rows}
+
+    def list_active_by_role(self, role: str) -> list[StaffAccount]:
+        """Load active staff accounts for one role in deterministic order.
+
+        Args:
+            role: Staff role claim used for recipient resolution.
+
+        Returns:
+            list[StaffAccount]: Active staff accounts for the requested role.
+        """
+        return list(
+            self._session.query(StaffAccount)
+            .filter(
+                StaffAccount.role == role,
+                StaffAccount.is_active.is_(True),
+            )
+            .order_by(StaffAccount.login.asc(), StaffAccount.staff_id.asc())
+            .all()
+        )

--- a/apps/backend/src/hrm_backend/employee/dao/onboarding_task_dao.py
+++ b/apps/backend/src/hrm_backend/employee/dao/onboarding_task_dao.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from hrm_backend.employee.models.onboarding import OnboardingTask
@@ -117,3 +118,33 @@ class OnboardingTaskDAO:
 
         self._session.flush()
         return entity
+
+    def list_visible_to_actor(
+        self,
+        *,
+        actor_role: str,
+        actor_staff_id: str,
+    ) -> list[OnboardingTask]:
+        """Load onboarding tasks visible to one manager/accountant actor.
+
+        Args:
+            actor_role: Current actor role used for role-assigned task visibility.
+            actor_staff_id: Current actor staff subject used for explicit assignment visibility.
+
+        Returns:
+            list[OnboardingTask]: Visible onboarding tasks ordered by latest update.
+        """
+        return list(
+            self._session.query(OnboardingTask)
+            .filter(
+                or_(
+                    OnboardingTask.assigned_role == actor_role,
+                    OnboardingTask.assigned_staff_id == actor_staff_id,
+                )
+            )
+            .order_by(
+                OnboardingTask.updated_at.desc(),
+                OnboardingTask.task_id.asc(),
+            )
+            .all()
+        )

--- a/apps/backend/src/hrm_backend/employee/dependencies/employee.py
+++ b/apps/backend/src/hrm_backend/employee/dependencies/employee.py
@@ -30,10 +30,16 @@ from hrm_backend.employee.services.onboarding_task_service import OnboardingTask
 from hrm_backend.employee.services.onboarding_template_service import (
     OnboardingTemplateService,
 )
+from hrm_backend.notifications.dependencies.notifications import get_notification_service
+from hrm_backend.notifications.services.notification_service import NotificationService
 
 SessionDependency = Annotated[Session, Depends(get_db_session)]
 AuditDependency = Annotated[AuditService, Depends(get_audit_service)]
 StaffAccountDAODependency = Annotated[StaffAccountDAO, Depends(get_staff_account_dao)]
+NotificationServiceDependency = Annotated[
+    NotificationService,
+    Depends(get_notification_service),
+]
 
 
 def get_hire_conversion_service(session: SessionDependency) -> HireConversionService:
@@ -51,6 +57,7 @@ def get_hire_conversion_service(session: SessionDependency) -> HireConversionSer
 def get_employee_profile_service(
     session: SessionDependency,
     audit_service: AuditDependency,
+    notification_service: NotificationServiceDependency,
 ) -> EmployeeProfileService:
     """Build employee profile service for the current request session.
 
@@ -71,6 +78,8 @@ def get_employee_profile_service(
             run_dao=OnboardingRunDAO(session=session),
             task_dao=OnboardingTaskDAO(session=session),
             template_dao=OnboardingTemplateDAO(session=session),
+            profile_dao=EmployeeProfileDAO(session=session),
+            notification_service=notification_service,
             audit_service=audit_service,
         ),
         audit_service=audit_service,
@@ -100,6 +109,7 @@ def get_onboarding_template_service(
 def get_onboarding_task_service(
     session: SessionDependency,
     audit_service: AuditDependency,
+    notification_service: NotificationServiceDependency,
 ) -> OnboardingTaskService:
     """Build onboarding task service for the current request session.
 
@@ -115,6 +125,8 @@ def get_onboarding_task_service(
         run_dao=OnboardingRunDAO(session=session),
         task_dao=OnboardingTaskDAO(session=session),
         template_dao=OnboardingTemplateDAO(session=session),
+        profile_dao=EmployeeProfileDAO(session=session),
+        notification_service=notification_service,
         audit_service=audit_service,
     )
 

--- a/apps/backend/src/hrm_backend/employee/services/onboarding_task_service.py
+++ b/apps/backend/src/hrm_backend/employee/services/onboarding_task_service.py
@@ -10,10 +10,12 @@ from sqlalchemy.orm import Session
 
 from hrm_backend.audit.services.audit_service import AuditService, actor_from_auth_context
 from hrm_backend.auth.schemas.token_claims import AuthContext
+from hrm_backend.employee.dao.employee_profile_dao import EmployeeProfileDAO
 from hrm_backend.employee.dao.onboarding_run_dao import OnboardingRunDAO
 from hrm_backend.employee.dao.onboarding_task_dao import OnboardingTaskDAO
 from hrm_backend.employee.dao.onboarding_template_dao import OnboardingTemplateDAO
 from hrm_backend.employee.models.onboarding import OnboardingRun, OnboardingTask
+from hrm_backend.employee.models.profile import EmployeeProfile
 from hrm_backend.employee.models.template import OnboardingTemplate, OnboardingTemplateItem
 from hrm_backend.employee.schemas.onboarding import (
     OnboardingTaskCreate,
@@ -22,6 +24,7 @@ from hrm_backend.employee.schemas.onboarding import (
     OnboardingTaskUpdateRequest,
 )
 from hrm_backend.employee.utils.onboarding import ONBOARDING_TASK_STATUS_COMPLETED
+from hrm_backend.notifications.services.notification_service import NotificationService
 
 ONBOARDING_RUN_NOT_FOUND = "onboarding_run_not_found"
 ONBOARDING_TASK_NOT_FOUND = "onboarding_task_not_found"
@@ -43,6 +46,8 @@ class OnboardingTaskService:
         run_dao: OnboardingRunDAO,
         task_dao: OnboardingTaskDAO,
         template_dao: OnboardingTemplateDAO,
+        profile_dao: EmployeeProfileDAO,
+        notification_service: NotificationService,
         audit_service: AuditService,
     ) -> None:
         """Initialize onboarding task service dependencies.
@@ -52,12 +57,16 @@ class OnboardingTaskService:
             run_dao: DAO for onboarding run lookups.
             task_dao: DAO for onboarding task rows.
             template_dao: DAO for active onboarding template resolution.
+            profile_dao: DAO for employee profile lookups used in notification copy.
+            notification_service: In-app notification service for assignment changes.
             audit_service: Audit service for success and failure traces.
         """
         self._session = session
         self._run_dao = run_dao
         self._task_dao = task_dao
         self._template_dao = template_dao
+        self._profile_dao = profile_dao
+        self._notification_service = notification_service
         self._audit_service = audit_service
 
     def build_create_payloads(
@@ -176,6 +185,8 @@ class OnboardingTaskService:
                 detail=ONBOARDING_TASK_NOT_FOUND,
             )
 
+        previous_assigned_role = entity.assigned_role
+        previous_assigned_staff_id = entity.assigned_staff_id
         if "status" in payload.model_fields_set:
             entity.status = payload.status or entity.status
             if payload.status == ONBOARDING_TASK_STATUS_COMPLETED:
@@ -191,7 +202,17 @@ class OnboardingTaskService:
         if "due_at" in payload.model_fields_set:
             entity.due_at = payload.due_at
 
-        updated = self._task_dao.update_task(entity=entity)
+        updated = self._task_dao.update_task(entity=entity, commit=False)
+        profile = self._profile_dao.get_by_id(run.employee_id)
+        self._notification_service.emit_onboarding_task_assignment_notifications(
+            task=updated,
+            employee_id=run.employee_id,
+            employee_full_name=_resolve_employee_full_name(profile),
+            previous_assigned_role=previous_assigned_role,
+            previous_assigned_staff_id=previous_assigned_staff_id,
+        )
+        self._session.commit()
+        self._session.refresh(updated)
         self._audit_success(
             action="onboarding_task:update",
             auth_context=auth_context,
@@ -322,3 +343,11 @@ def _to_task_response(entity: OnboardingTask) -> OnboardingTaskResponse:
         created_at=entity.created_at,
         updated_at=entity.updated_at,
     )
+
+
+def _resolve_employee_full_name(profile: EmployeeProfile | None) -> str:
+    """Resolve a human-readable employee label for notification copy."""
+    if profile is None:
+        return "employee"
+    full_name = f"{profile.first_name} {profile.last_name}".strip()
+    return full_name or "employee"

--- a/apps/backend/src/hrm_backend/main.py
+++ b/apps/backend/src/hrm_backend/main.py
@@ -15,6 +15,7 @@ from hrm_backend.employee.routers.v1 import router as employee_router
 from hrm_backend.finance.routers.v1 import router as finance_router
 from hrm_backend.interviews.routers.v1 import public_router as interview_public_router
 from hrm_backend.interviews.routers.v1 import router as interview_router
+from hrm_backend.notifications.routers.v1 import router as notification_router
 from hrm_backend.rbac import ROLE_PERMISSION_MATRIX
 from hrm_backend.scoring.routers.v1 import router as scoring_router
 from hrm_backend.settings import get_settings
@@ -35,6 +36,7 @@ app.include_router(candidate_router)
 app.include_router(candidate_public_router)
 app.include_router(employee_router)
 app.include_router(finance_router)
+app.include_router(notification_router)
 app.include_router(vacancy_router)
 app.include_router(scoring_router)
 app.include_router(interview_router)

--- a/apps/backend/src/hrm_backend/notifications/__init__.py
+++ b/apps/backend/src/hrm_backend/notifications/__init__.py
@@ -1,0 +1,1 @@
+"""Platform package for in-app notifications and server-computed digests."""

--- a/apps/backend/src/hrm_backend/notifications/dao/__init__.py
+++ b/apps/backend/src/hrm_backend/notifications/dao/__init__.py
@@ -1,0 +1,5 @@
+"""Notification DAO exports."""
+
+from hrm_backend.notifications.dao.notification_dao import NotificationDAO
+
+__all__ = ["NotificationDAO"]

--- a/apps/backend/src/hrm_backend/notifications/dao/notification_dao.py
+++ b/apps/backend/src/hrm_backend/notifications/dao/notification_dao.py
@@ -1,0 +1,154 @@
+"""Data-access helpers for in-app notification persistence."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+
+from sqlalchemy.orm import Session
+
+from hrm_backend.notifications.models.notification import Notification
+from hrm_backend.notifications.schemas.notification import NotificationCreate
+
+
+class NotificationDAO:
+    """Persist and query recipient-scoped in-app notifications."""
+
+    def __init__(self, session: Session) -> None:
+        """Initialize DAO with an active SQLAlchemy session.
+
+        Args:
+            session: Active request or job session.
+        """
+        self._session = session
+
+    def get_by_id_for_recipient(
+        self,
+        *,
+        notification_id: str,
+        recipient_staff_id: str,
+    ) -> Notification | None:
+        """Load one notification only when it belongs to the requested recipient."""
+        return (
+            self._session.query(Notification)
+            .filter(
+                Notification.notification_id == notification_id,
+                Notification.recipient_staff_id == recipient_staff_id,
+            )
+            .first()
+        )
+
+    def list_for_recipient(
+        self,
+        *,
+        recipient_staff_id: str,
+        unread_only: bool,
+        limit: int,
+        offset: int,
+    ) -> list[Notification]:
+        """List notifications for one recipient with optional unread-only filtering."""
+        query = self._session.query(Notification).filter(
+            Notification.recipient_staff_id == recipient_staff_id,
+        )
+        if unread_only:
+            query = query.filter(Notification.read_at.is_(None))
+        return list(
+            query.order_by(
+                Notification.created_at.desc(),
+                Notification.notification_id.desc(),
+            )
+            .offset(offset)
+            .limit(limit)
+            .all()
+        )
+
+    def count_all_for_recipient(self, *, recipient_staff_id: str) -> int:
+        """Count all notifications stored for one recipient."""
+        return (
+            self._session.query(Notification)
+            .filter(Notification.recipient_staff_id == recipient_staff_id)
+            .count()
+        )
+
+    def count_unread_for_recipient(self, *, recipient_staff_id: str) -> int:
+        """Count unread notifications stored for one recipient."""
+        return (
+            self._session.query(Notification)
+            .filter(
+                Notification.recipient_staff_id == recipient_staff_id,
+                Notification.read_at.is_(None),
+            )
+            .count()
+        )
+
+    def create_notifications(
+        self,
+        *,
+        payloads: Sequence[NotificationCreate],
+        commit: bool = True,
+    ) -> list[Notification]:
+        """Insert one or more notification rows while skipping existing dedupe pairs."""
+        if not payloads:
+            return []
+
+        dedupe_keys_by_recipient: dict[str, set[str]] = defaultdict(set)
+        for payload in payloads:
+            dedupe_keys_by_recipient[str(payload.recipient_staff_id)].add(payload.dedupe_key)
+
+        existing_pairs: set[tuple[str, str]] = set()
+        for recipient_staff_id, dedupe_keys in dedupe_keys_by_recipient.items():
+            rows = (
+                self._session.query(Notification.dedupe_key)
+                .filter(
+                    Notification.recipient_staff_id == recipient_staff_id,
+                    Notification.dedupe_key.in_(sorted(dedupe_keys)),
+                )
+                .all()
+            )
+            existing_pairs.update((recipient_staff_id, dedupe_key) for (dedupe_key,) in rows)
+
+        entities = []
+        for payload in payloads:
+            recipient_staff_id = str(payload.recipient_staff_id)
+            dedupe_pair = (recipient_staff_id, payload.dedupe_key)
+            if dedupe_pair in existing_pairs:
+                continue
+            entity = Notification(
+                recipient_staff_id=recipient_staff_id,
+                recipient_role=payload.recipient_role,
+                kind=payload.kind,
+                source_type=payload.source_type,
+                source_id=str(payload.source_id),
+                dedupe_key=payload.dedupe_key,
+                title=payload.title,
+                body=payload.body,
+                payload_json=payload.payload.model_dump(mode="json"),
+            )
+            self._session.add(entity)
+            entities.append(entity)
+            existing_pairs.add(dedupe_pair)
+
+        if commit:
+            self._session.commit()
+            for entity in entities:
+                self._session.refresh(entity)
+            return entities
+
+        self._session.flush()
+        return entities
+
+    def mark_as_read(
+        self,
+        *,
+        entity: Notification,
+        commit: bool = True,
+    ) -> Notification:
+        """Persist read-state changes for one notification row."""
+        self._session.add(entity)
+        if commit:
+            self._session.commit()
+            self._session.refresh(entity)
+            return entity
+
+        self._session.flush()
+        return entity

--- a/apps/backend/src/hrm_backend/notifications/dependencies/__init__.py
+++ b/apps/backend/src/hrm_backend/notifications/dependencies/__init__.py
@@ -1,0 +1,5 @@
+"""Notification dependency exports."""
+
+from hrm_backend.notifications.dependencies.notifications import get_notification_service
+
+__all__ = ["get_notification_service"]

--- a/apps/backend/src/hrm_backend/notifications/dependencies/notifications.py
+++ b/apps/backend/src/hrm_backend/notifications/dependencies/notifications.py
@@ -1,0 +1,46 @@
+"""Dependency providers for notification APIs and emitters."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from hrm_backend.audit.dependencies.audit import get_audit_service
+from hrm_backend.audit.services.audit_service import AuditService
+from hrm_backend.auth.dependencies.auth import get_staff_account_dao
+from hrm_backend.auth.infra.postgres.staff_account_dao import StaffAccountDAO
+from hrm_backend.core.db.session import get_db_session
+from hrm_backend.employee.dao.onboarding_task_dao import OnboardingTaskDAO
+from hrm_backend.notifications.dao.notification_dao import NotificationDAO
+from hrm_backend.notifications.services.notification_service import NotificationService
+from hrm_backend.vacancies.dao.vacancy_dao import VacancyDAO
+
+SessionDependency = Annotated[Session, Depends(get_db_session)]
+AuditDependency = Annotated[AuditService, Depends(get_audit_service)]
+StaffAccountDAODependency = Annotated[StaffAccountDAO, Depends(get_staff_account_dao)]
+
+
+def get_notification_service(
+    session: SessionDependency,
+    audit_service: AuditDependency,
+    staff_account_dao: StaffAccountDAODependency,
+) -> NotificationService:
+    """Build notification service for the current request session.
+
+    Args:
+        session: SQLAlchemy session bound to the current request scope.
+        audit_service: Audit service dependency for protected notification API access traces.
+        staff_account_dao: DAO for recipient role and subject resolution.
+
+    Returns:
+        NotificationService: In-app notification read/update/emission service.
+    """
+    return NotificationService(
+        notification_dao=NotificationDAO(session=session),
+        staff_account_dao=staff_account_dao,
+        task_dao=OnboardingTaskDAO(session=session),
+        vacancy_dao=VacancyDAO(session=session),
+        audit_service=audit_service,
+    )

--- a/apps/backend/src/hrm_backend/notifications/models/__init__.py
+++ b/apps/backend/src/hrm_backend/notifications/models/__init__.py
@@ -1,0 +1,5 @@
+"""Notification model exports."""
+
+from hrm_backend.notifications.models.notification import Notification
+
+__all__ = ["Notification"]

--- a/apps/backend/src/hrm_backend/notifications/models/notification.py
+++ b/apps/backend/src/hrm_backend/notifications/models/notification.py
@@ -1,0 +1,74 @@
+"""Persistence model for in-app notifications."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, String, Text, UniqueConstraint, Uuid
+from sqlalchemy.orm import Mapped, mapped_column
+
+from hrm_backend.core.models.base import Base
+
+
+class Notification(Base):
+    """In-app notification row scoped to one recipient staff account.
+
+    Attributes:
+        notification_id: Unique notification identifier.
+        recipient_staff_id: Recipient staff-account subject.
+        recipient_role: Recipient role snapshot captured at emit time.
+        kind: Stable notification kind used by frontend rendering.
+        source_type: Domain source category such as `vacancy` or `onboarding_task`.
+        source_id: Domain source identifier used for later correlation.
+        dedupe_key: Event fingerprint unique within one recipient scope.
+        title: Short human-readable notification title.
+        body: Human-readable notification message body.
+        payload_json: Additive structured payload used by frontend workspaces.
+        created_at: Notification creation timestamp.
+        read_at: Acknowledgement timestamp when the recipient marks the item as read.
+    """
+
+    __tablename__ = "notifications"
+    __table_args__ = (
+        UniqueConstraint(
+            "recipient_staff_id",
+            "dedupe_key",
+            name="ux_notifications_recipient_dedupe",
+        ),
+        Index(
+            "ix_notifications_recipient_created_at",
+            "recipient_staff_id",
+            "created_at",
+        ),
+        Index(
+            "ix_notifications_recipient_read_at",
+            "recipient_staff_id",
+            "read_at",
+        ),
+    )
+
+    notification_id: Mapped[str] = mapped_column(
+        String(36),
+        primary_key=True,
+        default=lambda: str(uuid4()),
+    )
+    recipient_staff_id: Mapped[str] = mapped_column(
+        Uuid(as_uuid=False),
+        ForeignKey("staff_accounts.staff_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    recipient_role: Mapped[str] = mapped_column(String(32), nullable=False)
+    kind: Mapped[str] = mapped_column(String(64), nullable=False)
+    source_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    source_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    dedupe_key: Mapped[str] = mapped_column(String(255), nullable=False)
+    title: Mapped[str] = mapped_column(String(256), nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    payload_json: Mapped[dict[str, object]] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/apps/backend/src/hrm_backend/notifications/routers/__init__.py
+++ b/apps/backend/src/hrm_backend/notifications/routers/__init__.py
@@ -1,0 +1,5 @@
+"""Notification router exports."""
+
+from hrm_backend.notifications.routers.v1 import router
+
+__all__ = ["router"]

--- a/apps/backend/src/hrm_backend/notifications/routers/v1.py
+++ b/apps/backend/src/hrm_backend/notifications/routers/v1.py
@@ -1,0 +1,79 @@
+"""Versioned HTTP routes for recipient-scoped notifications and digests."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query, Request
+
+from hrm_backend.auth.dependencies.auth import get_current_auth_context
+from hrm_backend.auth.schemas.token_claims import AuthContext
+from hrm_backend.notifications.dependencies.notifications import get_notification_service
+from hrm_backend.notifications.schemas.notification import (
+    NotificationDigestResponse,
+    NotificationListResponse,
+    NotificationResponse,
+)
+from hrm_backend.notifications.services.notification_service import NotificationService
+from hrm_backend.notifications.utils.notifications import NotificationListStatus
+from hrm_backend.rbac import Role, require_permission
+
+router = APIRouter(prefix="/api/v1/notifications", tags=["notifications"])
+NotificationServiceDependency = Annotated[
+    NotificationService,
+    Depends(get_notification_service),
+]
+CurrentAuthContext = Annotated[AuthContext, Depends(get_current_auth_context)]
+NotificationReadRole = Annotated[Role, Depends(require_permission("notification:read"))]
+NotificationUpdateRole = Annotated[Role, Depends(require_permission("notification:update"))]
+NotificationStatusQuery = Annotated[NotificationListStatus, Query()]
+NotificationLimitQuery = Annotated[int, Query(ge=1, le=100)]
+NotificationOffsetQuery = Annotated[int, Query(ge=0)]
+
+
+@router.get("", response_model=NotificationListResponse)
+def list_notifications(
+    request: Request,
+    _: NotificationReadRole,
+    auth_context: CurrentAuthContext,
+    service: NotificationServiceDependency,
+    status: NotificationStatusQuery = "unread",
+    limit: NotificationLimitQuery = 20,
+    offset: NotificationOffsetQuery = 0,
+) -> NotificationListResponse:
+    """List notifications that belong to the current authenticated recipient."""
+    return service.list_notifications(
+        auth_context=auth_context,
+        request=request,
+        list_status=status,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/digest", response_model=NotificationDigestResponse)
+def get_notification_digest(
+    request: Request,
+    _: NotificationReadRole,
+    auth_context: CurrentAuthContext,
+    service: NotificationServiceDependency,
+) -> NotificationDigestResponse:
+    """Return the on-demand notification digest for the current authenticated recipient."""
+    return service.get_digest(auth_context=auth_context, request=request)
+
+
+@router.post("/{notification_id}/read", response_model=NotificationResponse)
+def mark_notification_read(
+    notification_id: UUID,
+    request: Request,
+    _: NotificationUpdateRole,
+    auth_context: CurrentAuthContext,
+    service: NotificationServiceDependency,
+) -> NotificationResponse:
+    """Mark one recipient-owned notification as read."""
+    return service.mark_as_read(
+        notification_id=notification_id,
+        auth_context=auth_context,
+        request=request,
+    )

--- a/apps/backend/src/hrm_backend/notifications/schemas/__init__.py
+++ b/apps/backend/src/hrm_backend/notifications/schemas/__init__.py
@@ -1,0 +1,19 @@
+"""Notification schema exports."""
+
+from hrm_backend.notifications.schemas.notification import (
+    NotificationCreate,
+    NotificationDigestResponse,
+    NotificationDigestSummaryResponse,
+    NotificationListResponse,
+    NotificationPayload,
+    NotificationResponse,
+)
+
+__all__ = [
+    "NotificationCreate",
+    "NotificationDigestResponse",
+    "NotificationDigestSummaryResponse",
+    "NotificationListResponse",
+    "NotificationPayload",
+    "NotificationResponse",
+]

--- a/apps/backend/src/hrm_backend/notifications/schemas/notification.py
+++ b/apps/backend/src/hrm_backend/notifications/schemas/notification.py
@@ -1,0 +1,85 @@
+"""Request, response, and internal payloads for in-app notifications."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from hrm_backend.rbac import Role
+
+
+class NotificationPayload(BaseModel):
+    """Structured additive notification payload exposed to frontend workspaces."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    vacancy_id: UUID | None = None
+    onboarding_id: UUID | None = None
+    task_id: UUID | None = None
+    employee_id: UUID | None = None
+    vacancy_title: str | None = Field(default=None, max_length=256)
+    task_title: str | None = Field(default=None, max_length=256)
+    employee_full_name: str | None = Field(default=None, max_length=256)
+    due_at: datetime | None = None
+
+
+class NotificationCreate(BaseModel):
+    """Internal service payload used to persist one notification row."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    recipient_staff_id: UUID
+    recipient_role: Role
+    kind: str = Field(min_length=1, max_length=64)
+    source_type: str = Field(min_length=1, max_length=64)
+    source_id: UUID
+    dedupe_key: str = Field(min_length=1, max_length=255)
+    title: str = Field(min_length=1, max_length=256)
+    body: str = Field(min_length=1)
+    payload: NotificationPayload = Field(default_factory=NotificationPayload)
+
+
+class NotificationResponse(BaseModel):
+    """API representation of one in-app notification."""
+
+    notification_id: UUID
+    recipient_staff_id: UUID
+    recipient_role: Role
+    kind: str
+    source_type: str
+    source_id: UUID
+    status: str
+    title: str
+    body: str
+    payload: NotificationPayload
+    created_at: datetime
+    read_at: datetime | None
+
+
+class NotificationListResponse(BaseModel):
+    """Paginated notification list scoped to the current authenticated recipient."""
+
+    items: list[NotificationResponse]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+    unread_count: int = Field(ge=0)
+
+
+class NotificationDigestSummaryResponse(BaseModel):
+    """Server-computed summary counters for the current notification workspace."""
+
+    unread_notification_count: int = Field(ge=0)
+    active_task_count: int = Field(ge=0)
+    overdue_task_count: int = Field(ge=0)
+    owned_open_vacancy_count: int = Field(ge=0)
+
+
+class NotificationDigestResponse(BaseModel):
+    """On-demand digest payload for the current authenticated recipient."""
+
+    generated_at: datetime
+    summary: NotificationDigestSummaryResponse
+    latest_unread_items: list[NotificationResponse]

--- a/apps/backend/src/hrm_backend/notifications/services/__init__.py
+++ b/apps/backend/src/hrm_backend/notifications/services/__init__.py
@@ -1,0 +1,5 @@
+"""Notification service exports."""
+
+from hrm_backend.notifications.services.notification_service import NotificationService
+
+__all__ = ["NotificationService"]

--- a/apps/backend/src/hrm_backend/notifications/services/notification_service.py
+++ b/apps/backend/src/hrm_backend/notifications/services/notification_service.py
@@ -1,0 +1,387 @@
+"""Business service for in-app notifications and on-demand digests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from fastapi import HTTPException, Request, status
+
+from hrm_backend.audit.services.audit_service import AuditService, actor_from_auth_context
+from hrm_backend.auth.infra.postgres.staff_account_dao import StaffAccountDAO
+from hrm_backend.auth.models.staff_account import StaffAccount
+from hrm_backend.auth.schemas.token_claims import AuthContext
+from hrm_backend.employee.dao.onboarding_task_dao import OnboardingTaskDAO
+from hrm_backend.employee.models.onboarding import OnboardingTask
+from hrm_backend.employee.utils.onboarding import ONBOARDING_TASK_STATUS_COMPLETED
+from hrm_backend.notifications.dao.notification_dao import NotificationDAO
+from hrm_backend.notifications.models.notification import Notification
+from hrm_backend.notifications.schemas.notification import (
+    NotificationCreate,
+    NotificationDigestResponse,
+    NotificationDigestSummaryResponse,
+    NotificationListResponse,
+    NotificationPayload,
+    NotificationResponse,
+)
+from hrm_backend.notifications.utils.notifications import (
+    DIGEST_UNREAD_LIMIT,
+    NOTIFICATION_KIND_ONBOARDING_TASK_ASSIGNMENT,
+    NOTIFICATION_KIND_VACANCY_ASSIGNMENT,
+    is_notifiable_recipient_role,
+    resolve_notification_status,
+)
+from hrm_backend.vacancies.dao.vacancy_dao import VacancyDAO
+from hrm_backend.vacancies.models.vacancy import Vacancy
+
+NOTIFICATION_NOT_FOUND = "notification_not_found"
+
+
+class NotificationService:
+    """Read, update, and emit recipient-scoped in-app notifications."""
+
+    def __init__(
+        self,
+        *,
+        notification_dao: NotificationDAO,
+        staff_account_dao: StaffAccountDAO,
+        task_dao: OnboardingTaskDAO,
+        vacancy_dao: VacancyDAO,
+        audit_service: AuditService,
+    ) -> None:
+        """Initialize notification service dependencies.
+
+        Args:
+            notification_dao: DAO for notification persistence and reads.
+            staff_account_dao: DAO for role/staff recipient resolution.
+            task_dao: DAO for task counts used in digest computation.
+            vacancy_dao: DAO for manager-owned vacancy counts used in digests.
+            audit_service: Audit service for protected notification API reads and updates.
+        """
+        self._notification_dao = notification_dao
+        self._staff_account_dao = staff_account_dao
+        self._task_dao = task_dao
+        self._vacancy_dao = vacancy_dao
+        self._audit_service = audit_service
+
+    def list_notifications(
+        self,
+        *,
+        auth_context: AuthContext,
+        request: Request,
+        list_status: str,
+        limit: int,
+        offset: int,
+    ) -> NotificationListResponse:
+        """List notifications that belong only to the current authenticated recipient."""
+        actor_sub, actor_role = actor_from_auth_context(auth_context)
+        unread_only = list_status == "unread"
+        items = self._notification_dao.list_for_recipient(
+            recipient_staff_id=actor_sub,
+            unread_only=unread_only,
+            limit=limit,
+            offset=offset,
+        )
+        unread_count = self._notification_dao.count_unread_for_recipient(
+            recipient_staff_id=actor_sub,
+        )
+        total = (
+            unread_count
+            if unread_only
+            else self._notification_dao.count_all_for_recipient(recipient_staff_id=actor_sub)
+        )
+        self._audit_service.record_api_event(
+            action="notification:list",
+            resource_type="notification",
+            result="success",
+            request=request,
+            actor_sub=actor_sub,
+            actor_role=actor_role,
+        )
+        return NotificationListResponse(
+            items=[_to_notification_response(entity) for entity in items],
+            total=total,
+            limit=limit,
+            offset=offset,
+            unread_count=unread_count,
+        )
+
+    def mark_as_read(
+        self,
+        *,
+        notification_id: UUID,
+        auth_context: AuthContext,
+        request: Request,
+    ) -> NotificationResponse:
+        """Mark one recipient-owned notification as read."""
+        actor_sub, actor_role = actor_from_auth_context(auth_context)
+        entity = self._notification_dao.get_by_id_for_recipient(
+            notification_id=str(notification_id),
+            recipient_staff_id=actor_sub,
+        )
+        if entity is None:
+            self._audit_service.record_api_event(
+                action="notification:update",
+                resource_type="notification",
+                result="failure",
+                request=request,
+                actor_sub=actor_sub,
+                actor_role=actor_role,
+                resource_id=str(notification_id),
+                reason=NOTIFICATION_NOT_FOUND,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=NOTIFICATION_NOT_FOUND,
+            )
+
+        if entity.read_at is None:
+            entity.read_at = datetime.now(UTC)
+            entity = self._notification_dao.mark_as_read(entity=entity)
+
+        self._audit_service.record_api_event(
+            action="notification:update",
+            resource_type="notification",
+            result="success",
+            request=request,
+            actor_sub=actor_sub,
+            actor_role=actor_role,
+            resource_id=entity.notification_id,
+        )
+        return _to_notification_response(entity)
+
+    def get_digest(
+        self,
+        *,
+        auth_context: AuthContext,
+        request: Request,
+    ) -> NotificationDigestResponse:
+        """Build an on-demand digest for the current authenticated recipient."""
+        actor_sub, actor_role = actor_from_auth_context(auth_context)
+        unread_count = self._notification_dao.count_unread_for_recipient(
+            recipient_staff_id=actor_sub,
+        )
+        latest_unread = self._notification_dao.list_for_recipient(
+            recipient_staff_id=actor_sub,
+            unread_only=True,
+            limit=DIGEST_UNREAD_LIMIT,
+            offset=0,
+        )
+        assigned_tasks = self._task_dao.list_visible_to_actor(
+            actor_role=actor_role,
+            actor_staff_id=actor_sub,
+        )
+        active_tasks = [
+            task for task in assigned_tasks if task.status != ONBOARDING_TASK_STATUS_COMPLETED
+        ]
+        now = datetime.now(UTC)
+        owned_open_vacancy_count = 0
+        if actor_role == "manager":
+            owned_open_vacancy_count = sum(
+                1
+                for vacancy in self._vacancy_dao.list_by_hiring_manager_staff_id(actor_sub)
+                if vacancy.status == "open"
+            )
+
+        summary = NotificationDigestSummaryResponse(
+            unread_notification_count=unread_count,
+            active_task_count=len(active_tasks),
+            overdue_task_count=sum(
+                1
+                for task in active_tasks
+                if task.due_at is not None and _normalize_datetime(task.due_at) < now
+            ),
+            owned_open_vacancy_count=owned_open_vacancy_count,
+        )
+        self._audit_service.record_api_event(
+            action="notification_digest:read",
+            resource_type="notification",
+            result="success",
+            request=request,
+            actor_sub=actor_sub,
+            actor_role=actor_role,
+        )
+        return NotificationDigestResponse(
+            generated_at=now,
+            summary=summary,
+            latest_unread_items=[_to_notification_response(entity) for entity in latest_unread],
+        )
+
+    def emit_vacancy_assignment_notifications(
+        self,
+        *,
+        vacancy: Vacancy,
+        previous_hiring_manager_staff_id: str | None,
+    ) -> None:
+        """Emit a manager notification when vacancy ownership changes to a new recipient."""
+        new_accounts = self._resolve_direct_recipient_accounts(vacancy.hiring_manager_staff_id)
+        previous_recipient_ids = {
+            account.staff_id
+            for account in self._resolve_direct_recipient_accounts(previous_hiring_manager_staff_id)
+        }
+        if not new_accounts:
+            return
+
+        payloads = [
+            NotificationCreate(
+                recipient_staff_id=UUID(account.staff_id),
+                recipient_role=account.role,
+                kind=NOTIFICATION_KIND_VACANCY_ASSIGNMENT,
+                source_type="vacancy",
+                source_id=UUID(vacancy.vacancy_id),
+                dedupe_key=_build_event_dedupe_key(
+                    kind=NOTIFICATION_KIND_VACANCY_ASSIGNMENT,
+                    source_id=vacancy.vacancy_id,
+                    event_time=_normalize_datetime(vacancy.updated_at),
+                ),
+                title=f"Vacancy assigned: {vacancy.title}",
+                body=(
+                    f"You were assigned as the hiring manager for {vacancy.title} "
+                    f"in {vacancy.department}."
+                ),
+                payload=NotificationPayload(
+                    vacancy_id=UUID(vacancy.vacancy_id),
+                    vacancy_title=vacancy.title,
+                ),
+            )
+            for account in new_accounts
+            if account.staff_id not in previous_recipient_ids
+        ]
+        self._notification_dao.create_notifications(payloads=payloads, commit=False)
+
+    def emit_onboarding_task_assignment_notifications(
+        self,
+        *,
+        task: OnboardingTask,
+        employee_id: str,
+        employee_full_name: str,
+        previous_assigned_role: str | None,
+        previous_assigned_staff_id: str | None,
+    ) -> None:
+        """Emit manager/accountant notifications when task assignment visibility changes."""
+        new_accounts = self._resolve_assignment_recipient_accounts(
+            assigned_role=task.assigned_role,
+            assigned_staff_id=task.assigned_staff_id,
+        )
+        previous_recipient_ids = {
+            account.staff_id
+            for account in self._resolve_assignment_recipient_accounts(
+                assigned_role=previous_assigned_role,
+                assigned_staff_id=previous_assigned_staff_id,
+            )
+        }
+        if not new_accounts:
+            return
+
+        payloads = [
+            NotificationCreate(
+                recipient_staff_id=UUID(account.staff_id),
+                recipient_role=account.role,
+                kind=NOTIFICATION_KIND_ONBOARDING_TASK_ASSIGNMENT,
+                source_type="onboarding_task",
+                source_id=UUID(task.task_id),
+                dedupe_key=_build_event_dedupe_key(
+                    kind=NOTIFICATION_KIND_ONBOARDING_TASK_ASSIGNMENT,
+                    source_id=task.task_id,
+                    event_time=_normalize_datetime(task.updated_at),
+                ),
+                title=f"Onboarding task assigned: {task.title}",
+                body=_build_task_assignment_body(
+                    employee_full_name=employee_full_name,
+                    task_title=task.title,
+                    due_at=task.due_at,
+                ),
+                payload=NotificationPayload(
+                    onboarding_id=UUID(task.onboarding_id),
+                    task_id=UUID(task.task_id),
+                    employee_id=UUID(employee_id),
+                    employee_full_name=employee_full_name,
+                    task_title=task.title,
+                    due_at=task.due_at,
+                ),
+            )
+            for account in new_accounts
+            if account.staff_id not in previous_recipient_ids
+        ]
+        self._notification_dao.create_notifications(payloads=payloads, commit=False)
+
+    def _resolve_direct_recipient_accounts(self, staff_id: str | None) -> list[StaffAccount]:
+        """Resolve a single staff subject to an active v1 notification recipient if possible."""
+        if staff_id is None:
+            return []
+        account = self._staff_account_dao.get_by_id(staff_id)
+        if (
+            account is None
+            or not account.is_active
+            or not is_notifiable_recipient_role(account.role)
+        ):
+            return []
+        return [account]
+
+    def _resolve_assignment_recipient_accounts(
+        self,
+        *,
+        assigned_role: str | None,
+        assigned_staff_id: str | None,
+    ) -> list[StaffAccount]:
+        """Resolve all manager/accountant recipients implied by one task assignment state."""
+        recipients: dict[str, StaffAccount] = {}
+        if assigned_role is not None and is_notifiable_recipient_role(assigned_role):
+            for account in self._staff_account_dao.list_active_by_role(assigned_role):
+                recipients[account.staff_id] = account
+
+        for account in self._resolve_direct_recipient_accounts(assigned_staff_id):
+            recipients[account.staff_id] = account
+
+        return list(recipients.values())
+
+
+def _to_notification_response(entity: Notification) -> NotificationResponse:
+    """Map one notification ORM entity to the public response schema."""
+    return NotificationResponse(
+        notification_id=UUID(entity.notification_id),
+        recipient_staff_id=UUID(entity.recipient_staff_id),
+        recipient_role=entity.recipient_role,
+        kind=entity.kind,
+        source_type=entity.source_type,
+        source_id=UUID(entity.source_id),
+        status=resolve_notification_status(entity.read_at),
+        title=entity.title,
+        body=entity.body,
+        payload=NotificationPayload.model_validate(entity.payload_json),
+        created_at=_normalize_datetime(entity.created_at),
+        read_at=_normalize_datetime(entity.read_at),
+    )
+
+
+def _normalize_datetime(value: datetime | None) -> datetime | None:
+    """Normalize persisted datetimes to timezone-aware UTC values."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _build_event_dedupe_key(*, kind: str, source_id: str, event_time: datetime | None) -> str:
+    """Build a deterministic dedupe key for one emitted notification event."""
+    suffix = "unknown"
+    if event_time is not None:
+        suffix = event_time.astimezone(UTC).isoformat()
+    return f"{kind}:{source_id}:{suffix}"
+
+
+def _build_task_assignment_body(
+    *,
+    employee_full_name: str,
+    task_title: str,
+    due_at: datetime | None,
+) -> str:
+    """Build the user-facing onboarding-task assignment message body."""
+    base = f"{task_title} for {employee_full_name}."
+    if due_at is None:
+        return base
+    normalized_due_at = _normalize_datetime(due_at)
+    if normalized_due_at is None:
+        return base
+    return f"{base} Due at {normalized_due_at.isoformat()}."

--- a/apps/backend/src/hrm_backend/notifications/utils/__init__.py
+++ b/apps/backend/src/hrm_backend/notifications/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Notification utility package."""

--- a/apps/backend/src/hrm_backend/notifications/utils/notifications.py
+++ b/apps/backend/src/hrm_backend/notifications/utils/notifications.py
@@ -1,0 +1,43 @@
+"""Shared notification constants and helper utilities."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+NOTIFICATION_KIND_VACANCY_ASSIGNMENT = "vacancy_assignment"
+NOTIFICATION_KIND_ONBOARDING_TASK_ASSIGNMENT = "onboarding_task_assignment"
+NOTIFICATION_STATUS_UNREAD = "unread"
+NOTIFICATION_STATUS_READ = "read"
+DIGEST_UNREAD_LIMIT = 5
+NOTIFIABLE_RECIPIENT_ROLES = frozenset({"manager", "accountant"})
+
+NotificationKind = Literal["vacancy_assignment", "onboarding_task_assignment"]
+NotificationStatus = Literal["unread", "read"]
+NotificationListStatus = Literal["unread", "all"]
+
+
+def resolve_notification_status(read_at: datetime | None) -> NotificationStatus:
+    """Resolve the API notification status from the persisted read timestamp.
+
+    Args:
+        read_at: Notification read timestamp if the recipient already acknowledged the item.
+
+    Returns:
+        NotificationStatus: `read` when the timestamp exists, otherwise `unread`.
+    """
+    if read_at is None:
+        return NOTIFICATION_STATUS_UNREAD
+    return NOTIFICATION_STATUS_READ
+
+
+def is_notifiable_recipient_role(role: str | None) -> bool:
+    """Return whether the provided staff role participates in the v1 notification slice.
+
+    Args:
+        role: Staff-account role to evaluate.
+
+    Returns:
+        bool: `True` when the role is one of the supported in-app recipient roles.
+    """
+    return role in NOTIFIABLE_RECIPIENT_ROLES

--- a/apps/backend/src/hrm_backend/rbac.py
+++ b/apps/backend/src/hrm_backend/rbac.py
@@ -42,6 +42,8 @@ Permission = Literal[
     "employee_portal:read",
     "employee_portal:update",
     "manager_workspace:read",
+    "notification:read",
+    "notification:update",
     "onboarding_dashboard:read",
     "onboarding_task:list",
     "onboarding_task:update",
@@ -136,6 +138,8 @@ ROLE_PERMISSION_MATRIX: Final[dict[Role, set[Permission]]] = {
     },
     "manager": {
         "manager_workspace:read",
+        "notification:read",
+        "notification:update",
         "onboarding_dashboard:read",
         "analytics:read",
     },
@@ -151,6 +155,8 @@ ROLE_PERMISSION_MATRIX: Final[dict[Role, set[Permission]]] = {
     },
     "accountant": {
         "accounting:read",
+        "notification:read",
+        "notification:update",
         "analytics:read",
     },
 }

--- a/apps/backend/src/hrm_backend/vacancies/dao/vacancy_dao.py
+++ b/apps/backend/src/hrm_backend/vacancies/dao/vacancy_dao.py
@@ -24,6 +24,7 @@ class VacancyDAO:
         payload: VacancyCreateRequest,
         *,
         hiring_manager_staff_id: str | None = None,
+        commit: bool = True,
     ) -> Vacancy:
         """Insert vacancy row.
 
@@ -42,8 +43,12 @@ class VacancyDAO:
             hiring_manager_staff_id=hiring_manager_staff_id,
         )
         self._session.add(entity)
-        self._session.commit()
-        self._session.refresh(entity)
+        if commit:
+            self._session.commit()
+            self._session.refresh(entity)
+            return entity
+
+        self._session.flush()
         return entity
 
     def get_by_id(self, vacancy_id: str) -> Vacancy | None:
@@ -81,7 +86,13 @@ class VacancyDAO:
             .all()
         )
 
-    def update_vacancy(self, entity: Vacancy, payload: VacancyUpdateRequest) -> Vacancy:
+    def update_vacancy(
+        self,
+        entity: Vacancy,
+        payload: VacancyUpdateRequest,
+        *,
+        commit: bool = True,
+    ) -> Vacancy:
         """Apply partial vacancy update and persist changes.
 
         Args:
@@ -97,6 +108,10 @@ class VacancyDAO:
         ).items():
             setattr(entity, field_name, value)
         self._session.add(entity)
-        self._session.commit()
-        self._session.refresh(entity)
+        if commit:
+            self._session.commit()
+            self._session.refresh(entity)
+            return entity
+
+        self._session.flush()
         return entity

--- a/apps/backend/src/hrm_backend/vacancies/dependencies/vacancies.py
+++ b/apps/backend/src/hrm_backend/vacancies/dependencies/vacancies.py
@@ -24,6 +24,8 @@ from hrm_backend.core.db.session import get_db_session
 from hrm_backend.employee.dependencies.employee import get_hire_conversion_service
 from hrm_backend.interviews.dao.feedback_dao import InterviewFeedbackDAO
 from hrm_backend.interviews.dao.interview_dao import InterviewDAO
+from hrm_backend.notifications.dependencies.notifications import get_notification_service
+from hrm_backend.notifications.services.notification_service import NotificationService
 from hrm_backend.settings import AppSettings, get_settings
 from hrm_backend.vacancies.dao.public_apply_guard_dao import PublicApplyGuardDAO
 from hrm_backend.vacancies.infra.postgres import OfferDAO, PipelineTransitionDAO, VacancyDAO
@@ -40,12 +42,17 @@ SettingsDependency = Annotated[AppSettings, Depends(get_settings)]
 CandidateStorageDependency = Annotated[CandidateStorage, Depends(get_candidate_storage)]
 RedisClientDependency = Annotated[Redis, Depends(get_redis_client)]
 StaffAccountDAODependency = Annotated[StaffAccountDAO, Depends(get_staff_account_dao)]
+NotificationServiceDependency = Annotated[
+    NotificationService,
+    Depends(get_notification_service),
+]
 
 
 def get_vacancy_service(
     session: SessionDependency,
     audit_service: AuditDependency,
     staff_account_dao: StaffAccountDAODependency,
+    notification_service: NotificationServiceDependency,
 ) -> VacancyService:
     """Build vacancy service dependency.
 
@@ -67,6 +74,7 @@ def get_vacancy_service(
         interview_feedback_dao=InterviewFeedbackDAO(session=session),
         hire_conversion_service=hire_conversion_service,
         staff_account_dao=staff_account_dao,
+        notification_service=notification_service,
         audit_service=audit_service,
     )
 

--- a/apps/backend/src/hrm_backend/vacancies/services/vacancy_service.py
+++ b/apps/backend/src/hrm_backend/vacancies/services/vacancy_service.py
@@ -19,6 +19,7 @@ from hrm_backend.interviews.utils.feedback import (
     GATE_REASON_MISSING,
     build_feedback_panel_summary,
 )
+from hrm_backend.notifications.services.notification_service import NotificationService
 from hrm_backend.vacancies.dao.offer_dao import OfferDAO
 from hrm_backend.vacancies.dao.pipeline_transition_dao import PipelineTransitionDAO
 from hrm_backend.vacancies.dao.vacancy_dao import VacancyDAO
@@ -56,6 +57,7 @@ class VacancyService:
         interview_feedback_dao: InterviewFeedbackDAO,
         hire_conversion_service: HireConversionService,
         staff_account_dao: StaffAccountDAO,
+        notification_service: NotificationService,
         audit_service: AuditService,
     ) -> None:
         """Initialize vacancy service dependencies.
@@ -70,6 +72,7 @@ class VacancyService:
             interview_feedback_dao: Interview feedback DAO.
             hire_conversion_service: Durable employee-domain handoff service.
             staff_account_dao: Staff-account DAO used to resolve assigned-manager labels.
+            notification_service: In-app notification service for manager ownership changes.
             audit_service: Audit service.
         """
         self._session = session
@@ -81,6 +84,7 @@ class VacancyService:
         self._interview_feedback_dao = interview_feedback_dao
         self._hire_conversion_service = hire_conversion_service
         self._staff_account_dao = staff_account_dao
+        self._notification_service = notification_service
         self._audit_service = audit_service
 
     def create_vacancy(
@@ -91,12 +95,20 @@ class VacancyService:
         request: Request,
     ) -> VacancyResponse:
         """Create vacancy row and emit audit event."""
+        hiring_manager_staff_id = self._resolve_hiring_manager_staff_id(
+            payload.hiring_manager_login
+        )
         entity = self._vacancy_dao.create_vacancy(
             payload,
-            hiring_manager_staff_id=self._resolve_hiring_manager_staff_id(
-                payload.hiring_manager_login
-            ),
+            hiring_manager_staff_id=hiring_manager_staff_id,
+            commit=False,
         )
+        self._notification_service.emit_vacancy_assignment_notifications(
+            vacancy=entity,
+            previous_hiring_manager_staff_id=None,
+        )
+        self._session.commit()
+        self._session.refresh(entity)
         actor_sub, actor_role = actor_from_auth_context(auth_context)
         self._audit_service.record_api_event(
             action="vacancy:create",
@@ -164,11 +176,18 @@ class VacancyService:
         entity = self._vacancy_dao.get_by_id(str(vacancy_id))
         if entity is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Vacancy not found")
+        previous_hiring_manager_staff_id = entity.hiring_manager_staff_id
         if "hiring_manager_login" in payload.model_fields_set:
             entity.hiring_manager_staff_id = self._resolve_hiring_manager_staff_id(
                 payload.hiring_manager_login
             )
-        updated = self._vacancy_dao.update_vacancy(entity=entity, payload=payload)
+        updated = self._vacancy_dao.update_vacancy(entity=entity, payload=payload, commit=False)
+        self._notification_service.emit_vacancy_assignment_notifications(
+            vacancy=updated,
+            previous_hiring_manager_staff_id=previous_hiring_manager_staff_id,
+        )
+        self._session.commit()
+        self._session.refresh(updated)
         actor_sub, actor_role = actor_from_auth_context(auth_context)
         self._audit_service.record_api_event(
             action="vacancy:update",

--- a/apps/backend/tests/integration/notifications/test_notification_api.py
+++ b/apps/backend/tests/integration/notifications/test_notification_api.py
@@ -1,0 +1,281 @@
+"""Integration tests for recipient-scoped notification APIs."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from hrm_backend.auth.dependencies.auth import get_current_auth_context
+from hrm_backend.auth.models.staff_account import StaffAccount
+from hrm_backend.auth.schemas.token_claims import AuthContext
+from hrm_backend.core.models.base import Base
+from hrm_backend.employee.models.onboarding import OnboardingRun, OnboardingTask
+from hrm_backend.main import app
+from hrm_backend.settings import AppSettings, get_settings
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture()
+def sqlite_database_url(tmp_path: Path) -> str:
+    """Provide temporary SQLite URL for notification integration tests."""
+    return f"sqlite+pysqlite:///{tmp_path / 'notifications_api.db'}"
+
+
+@pytest.fixture()
+def configured_app(sqlite_database_url: str):
+    """Configure app dependency overrides for notification integration tests."""
+    settings = AppSettings(
+        database_url=sqlite_database_url,
+        redis_url="redis://localhost:6379/15",
+        jwt_secret="integration-secret-with-minimum-32-bytes",
+    )
+    context_holder = {
+        "context": AuthContext(
+            subject_id=uuid4(),
+            role="hr",
+            session_id=uuid4(),
+            token_id=uuid4(),
+            expires_at=9999999999,
+        )
+    }
+
+    def _get_settings_override() -> AppSettings:
+        return settings
+
+    def _get_auth_context_override() -> AuthContext:
+        return context_holder["context"]
+
+    app.dependency_overrides[get_settings] = _get_settings_override
+    app.dependency_overrides[get_current_auth_context] = _get_auth_context_override
+
+    engine = create_engine(sqlite_database_url, future=True)
+    Base.metadata.create_all(engine)
+    try:
+        yield app, context_holder, engine
+    finally:
+        app.dependency_overrides.pop(get_settings, None)
+        app.dependency_overrides.pop(get_current_auth_context, None)
+        engine.dispose()
+
+
+@pytest.fixture()
+async def api_client(configured_app) -> AsyncClient:
+    """Provide async API client for notification integration tests."""
+    configured, *_ = configured_app
+    async with AsyncClient(
+        transport=ASGITransport(app=configured),
+        base_url="http://testserver",
+    ) as client:
+        yield client
+
+
+def _seed_staff_accounts(engine) -> dict[str, str]:
+    """Insert manager/accountant fixture accounts used by API tests."""
+    manager_id = "11111111-1111-4111-8111-111111111111"
+    manager_beta_id = "12121212-1212-4212-8212-121212121212"
+    accountant_id = "22222222-2222-4222-8222-222222222222"
+    with Session(engine) as session:
+        session.add_all(
+            [
+                StaffAccount(
+                    staff_id=manager_id,
+                    login="manager-alpha",
+                    email="manager-alpha@example.com",
+                    password_hash="hash",
+                    role="manager",
+                    is_active=True,
+                ),
+                StaffAccount(
+                    staff_id=manager_beta_id,
+                    login="manager-beta",
+                    email="manager-beta@example.com",
+                    password_hash="hash",
+                    role="manager",
+                    is_active=True,
+                ),
+                StaffAccount(
+                    staff_id=accountant_id,
+                    login="accountant-alpha",
+                    email="accountant@example.com",
+                    password_hash="hash",
+                    role="accountant",
+                    is_active=True,
+                ),
+                StaffAccount(
+                    staff_id="33333333-3333-4333-8333-333333333333",
+                    login="hr-user",
+                    email="hr@example.com",
+                    password_hash="hash",
+                    role="hr",
+                    is_active=True,
+                ),
+            ]
+        )
+        session.commit()
+    return {
+        "manager_id": manager_id,
+        "manager_beta_id": manager_beta_id,
+        "accountant_id": accountant_id,
+    }
+
+
+def _seed_onboarding_task(engine) -> dict[str, str]:
+    """Insert one onboarding run and unassigned task for accountant notification tests."""
+    onboarding_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    task_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+    with Session(engine) as session:
+        session.add(
+            OnboardingRun(
+                onboarding_id=onboarding_id,
+                employee_id="cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+                hire_conversion_id="dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+                status="started",
+                started_at=datetime(2026, 3, 12, 9, 0, tzinfo=UTC),
+                started_by_staff_id="33333333-3333-4333-8333-333333333333",
+            )
+        )
+        session.add(
+            OnboardingTask(
+                task_id=task_id,
+                onboarding_id=onboarding_id,
+                template_id="eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+                template_item_id="ffffffff-ffff-4fff-8fff-ffffffffffff",
+                code="collect_bank_details",
+                title="Collect bank details",
+                description=None,
+                sort_order=10,
+                is_required=True,
+                status="pending",
+                assigned_role=None,
+                assigned_staff_id=None,
+                due_at=None,
+                completed_at=None,
+                created_at=datetime(2026, 3, 12, 9, 0, tzinfo=UTC),
+                updated_at=datetime(2026, 3, 12, 9, 0, tzinfo=UTC),
+            )
+        )
+        session.commit()
+    return {"onboarding_id": onboarding_id, "task_id": task_id}
+
+
+async def test_manager_notifications_api_is_fail_closed_and_supports_mark_read(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
+    """Verify manager notification reads stay recipient-scoped and support mark-read flow."""
+    _, context_holder, engine = configured_app
+    staff_ids = _seed_staff_accounts(engine)
+
+    create_response = await api_client.post(
+        "/api/v1/vacancies",
+        json={
+            "title": "Platform Engineer",
+            "description": "Build platform foundations.",
+            "department": "Engineering",
+            "status": "open",
+        },
+    )
+    assert create_response.status_code == 200
+    vacancy_id = create_response.json()["vacancy_id"]
+
+    patch_response = await api_client.patch(
+        f"/api/v1/vacancies/{vacancy_id}",
+        json={"hiring_manager_login": "manager-alpha"},
+    )
+    assert patch_response.status_code == 200
+
+    context_holder["context"] = AuthContext(
+        subject_id=staff_ids["manager_id"],
+        role="manager",
+        session_id=uuid4(),
+        token_id=uuid4(),
+        expires_at=9999999999,
+    )
+
+    unread_response = await api_client.get("/api/v1/notifications?status=unread&limit=20&offset=0")
+    assert unread_response.status_code == 200
+    unread_payload = unread_response.json()
+    assert unread_payload["total"] == 1
+    assert unread_payload["unread_count"] == 1
+    notification_id = unread_payload["items"][0]["notification_id"]
+    assert unread_payload["items"][0]["kind"] == "vacancy_assignment"
+
+    digest_response = await api_client.get("/api/v1/notifications/digest")
+    assert digest_response.status_code == 200
+    digest_payload = digest_response.json()
+    assert digest_payload["summary"]["unread_notification_count"] == 1
+    assert digest_payload["summary"]["owned_open_vacancy_count"] == 1
+
+    read_response = await api_client.post(f"/api/v1/notifications/{notification_id}/read")
+    assert read_response.status_code == 200
+    assert read_response.json()["status"] == "read"
+
+    context_holder["context"] = AuthContext(
+        subject_id=staff_ids["manager_beta_id"],
+        role="manager",
+        session_id=uuid4(),
+        token_id=uuid4(),
+        expires_at=9999999999,
+    )
+    denied_read_response = await api_client.post(f"/api/v1/notifications/{notification_id}/read")
+    assert denied_read_response.status_code == 404
+    assert denied_read_response.json()["detail"] == "notification_not_found"
+
+
+async def test_accountant_notifications_emit_only_on_assignment_changes(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
+    """Verify accountant notifications are emitted on assignment change and deduped otherwise."""
+    _, context_holder, engine = configured_app
+    staff_ids = _seed_staff_accounts(engine)
+    onboarding_ids = _seed_onboarding_task(engine)
+
+    update_response = await api_client.patch(
+        f"/api/v1/onboarding/runs/{onboarding_ids['onboarding_id']}/tasks/{onboarding_ids['task_id']}",
+        json={"assigned_role": "accountant"},
+    )
+    assert update_response.status_code == 200
+
+    due_at = (datetime.now(UTC) + timedelta(days=2)).isoformat()
+    due_date_response = await api_client.patch(
+        f"/api/v1/onboarding/runs/{onboarding_ids['onboarding_id']}/tasks/{onboarding_ids['task_id']}",
+        json={"due_at": due_at},
+    )
+    assert due_date_response.status_code == 200
+
+    repeat_assignment_response = await api_client.patch(
+        f"/api/v1/onboarding/runs/{onboarding_ids['onboarding_id']}/tasks/{onboarding_ids['task_id']}",
+        json={"assigned_role": "accountant"},
+    )
+    assert repeat_assignment_response.status_code == 200
+
+    context_holder["context"] = AuthContext(
+        subject_id=staff_ids["accountant_id"],
+        role="accountant",
+        session_id=uuid4(),
+        token_id=uuid4(),
+        expires_at=9999999999,
+    )
+
+    all_response = await api_client.get("/api/v1/notifications?status=all&limit=20&offset=0")
+    assert all_response.status_code == 200
+    payload = all_response.json()
+    assert payload["total"] == 1
+    assert payload["unread_count"] == 1
+    assert payload["items"][0]["kind"] == "onboarding_task_assignment"
+    assert payload["items"][0]["payload"]["task_title"] == "Collect bank details"
+
+    digest_response = await api_client.get("/api/v1/notifications/digest")
+    assert digest_response.status_code == 200
+    digest_payload = digest_response.json()
+    assert digest_payload["summary"]["unread_notification_count"] == 1
+    assert digest_payload["summary"]["active_task_count"] == 1
+    assert digest_payload["summary"]["owned_open_vacancy_count"] == 0

--- a/apps/backend/tests/unit/employee/test_onboarding_task_service.py
+++ b/apps/backend/tests/unit/employee/test_onboarding_task_service.py
@@ -38,11 +38,27 @@ class _UnusedTemplateDAO:
     """DAO double used when onboarding template persistence is not under test."""
 
 
+class _UnusedProfileDAO:
+    """DAO double used when employee profile reads are not under test."""
+
+    def get_by_id(self, *_args, **_kwargs):
+        """Return no employee profile for focused unit tests."""
+        return None
+
+
 class _AuditServiceStub:
     """Audit double that captures no-op API event writes."""
 
     def record_api_event(self, **kwargs) -> None:
         """Ignore audit writes during focused unit tests."""
+        del kwargs
+
+
+class _NotificationServiceStub:
+    """Notification double that ignores assignment side effects."""
+
+    def emit_onboarding_task_assignment_notifications(self, **kwargs) -> None:
+        """Ignore notification writes during focused unit tests."""
         del kwargs
 
 
@@ -122,6 +138,8 @@ def test_build_create_payloads_orders_tasks_from_active_template_bundle() -> Non
         run_dao=_UnusedRunDAO(),  # type: ignore[arg-type]
         task_dao=_UnusedTaskDAO(),  # type: ignore[arg-type]
         template_dao=_UnusedTemplateDAO(),  # type: ignore[arg-type]
+        profile_dao=_UnusedProfileDAO(),  # type: ignore[arg-type]
+        notification_service=_NotificationServiceStub(),  # type: ignore[arg-type]
         audit_service=_AuditServiceStub(),  # type: ignore[arg-type]
     )
     run = OnboardingRun(
@@ -184,6 +202,8 @@ def test_onboarding_task_persistence_enforces_one_generation_per_run() -> None:
                 run_dao=OnboardingRunDAO(session=session),
                 task_dao=OnboardingTaskDAO(session=session),
                 template_dao=OnboardingTemplateDAO(session=session),
+                profile_dao=_UnusedProfileDAO(),  # type: ignore[arg-type]
+                notification_service=_NotificationServiceStub(),  # type: ignore[arg-type]
                 audit_service=_AuditServiceStub(),  # type: ignore[arg-type]
             )
 
@@ -210,6 +230,8 @@ def test_update_task_patch_semantics_manage_completion_and_nullable_fields() -> 
                 run_dao=OnboardingRunDAO(session=session),
                 task_dao=OnboardingTaskDAO(session=session),
                 template_dao=OnboardingTemplateDAO(session=session),
+                profile_dao=_UnusedProfileDAO(),  # type: ignore[arg-type]
+                notification_service=_NotificationServiceStub(),  # type: ignore[arg-type]
                 audit_service=_AuditServiceStub(),  # type: ignore[arg-type]
             )
 

--- a/apps/backend/tests/unit/notifications/test_notification_service.py
+++ b/apps/backend/tests/unit/notifications/test_notification_service.py
@@ -1,0 +1,317 @@
+"""Unit tests for recipient-scoped in-app notification service behavior."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from starlette.requests import Request
+
+from hrm_backend.audit.services.audit_service import AuditService
+from hrm_backend.auth.infra.postgres.staff_account_dao import StaffAccountDAO
+from hrm_backend.auth.models.staff_account import StaffAccount
+from hrm_backend.auth.schemas.token_claims import AuthContext
+from hrm_backend.core.models.base import Base
+from hrm_backend.employee.dao.onboarding_task_dao import OnboardingTaskDAO
+from hrm_backend.employee.models.onboarding import OnboardingRun, OnboardingTask
+from hrm_backend.notifications.dao.notification_dao import NotificationDAO
+from hrm_backend.notifications.models.notification import Notification
+from hrm_backend.notifications.services.notification_service import NotificationService
+from hrm_backend.vacancies.dao.vacancy_dao import VacancyDAO
+from hrm_backend.vacancies.models.vacancy import Vacancy
+
+
+class _AuditServiceStub(AuditService):
+    """Audit double that records notification API events in memory."""
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, object]] = []
+
+    def record_api_event(self, **kwargs) -> None:  # type: ignore[override]
+        """Capture API audit payloads for focused service assertions."""
+        self.events.append(kwargs)
+
+
+def _build_request(path: str, method: str = "GET") -> Request:
+    """Create a minimal Starlette request object for service calls."""
+    return Request(
+        {
+            "type": "http",
+            "method": method,
+            "path": path,
+            "headers": [],
+            "client": ("127.0.0.1", 8000),
+        }
+    )
+
+
+def _build_auth_context(*, role: str, subject_id: str) -> AuthContext:
+    """Create deterministic auth context for notification tests."""
+    return AuthContext(
+        subject_id=UUID(subject_id),
+        role=role,
+        session_id=uuid4(),
+        token_id=uuid4(),
+        expires_at=9999999999,
+    )
+
+
+def _seed_staff_accounts(session: Session) -> dict[str, str]:
+    """Insert manager/accountant fixture accounts used by notification tests."""
+    manager_id = "11111111-1111-4111-8111-111111111111"
+    accountant_alpha_id = "22222222-2222-4222-8222-222222222222"
+    accountant_beta_id = "33333333-3333-4333-8333-333333333333"
+    session.add_all(
+        [
+            StaffAccount(
+                staff_id=manager_id,
+                login="manager-alpha",
+                email="manager@example.com",
+                password_hash="hash",
+                role="manager",
+                is_active=True,
+            ),
+            StaffAccount(
+                staff_id=accountant_alpha_id,
+                login="accountant-alpha",
+                email="accountant-alpha@example.com",
+                password_hash="hash",
+                role="accountant",
+                is_active=True,
+            ),
+            StaffAccount(
+                staff_id=accountant_beta_id,
+                login="accountant-beta",
+                email="accountant-beta@example.com",
+                password_hash="hash",
+                role="accountant",
+                is_active=True,
+            ),
+            StaffAccount(
+                staff_id="44444444-4444-4444-8444-444444444444",
+                login="hr-user",
+                email="hr@example.com",
+                password_hash="hash",
+                role="hr",
+                is_active=True,
+            ),
+        ]
+    )
+    session.commit()
+    return {
+        "manager_id": manager_id,
+        "accountant_alpha_id": accountant_alpha_id,
+        "accountant_beta_id": accountant_beta_id,
+    }
+
+
+def _seed_manager_workspace_state(
+    session: Session,
+    *,
+    manager_id: str,
+) -> tuple[Vacancy, OnboardingTask]:
+    """Insert one manager-owned vacancy and one manager-visible onboarding task."""
+    vacancy = Vacancy(
+        vacancy_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        title="Platform Engineer",
+        description="Build platform foundations.",
+        department="Engineering",
+        status="open",
+        hiring_manager_staff_id=manager_id,
+        created_at=datetime(2026, 3, 13, 9, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 3, 13, 9, 0, tzinfo=UTC),
+    )
+    run = OnboardingRun(
+        onboarding_id="bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        employee_id="cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        hire_conversion_id="dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+        status="started",
+        started_at=datetime(2026, 3, 12, 9, 0, tzinfo=UTC),
+        started_by_staff_id="44444444-4444-4444-8444-444444444444",
+    )
+    task = OnboardingTask(
+        task_id="eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+        onboarding_id=run.onboarding_id,
+        template_id="ffffffff-ffff-4fff-8fff-ffffffffffff",
+        template_item_id="12121212-1212-4212-8212-121212121212",
+        code="manager_intro",
+        title="Manager intro",
+        description=None,
+        sort_order=10,
+        is_required=True,
+        status="pending",
+        assigned_role="manager",
+        assigned_staff_id=None,
+        due_at=datetime.now(UTC) - timedelta(days=1),
+        completed_at=None,
+        created_at=datetime(2026, 3, 12, 9, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 3, 13, 10, 0, tzinfo=UTC),
+    )
+    session.add_all([vacancy, run, task])
+    session.commit()
+    return vacancy, task
+
+
+def test_notification_service_emits_assignment_events_with_role_fanout_and_dedupe() -> None:
+    """Verify assignment emitters create one row per recipient and dedupe repeated writes."""
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    audit_service = _AuditServiceStub()
+
+    with Session(engine) as session:
+        staff_ids = _seed_staff_accounts(session)
+        vacancy, task = _seed_manager_workspace_state(session, manager_id=staff_ids["manager_id"])
+        service = NotificationService(
+            notification_dao=NotificationDAO(session=session),
+            staff_account_dao=StaffAccountDAO(session=session),
+            task_dao=OnboardingTaskDAO(session=session),
+            vacancy_dao=VacancyDAO(session=session),
+            audit_service=audit_service,
+        )
+        task.assigned_role = "accountant"
+        task.updated_at = datetime(2026, 3, 13, 11, 0, tzinfo=UTC)
+        session.flush()
+
+        service.emit_vacancy_assignment_notifications(
+            vacancy=vacancy,
+            previous_hiring_manager_staff_id=None,
+        )
+        service.emit_vacancy_assignment_notifications(
+            vacancy=vacancy,
+            previous_hiring_manager_staff_id=None,
+        )
+        service.emit_onboarding_task_assignment_notifications(
+            task=task,
+            employee_id="cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+            employee_full_name="Ada Adams",
+            previous_assigned_role=None,
+            previous_assigned_staff_id=None,
+        )
+        service.emit_onboarding_task_assignment_notifications(
+            task=task,
+            employee_id="cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+            employee_full_name="Ada Adams",
+            previous_assigned_role=None,
+            previous_assigned_staff_id=None,
+        )
+        session.commit()
+
+        notifications = (
+            session.query(Notification)
+            .order_by(Notification.recipient_staff_id.asc(), Notification.kind.asc())
+            .all()
+        )
+
+    assert len(notifications) == 3
+    assert [notification.kind for notification in notifications] == [
+        "vacancy_assignment",
+        "onboarding_task_assignment",
+        "onboarding_task_assignment",
+    ]
+    assert notifications[0].recipient_staff_id == staff_ids["manager_id"]
+    assert {
+        notifications[1].recipient_staff_id,
+        notifications[2].recipient_staff_id,
+    } == {
+        staff_ids["accountant_alpha_id"],
+        staff_ids["accountant_beta_id"],
+    }
+
+
+def test_notification_service_list_mark_read_and_digest_are_recipient_scoped() -> None:
+    """Verify list/read/digest flows stay recipient-scoped and expose correct counts."""
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    audit_service = _AuditServiceStub()
+
+    with Session(engine) as session:
+        staff_ids = _seed_staff_accounts(session)
+        vacancy, task = _seed_manager_workspace_state(session, manager_id=staff_ids["manager_id"])
+        service = NotificationService(
+            notification_dao=NotificationDAO(session=session),
+            staff_account_dao=StaffAccountDAO(session=session),
+            task_dao=OnboardingTaskDAO(session=session),
+            vacancy_dao=VacancyDAO(session=session),
+            audit_service=audit_service,
+        )
+
+        service.emit_vacancy_assignment_notifications(
+            vacancy=vacancy,
+            previous_hiring_manager_staff_id=None,
+        )
+        session.commit()
+
+        manager_context = _build_auth_context(
+            role="manager",
+            subject_id=staff_ids["manager_id"],
+        )
+        accountant_context = _build_auth_context(
+            role="accountant",
+            subject_id=staff_ids["accountant_alpha_id"],
+        )
+
+        list_payload = service.list_notifications(
+            auth_context=manager_context,
+            request=_build_request("/api/v1/notifications"),
+            list_status="unread",
+            limit=20,
+            offset=0,
+        )
+        assert list_payload.total == 1
+        assert list_payload.unread_count == 1
+        assert list_payload.items[0].title == "Vacancy assigned: Platform Engineer"
+
+        digest = service.get_digest(
+            auth_context=manager_context,
+            request=_build_request("/api/v1/notifications/digest"),
+        )
+        assert digest.summary.unread_notification_count == 1
+        assert digest.summary.active_task_count == 1
+        assert digest.summary.overdue_task_count == 1
+        assert digest.summary.owned_open_vacancy_count == 1
+        assert len(digest.latest_unread_items) == 1
+
+        with pytest.raises(HTTPException) as exc_info:
+            service.mark_as_read(
+                notification_id=list_payload.items[0].notification_id,
+                auth_context=accountant_context,
+                request=_build_request(
+                    f"/api/v1/notifications/{list_payload.items[0].notification_id}/read",
+                    method="POST",
+                ),
+            )
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "notification_not_found"
+
+        read_payload = service.mark_as_read(
+            notification_id=list_payload.items[0].notification_id,
+            auth_context=manager_context,
+            request=_build_request(
+                f"/api/v1/notifications/{list_payload.items[0].notification_id}/read",
+                method="POST",
+            ),
+        )
+        assert read_payload.status == "read"
+
+        all_payload = service.list_notifications(
+            auth_context=manager_context,
+            request=_build_request("/api/v1/notifications?status=all"),
+            list_status="all",
+            limit=20,
+            offset=0,
+        )
+        assert all_payload.total == 1
+        assert all_payload.unread_count == 0
+        assert all_payload.items[0].status == "read"
+
+    assert [event["action"] for event in audit_service.events] == [
+        "notification:list",
+        "notification_digest:read",
+        "notification:update",
+        "notification:update",
+        "notification:list",
+    ]

--- a/apps/backend/tests/unit/rbac/test_rbac.py
+++ b/apps/backend/tests/unit/rbac/test_rbac.py
@@ -125,6 +125,24 @@ def test_manager_can_read_manager_workspace_permission() -> None:
     assert decision.allowed is True
 
 
+def test_manager_can_read_and_update_notifications_permissions() -> None:
+    """Verify manager role can access in-app notification read/update endpoints."""
+    read_decision = evaluate_permission(role="manager", permission="notification:read")
+    update_decision = evaluate_permission(role="manager", permission="notification:update")
+
+    assert read_decision.allowed is True
+    assert update_decision.allowed is True
+
+
+def test_accountant_can_read_and_update_notifications_permissions() -> None:
+    """Verify accountant role can access in-app notification read/update endpoints."""
+    read_decision = evaluate_permission(role="accountant", permission="notification:read")
+    update_decision = evaluate_permission(role="accountant", permission="notification:update")
+
+    assert read_decision.allowed is True
+    assert update_decision.allowed is True
+
+
 def test_employee_can_access_and_update_self_service_portal_permissions() -> None:
     """Verify employee role can read and update self-service onboarding portal endpoints."""
     read_decision = evaluate_permission(role="employee", permission="employee_portal:read")
@@ -195,6 +213,15 @@ def test_manager_is_denied_for_onboarding_task_list_permission() -> None:
     assert decision.allowed is False
     assert decision.reason is not None
     assert "onboarding_task:list" in decision.reason
+
+
+def test_hr_is_denied_for_notification_read_permission() -> None:
+    """Verify HR role cannot access manager/accountant notification endpoints in v1."""
+    decision = evaluate_permission(role="hr", permission="notification:read")
+
+    assert decision.allowed is False
+    assert decision.reason is not None
+    assert "notification:read" in decision.reason
 
 
 def test_employee_is_denied_for_onboarding_dashboard_permission() -> None:

--- a/apps/backend/tests/unit/vacancies/test_hire_conversion_atomicity.py
+++ b/apps/backend/tests/unit/vacancies/test_hire_conversion_atomicity.py
@@ -45,6 +45,14 @@ class _FakeAuditService:
         self.events.append(payload)
 
 
+class _NotificationServiceStub:
+    """Notification double that ignores vacancy ownership side effects."""
+
+    def emit_vacancy_assignment_notifications(self, **kwargs) -> None:
+        """Ignore notification writes during focused unit tests."""
+        del kwargs
+
+
 def _build_request() -> Request:
     """Create a minimal request object for service-level tests."""
     request = Request(
@@ -131,6 +139,7 @@ def test_hired_transition_rolls_back_when_handoff_persistence_fails(tmp_path: Pa
             interview_feedback_dao=InterviewFeedbackDAO(session=session),
             staff_account_dao=StaffAccountDAO(session=session),
             hire_conversion_service=_FailingHireConversionService(),  # type: ignore[arg-type]
+            notification_service=_NotificationServiceStub(),  # type: ignore[arg-type]
             audit_service=_FakeAuditService(),  # type: ignore[arg-type]
         )
 

--- a/apps/frontend/src/api/generated/openapi-types.ts
+++ b/apps/frontend/src/api/generated/openapi-types.ts
@@ -434,6 +434,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/notifications": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Notifications
+         * @description List notifications that belong to the current authenticated recipient.
+         */
+        get: operations["list_notifications_api_v1_notifications_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/notifications/digest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Notification Digest
+         * @description Return the on-demand notification digest for the current authenticated recipient.
+         */
+        get: operations["get_notification_digest_api_v1_notifications_digest_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/notifications/{notification_id}/read": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Mark Notification Read
+         * @description Mark one recipient-owned notification as read.
+         */
+        post: operations["mark_notification_read_api_v1_notifications__notification_id__read_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/onboarding/runs": {
         parameters: {
             query?: never;
@@ -2484,6 +2544,116 @@ export interface components {
             subject_id: string;
         };
         /**
+         * NotificationDigestResponse
+         * @description On-demand digest payload for the current authenticated recipient.
+         */
+        NotificationDigestResponse: {
+            /**
+             * Generated At
+             * Format: date-time
+             */
+            generated_at: string;
+            /** Latest Unread Items */
+            latest_unread_items: components["schemas"]["NotificationResponse"][];
+            summary: components["schemas"]["NotificationDigestSummaryResponse"];
+        };
+        /**
+         * NotificationDigestSummaryResponse
+         * @description Server-computed summary counters for the current notification workspace.
+         */
+        NotificationDigestSummaryResponse: {
+            /** Active Task Count */
+            active_task_count: number;
+            /** Overdue Task Count */
+            overdue_task_count: number;
+            /** Owned Open Vacancy Count */
+            owned_open_vacancy_count: number;
+            /** Unread Notification Count */
+            unread_notification_count: number;
+        };
+        /**
+         * NotificationListResponse
+         * @description Paginated notification list scoped to the current authenticated recipient.
+         */
+        NotificationListResponse: {
+            /** Items */
+            items: components["schemas"]["NotificationResponse"][];
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
+            /** Total */
+            total: number;
+            /** Unread Count */
+            unread_count: number;
+        };
+        /**
+         * NotificationPayload
+         * @description Structured additive notification payload exposed to frontend workspaces.
+         */
+        NotificationPayload: {
+            /** Due At */
+            due_at?: string | null;
+            /** Employee Full Name */
+            employee_full_name?: string | null;
+            /** Employee Id */
+            employee_id?: string | null;
+            /** Onboarding Id */
+            onboarding_id?: string | null;
+            /** Task Id */
+            task_id?: string | null;
+            /** Task Title */
+            task_title?: string | null;
+            /** Vacancy Id */
+            vacancy_id?: string | null;
+            /** Vacancy Title */
+            vacancy_title?: string | null;
+        };
+        /**
+         * NotificationResponse
+         * @description API representation of one in-app notification.
+         */
+        NotificationResponse: {
+            /** Body */
+            body: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Kind */
+            kind: string;
+            /**
+             * Notification Id
+             * Format: uuid
+             */
+            notification_id: string;
+            payload: components["schemas"]["NotificationPayload"];
+            /** Read At */
+            read_at: string | null;
+            /**
+             * Recipient Role
+             * @enum {string}
+             */
+            recipient_role: "admin" | "hr" | "manager" | "employee" | "leader" | "accountant";
+            /**
+             * Recipient Staff Id
+             * Format: uuid
+             */
+            recipient_staff_id: string;
+            /**
+             * Source Id
+             * Format: uuid
+             */
+            source_id: string;
+            /** Source Type */
+            source_type: string;
+            /** Status */
+            status: string;
+            /** Title */
+            title: string;
+        };
+        /**
          * OfferDecisionRequest
          * @description Optional note payload for recording accepted or declined offer status.
          */
@@ -4089,6 +4259,90 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["EmployeeProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_notifications_api_v1_notifications_get: {
+        parameters: {
+            query?: {
+                status?: "unread" | "all";
+                limit?: number;
+                offset?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_notification_digest_api_v1_notifications_digest_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationDigestResponse"];
+                };
+            };
+        };
+    };
+    mark_notification_read_api_v1_notifications__notification_id__read_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                notification_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationResponse"];
                 };
             };
             /** @description Validation Error */

--- a/apps/frontend/src/api/index.ts
+++ b/apps/frontend/src/api/index.ts
@@ -17,6 +17,11 @@ export {
   getOnboardingDashboardRun,
   listOnboardingDashboardRuns,
 } from "./onboardingDashboard";
+export {
+  getNotificationDigest,
+  listNotifications,
+  markNotificationRead,
+} from "./notifications";
 export { acceptOffer, declineOffer, getOffer, sendOffer, upsertOffer } from "./offers";
 export {
   getCandidateCvAnalysis,
@@ -90,6 +95,15 @@ export type {
   ManagerWorkspaceStageSummaryResponse,
   ManagerWorkspaceVacancyListItemResponse,
 } from "./managerWorkspace";
+export type {
+  NotificationDigestResponse,
+  NotificationDigestSummaryResponse,
+  NotificationListQuery,
+  NotificationListResponse,
+  NotificationListStatus,
+  NotificationPayloadResponse,
+  NotificationResponse,
+} from "./notifications";
 export type {
   OnboardingDashboardDetailResponse,
   OnboardingDashboardListQuery,

--- a/apps/frontend/src/api/notifications.ts
+++ b/apps/frontend/src/api/notifications.ts
@@ -1,0 +1,63 @@
+import type { components } from "./generated/openapi-types";
+import { typedApiClient } from "./typedClient";
+
+export type NotificationListStatus = "unread" | "all";
+export type NotificationPayloadResponse = components["schemas"]["NotificationPayload"];
+export type NotificationResponse = components["schemas"]["NotificationResponse"];
+export type NotificationListResponse = components["schemas"]["NotificationListResponse"];
+export type NotificationDigestSummaryResponse =
+  components["schemas"]["NotificationDigestSummaryResponse"];
+export type NotificationDigestResponse = components["schemas"]["NotificationDigestResponse"];
+
+export type NotificationListQuery = {
+  status?: NotificationListStatus;
+  limit?: number;
+  offset?: number;
+};
+
+function withAuth(accessToken: string): RequestInit {
+  return {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  };
+}
+
+/**
+ * Load recipient-scoped notifications for the current authenticated staff subject.
+ */
+export function listNotifications(
+  accessToken: string,
+  query: NotificationListQuery,
+): Promise<NotificationListResponse> {
+  return typedApiClient.get<NotificationListResponse>(
+    "/api/v1/notifications",
+    query,
+    withAuth(accessToken),
+  );
+}
+
+/**
+ * Load the on-demand digest for the current authenticated recipient.
+ */
+export function getNotificationDigest(accessToken: string): Promise<NotificationDigestResponse> {
+  return typedApiClient.get<NotificationDigestResponse>(
+    "/api/v1/notifications/digest",
+    undefined,
+    withAuth(accessToken),
+  );
+}
+
+/**
+ * Mark one recipient-owned notification as read.
+ */
+export function markNotificationRead(
+  accessToken: string,
+  notificationId: string,
+): Promise<NotificationResponse> {
+  return typedApiClient.post<NotificationResponse>(
+    `/api/v1/notifications/${notificationId}/read`,
+    undefined,
+    withAuth(accessToken),
+  );
+}

--- a/apps/frontend/src/app/i18n.ts
+++ b/apps/frontend/src/app/i18n.ts
@@ -251,6 +251,34 @@ const resources = {
           generic: "Failed to load accountant workspace data.",
         },
       },
+      notificationsPanel: {
+        title: "Notifications",
+        subtitle: {
+          manager:
+            "Review unread assignment updates and the latest manager-facing digest without leaving /.",
+          accountant:
+            "Review unread assignment updates and the latest accountant-facing digest without leaving /.",
+        },
+        loading: "Loading notifications...",
+        empty: "You are all caught up. No unread notifications remain.",
+        unread: "Unread",
+        markRead: "Mark as read",
+        markReadPending: "Saving...",
+        receivedAt: "Received: {{value}}",
+        summary: {
+          unread: "Unread: {{value}}",
+          activeTasks: "Active tasks: {{value}}",
+          overdueTasks: "Overdue tasks: {{value}}",
+          openVacancies: "Open vacancies: {{value}}",
+        },
+        errors: {
+          http_401: "Your session is missing or expired. Sign in again.",
+          http_403: "Your account does not have access to in-app notifications.",
+          http_404: "The requested notification is no longer available.",
+          http_422: "The notifications request is invalid.",
+          generic: "Failed to load or update notifications.",
+        },
+      },
       hrDashboard: {
         title: "Recruitment workspace",
         subtitle:
@@ -1172,6 +1200,34 @@ const resources = {
           http_403: "У вашей учётной записи нет доступа к accountant workspace.",
           http_422: "Запрос accountant workspace заполнен некорректно.",
           generic: "Не удалось загрузить accountant workspace.",
+        },
+      },
+      notificationsPanel: {
+        title: "Уведомления",
+        subtitle: {
+          manager:
+            "Смотрите непрочитанные назначения и актуальный digest менеджера, не покидая /.",
+          accountant:
+            "Смотрите непрочитанные назначения и актуальный digest бухгалтера, не покидая /.",
+        },
+        loading: "Загрузка уведомлений...",
+        empty: "Непрочитанных уведомлений нет.",
+        unread: "Непрочитано",
+        markRead: "Отметить как прочитанное",
+        markReadPending: "Сохраняем...",
+        receivedAt: "Получено: {{value}}",
+        summary: {
+          unread: "Непрочитано: {{value}}",
+          activeTasks: "Активные задачи: {{value}}",
+          overdueTasks: "Просрочено: {{value}}",
+          openVacancies: "Открытые вакансии: {{value}}",
+        },
+        errors: {
+          http_401: "Сессия отсутствует или истекла. Войдите заново.",
+          http_403: "У вашей учётной записи нет доступа к in-app уведомлениям.",
+          http_404: "Запрошенное уведомление больше недоступно.",
+          http_422: "Запрос уведомлений заполнен некорректно.",
+          generic: "Не удалось загрузить или обновить уведомления.",
         },
       },
       hrDashboard: {

--- a/apps/frontend/src/components/NotificationsPanel.test.tsx
+++ b/apps/frontend/src/components/NotificationsPanel.test.tsx
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import "../app/i18n";
+import { NotificationsPanel } from "./NotificationsPanel";
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+function renderNotificationsPanel(workspace: "manager" | "accountant" = "manager") {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <NotificationsPanel accessToken="access-token" workspace={workspace} />
+    </QueryClientProvider>,
+  );
+}
+
+function jsonResponse(payload: unknown, status = 200): Promise<Response> {
+  return Promise.resolve(
+    new Response(JSON.stringify(payload), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+describe("NotificationsPanel", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders unread notifications and marks one item as read", async () => {
+    let isRead = false;
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/v1/notifications/digest")) {
+        return jsonResponse({
+          generated_at: "2026-03-13T10:00:00Z",
+          summary: {
+            unread_notification_count: isRead ? 0 : 1,
+            active_task_count: 2,
+            overdue_task_count: 1,
+            owned_open_vacancy_count: 1,
+          },
+          latest_unread_items: isRead
+            ? []
+            : [
+                {
+                  notification_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+                  recipient_staff_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+                  recipient_role: "manager",
+                  kind: "vacancy_assignment",
+                  source_type: "vacancy",
+                  source_id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+                  status: "unread",
+                  title: "Vacancy assigned: Platform Engineer",
+                  body: "You were assigned as the hiring manager for Platform Engineer in Engineering.",
+                  payload: {
+                    vacancy_id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+                    onboarding_id: null,
+                    task_id: null,
+                    employee_id: null,
+                    vacancy_title: "Platform Engineer",
+                    task_title: null,
+                    employee_full_name: null,
+                    due_at: null,
+                  },
+                  created_at: "2026-03-13T10:00:00Z",
+                  read_at: null,
+                },
+              ],
+        });
+      }
+      if (url.includes("/api/v1/notifications?")) {
+        return jsonResponse({
+          items: isRead
+            ? []
+            : [
+                {
+                  notification_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+                  recipient_staff_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+                  recipient_role: "manager",
+                  kind: "vacancy_assignment",
+                  source_type: "vacancy",
+                  source_id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+                  status: "unread",
+                  title: "Vacancy assigned: Platform Engineer",
+                  body: "You were assigned as the hiring manager for Platform Engineer in Engineering.",
+                  payload: {
+                    vacancy_id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+                    onboarding_id: null,
+                    task_id: null,
+                    employee_id: null,
+                    vacancy_title: "Platform Engineer",
+                    task_title: null,
+                    employee_full_name: null,
+                    due_at: null,
+                  },
+                  created_at: "2026-03-13T10:00:00Z",
+                  read_at: null,
+                },
+              ],
+          total: isRead ? 0 : 1,
+          limit: 5,
+          offset: 0,
+          unread_count: isRead ? 0 : 1,
+        });
+      }
+      if (url.endsWith("/api/v1/notifications/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/read")) {
+        isRead = true;
+        return jsonResponse({
+          notification_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          recipient_staff_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          recipient_role: "manager",
+          kind: "vacancy_assignment",
+          source_type: "vacancy",
+          source_id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          status: "read",
+          title: "Vacancy assigned: Platform Engineer",
+          body: "You were assigned as the hiring manager for Platform Engineer in Engineering.",
+          payload: {
+            vacancy_id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+            onboarding_id: null,
+            task_id: null,
+            employee_id: null,
+            vacancy_title: "Platform Engineer",
+            task_title: null,
+            employee_full_name: null,
+            due_at: null,
+          },
+          created_at: "2026-03-13T10:00:00Z",
+          read_at: "2026-03-13T10:05:00Z",
+        });
+      }
+      return jsonResponse({});
+    });
+
+    renderNotificationsPanel("manager");
+
+    expect(await screen.findByText(/notifications|уведомления/i)).toBeDefined();
+    expect(await screen.findByText(/vacancy assigned: platform engineer/i)).toBeDefined();
+    expect(await screen.findByText(/open vacancies: 1|открытые вакансии: 1/i)).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: /mark as read|отметить как прочитанное/i }));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some((call) =>
+          String(call[0]).includes("/api/v1/notifications/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/read"),
+        ),
+      ).toBe(true);
+    });
+    expect(await screen.findByText(/you are all caught up|непрочитанных уведомлений нет/i)).toBeDefined();
+  });
+
+  it("renders accountant empty state without manager-only summary chip", async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/v1/notifications/digest")) {
+        return jsonResponse({
+          generated_at: "2026-03-13T10:00:00Z",
+          summary: {
+            unread_notification_count: 0,
+            active_task_count: 1,
+            overdue_task_count: 0,
+            owned_open_vacancy_count: 0,
+          },
+          latest_unread_items: [],
+        });
+      }
+      if (url.includes("/api/v1/notifications?")) {
+        return jsonResponse({
+          items: [],
+          total: 0,
+          limit: 5,
+          offset: 0,
+          unread_count: 0,
+        });
+      }
+      return jsonResponse({});
+    });
+
+    renderNotificationsPanel("accountant");
+
+    expect(await screen.findByText(/notifications|уведомления/i)).toBeDefined();
+    expect(await screen.findByText(/you are all caught up|непрочитанных уведомлений нет/i)).toBeDefined();
+    expect(screen.queryByText(/open vacancies|открытые вакансии/i)).toBeNull();
+  });
+});

--- a/apps/frontend/src/components/NotificationsPanel.tsx
+++ b/apps/frontend/src/components/NotificationsPanel.tsx
@@ -1,0 +1,226 @@
+import {
+  Alert,
+  Button,
+  Chip,
+  CircularProgress,
+  Divider,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+
+import {
+  ApiError,
+  getNotificationDigest,
+  listNotifications,
+  markNotificationRead,
+  type NotificationDigestResponse,
+  type NotificationResponse,
+} from "../api";
+
+const MAX_UNREAD_ITEMS = 5;
+const EMPTY_DIGEST: NotificationDigestResponse = {
+  generated_at: "",
+  summary: {
+    unread_notification_count: 0,
+    active_task_count: 0,
+    overdue_task_count: 0,
+    owned_open_vacancy_count: 0,
+  },
+  latest_unread_items: [],
+};
+
+type NotificationsPanelProps = {
+  accessToken: string;
+  workspace: "manager" | "accountant";
+};
+
+/**
+ * Shared in-app notifications panel for manager and accountant workspaces.
+ */
+export function NotificationsPanel({ accessToken, workspace }: NotificationsPanelProps) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  const digestQuery = useQuery({
+    queryKey: ["notifications-digest", accessToken],
+    queryFn: () => getNotificationDigest(accessToken),
+    enabled: Boolean(accessToken),
+    retry: false,
+  });
+  const listQuery = useQuery({
+    queryKey: ["notifications-list", accessToken],
+    queryFn: () =>
+      listNotifications(accessToken, {
+        status: "unread",
+        limit: MAX_UNREAD_ITEMS,
+        offset: 0,
+      }),
+    enabled: Boolean(accessToken),
+    retry: false,
+  });
+  const markReadMutation = useMutation({
+    mutationFn: (notificationId: string) => markNotificationRead(accessToken, notificationId),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["notifications-digest", accessToken],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["notifications-list", accessToken],
+        }),
+      ]);
+    },
+  });
+
+  const summary = digestQuery.data?.summary ?? EMPTY_DIGEST.summary;
+  const unreadItems = Array.isArray(listQuery.data?.items)
+    ? listQuery.data.items
+    : Array.isArray(digestQuery.data?.latest_unread_items)
+      ? digestQuery.data.latest_unread_items
+      : [];
+  const hasLoadedPayload = digestQuery.isSuccess || listQuery.isSuccess;
+  const error = digestQuery.error ?? listQuery.error;
+
+  return (
+    <Paper sx={{ p: 3 }}>
+      <Stack spacing={2.5}>
+        <Stack spacing={0.5}>
+          <Typography variant="h6">{t("notificationsPanel.title")}</Typography>
+          <Typography variant="body2" color="text.secondary">
+            {t(`notificationsPanel.subtitle.${workspace}`)}
+          </Typography>
+        </Stack>
+
+        <Stack direction={{ xs: "column", md: "row" }} spacing={1} flexWrap="wrap" useFlexGap>
+          <Chip
+            label={t("notificationsPanel.summary.unread", {
+              value: summary.unread_notification_count,
+            })}
+            color="primary"
+            variant="outlined"
+          />
+          <Chip
+            label={t("notificationsPanel.summary.activeTasks", {
+              value: summary.active_task_count,
+            })}
+            variant="outlined"
+          />
+          <Chip
+            label={t("notificationsPanel.summary.overdueTasks", {
+              value: summary.overdue_task_count,
+            })}
+            color={summary.overdue_task_count > 0 ? "warning" : "default"}
+            variant="outlined"
+          />
+          {workspace === "manager" ? (
+            <Chip
+              label={t("notificationsPanel.summary.openVacancies", {
+                value: summary.owned_open_vacancy_count,
+              })}
+              variant="outlined"
+            />
+          ) : null}
+        </Stack>
+
+        {!hasLoadedPayload && (digestQuery.isLoading || listQuery.isLoading) ? (
+          <Stack spacing={2} alignItems="center" sx={{ py: 2 }}>
+            <CircularProgress size={24} />
+            <Typography variant="body2">{t("notificationsPanel.loading")}</Typography>
+          </Stack>
+        ) : null}
+
+        {error ? (
+          <Alert severity="error">{resolveNotificationsError(error, t)}</Alert>
+        ) : null}
+
+        {error || (!hasLoadedPayload && (digestQuery.isLoading || listQuery.isLoading)) ? null : unreadItems.length === 0 ? (
+          <Alert severity="info">{t("notificationsPanel.empty")}</Alert>
+        ) : (
+          <Stack divider={<Divider flexItem />}>
+            {unreadItems.map((notification) => (
+              <NotificationRow
+                key={notification.notification_id}
+                notification={notification}
+                isPending={markReadMutation.isPending && markReadMutation.variables === notification.notification_id}
+                onMarkRead={() => markReadMutation.mutate(notification.notification_id)}
+              />
+            ))}
+          </Stack>
+        )}
+      </Stack>
+    </Paper>
+  );
+}
+
+type NotificationRowProps = {
+  notification: NotificationResponse;
+  isPending: boolean;
+  onMarkRead: () => void;
+};
+
+function NotificationRow({ notification, isPending, onMarkRead }: NotificationRowProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Stack
+      direction={{ xs: "column", md: "row" }}
+      spacing={2}
+      justifyContent="space-between"
+      sx={{ py: 1.5 }}
+    >
+      <Stack spacing={0.75}>
+        <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+          <Typography variant="subtitle2">{notification.title}</Typography>
+          <Chip
+            label={t("notificationsPanel.unread")}
+            size="small"
+            color="primary"
+            variant="outlined"
+          />
+        </Stack>
+        <Typography variant="body2">{notification.body}</Typography>
+        <Typography variant="caption" color="text.secondary">
+          {t("notificationsPanel.receivedAt", {
+            value: formatDateTimeValue(notification.created_at),
+          })}
+        </Typography>
+      </Stack>
+
+      <Stack direction="row" justifyContent={{ xs: "flex-start", md: "flex-end" }}>
+        <Button size="small" variant="outlined" disabled={isPending} onClick={onMarkRead}>
+          {isPending
+            ? t("notificationsPanel.markReadPending")
+            : t("notificationsPanel.markRead")}
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}
+
+function resolveNotificationsError(
+  error: unknown,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): string {
+  if (error instanceof ApiError) {
+    return t(`notificationsPanel.errors.${error.detail}`, {
+      defaultValue: t(`notificationsPanel.errors.http_${error.status}`, {
+        defaultValue: t("notificationsPanel.errors.generic"),
+      }),
+    });
+  }
+  return t("notificationsPanel.errors.generic");
+}
+
+function formatDateTimeValue(value: string): string {
+  if (!value) {
+    return "";
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleString();
+}

--- a/apps/frontend/src/pages/AccountantWorkspacePage.tsx
+++ b/apps/frontend/src/pages/AccountantWorkspacePage.tsx
@@ -26,6 +26,7 @@ import {
 } from "../api";
 import { readAuthSession } from "../app/auth/session";
 import { useSentryRouteTags } from "../app/observability/sentry";
+import { NotificationsPanel } from "../components/NotificationsPanel";
 
 const ROWS_PER_PAGE = 20;
 
@@ -95,6 +96,8 @@ export function AccountantWorkspacePage() {
           {t("accountantWorkspaceSubtitle")}
         </Typography>
       </Stack>
+
+      <NotificationsPanel accessToken={accessToken} workspace="accountant" />
 
       <Stack
         component="form"

--- a/apps/frontend/src/pages/ManagerWorkspacePage.tsx
+++ b/apps/frontend/src/pages/ManagerWorkspacePage.tsx
@@ -26,6 +26,7 @@ import {
 } from "../api";
 import { readAuthSession } from "../app/auth/session";
 import { useSentryRouteTags } from "../app/observability/sentry";
+import { NotificationsPanel } from "../components/NotificationsPanel";
 import { OnboardingDashboardPanel } from "../components/OnboardingDashboardPanel";
 
 const EMPTY_OVERVIEW: ManagerWorkspaceOverviewResponse = {
@@ -90,6 +91,8 @@ export function ManagerWorkspacePage() {
           {t("managerDashboard.subtitle")}
         </Typography>
       </Stack>
+
+      <NotificationsPanel accessToken={accessToken} workspace="manager" />
 
       <Stack direction={{ xs: "column", md: "row" }} spacing={1} flexWrap="wrap" useFlexGap>
         <Chip

--- a/docs/api/openapi.frozen.json
+++ b/docs/api/openapi.frozen.json
@@ -3270,6 +3270,299 @@
         "title": "MeResponse",
         "type": "object"
       },
+      "NotificationDigestResponse": {
+        "description": "On-demand digest payload for the current authenticated recipient.",
+        "properties": {
+          "generated_at": {
+            "format": "date-time",
+            "title": "Generated At",
+            "type": "string"
+          },
+          "latest_unread_items": {
+            "items": {
+              "$ref": "#/components/schemas/NotificationResponse"
+            },
+            "title": "Latest Unread Items",
+            "type": "array"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/NotificationDigestSummaryResponse"
+          }
+        },
+        "required": [
+          "generated_at",
+          "summary",
+          "latest_unread_items"
+        ],
+        "title": "NotificationDigestResponse",
+        "type": "object"
+      },
+      "NotificationDigestSummaryResponse": {
+        "description": "Server-computed summary counters for the current notification workspace.",
+        "properties": {
+          "active_task_count": {
+            "minimum": 0.0,
+            "title": "Active Task Count",
+            "type": "integer"
+          },
+          "overdue_task_count": {
+            "minimum": 0.0,
+            "title": "Overdue Task Count",
+            "type": "integer"
+          },
+          "owned_open_vacancy_count": {
+            "minimum": 0.0,
+            "title": "Owned Open Vacancy Count",
+            "type": "integer"
+          },
+          "unread_notification_count": {
+            "minimum": 0.0,
+            "title": "Unread Notification Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "unread_notification_count",
+          "active_task_count",
+          "overdue_task_count",
+          "owned_open_vacancy_count"
+        ],
+        "title": "NotificationDigestSummaryResponse",
+        "type": "object"
+      },
+      "NotificationListResponse": {
+        "description": "Paginated notification list scoped to the current authenticated recipient.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/NotificationResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "minimum": 1.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "minimum": 0.0,
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "minimum": 0.0,
+            "title": "Total",
+            "type": "integer"
+          },
+          "unread_count": {
+            "minimum": 0.0,
+            "title": "Unread Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset",
+          "unread_count"
+        ],
+        "title": "NotificationListResponse",
+        "type": "object"
+      },
+      "NotificationPayload": {
+        "additionalProperties": false,
+        "description": "Structured additive notification payload exposed to frontend workspaces.",
+        "properties": {
+          "due_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Due At"
+          },
+          "employee_full_name": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Employee Full Name"
+          },
+          "employee_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Employee Id"
+          },
+          "onboarding_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Onboarding Id"
+          },
+          "task_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Id"
+          },
+          "task_title": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Title"
+          },
+          "vacancy_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vacancy Id"
+          },
+          "vacancy_title": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vacancy Title"
+          }
+        },
+        "title": "NotificationPayload",
+        "type": "object"
+      },
+      "NotificationResponse": {
+        "description": "API representation of one in-app notification.",
+        "properties": {
+          "body": {
+            "title": "Body",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "kind": {
+            "title": "Kind",
+            "type": "string"
+          },
+          "notification_id": {
+            "format": "uuid",
+            "title": "Notification Id",
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/NotificationPayload"
+          },
+          "read_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Read At"
+          },
+          "recipient_role": {
+            "enum": [
+              "admin",
+              "hr",
+              "manager",
+              "employee",
+              "leader",
+              "accountant"
+            ],
+            "title": "Recipient Role",
+            "type": "string"
+          },
+          "recipient_staff_id": {
+            "format": "uuid",
+            "title": "Recipient Staff Id",
+            "type": "string"
+          },
+          "source_id": {
+            "format": "uuid",
+            "title": "Source Id",
+            "type": "string"
+          },
+          "source_type": {
+            "title": "Source Type",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "notification_id",
+          "recipient_staff_id",
+          "recipient_role",
+          "kind",
+          "source_type",
+          "source_id",
+          "status",
+          "title",
+          "body",
+          "payload",
+          "created_at",
+          "read_at"
+        ],
+        "title": "NotificationResponse",
+        "type": "object"
+      },
       "OfferDecisionRequest": {
         "additionalProperties": false,
         "description": "Optional note payload for recording accepted or declined offer status.",
@@ -6761,6 +7054,158 @@
         "summary": "Get Employee Profile",
         "tags": [
           "employees"
+        ]
+      }
+    },
+    "/api/v1/notifications": {
+      "get": {
+        "description": "List notifications that belong to the current authenticated recipient.",
+        "operationId": "list_notifications_api_v1_notifications_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "default": "unread",
+              "enum": [
+                "unread",
+                "all"
+              ],
+              "title": "Status",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Notifications",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/api/v1/notifications/digest": {
+      "get": {
+        "description": "Return the on-demand notification digest for the current authenticated recipient.",
+        "operationId": "get_notification_digest_api_v1_notifications_digest_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationDigestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Notification Digest",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/api/v1/notifications/{notification_id}/read": {
+      "post": {
+        "description": "Mark one recipient-owned notification as read.",
+        "operationId": "mark_notification_read_api_v1_notifications__notification_id__read_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "notification_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Notification Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Mark Notification Read",
+        "tags": [
+          "notifications"
         ]
       }
     },

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -47,6 +47,7 @@ Use this log for decisions that change interfaces, data models, deployment topol
 | ADR-0040 | 2026-03-12 | accepted | Keep default Ollama runtime external-host compatible while adding an opt-in compose-local `ai-local` profile and separate scoring smoke | architect + backend-engineer | compose topology, scoring runtime, operator verification |
 | ADR-0041 | 2026-03-12 | accepted | Introduce explicit vacancy ownership and dedicated manager workspace reads on `/` | architect + backend-engineer + frontend-engineer | manager workspace visibility policy, vacancy ownership signal, frontend route semantics |
 | ADR-0042 | 2026-03-13 | accepted | Add accountant workspace + dual-format controlled export as a thin finance adapter over onboarding data | architect + backend-engineer + frontend-engineer | finance adapter boundary, controlled exports, frontend route semantics, observability |
+| ADR-0043 | 2026-03-13 | accepted | Add recipient-scoped in-app notifications and on-demand digests for manager/accountant workspaces | architect + backend-engineer + frontend-engineer | notification package boundary, recipient visibility policy, frontend embedded workspaces, OpenAPI contract |
 ## ADR-0001
 - Context: Project is at bootstrap stage and lacks durable knowledge artifacts.
 - Decision: Standardize docs structure under `docs/`, enforce updates per task, and keep agent workflow under `.ai/`.
@@ -874,3 +875,41 @@ Use this log for decisions that change interfaces, data models, deployment topol
     scope.
   - The employee domain stays the source of truth for onboarding state, while the finance adapter
     remains a thin read boundary layered on top of it.
+
+## ADR-0043
+- Context: `TASK-09-04` required role-specific notifications after manager/accountant workspaces
+  were already implemented, but the system still had no approved outbound notification
+  infrastructure, scheduler, event bus, or template-editor scope. The existing reliable seams were
+  narrow and explicit: vacancy ownership in `vacancy_service.py` and onboarding assignment changes
+  in `onboarding_task_service.py`.
+- Decision:
+  - Introduce a thin backend package `hrm_backend/notifications` for recipient-scoped in-app
+    notification persistence plus on-demand digest reads.
+  - Keep v1 delivery intentionally narrow:
+    - in-app only;
+    - mandatory recipient roles limited to `manager` and `accountant`;
+    - digest computed synchronously on `GET /api/v1/notifications/digest`;
+    - no email, SMS, webhooks, outbox, scheduler, or template-editor scope.
+  - Expose protected APIs:
+    - `GET /api/v1/notifications?status=unread|all&limit&offset`
+    - `POST /api/v1/notifications/{notification_id}/read`
+    - `GET /api/v1/notifications/digest`
+  - Keep reads and updates fail-closed:
+    - list/read-state changes are limited to `recipient_staff_id=<current subject>`;
+    - `POST /read` returns `404 notification_not_found` outside recipient scope.
+  - Emit notifications only from explicit assignment seams:
+    - vacancy ownership changes to `vacancies.hiring_manager_staff_id`;
+    - onboarding task assignment changes on `assigned_role` / `assigned_staff_id`.
+  - Fan out role-based onboarding notifications only to active manager/accountant accounts and
+    dedupe by recipient plus event fingerprint to avoid duplicate in-app rows on repeated writes.
+  - Keep candidate invite delivery manual-only and leave interview invitation transport unchanged.
+  - Solo-maintainer architectural self-review:
+    this ADR records that the slice stays additive, keeps current `/` route semantics, avoids new
+    async infrastructure, and preserves explicit fail-closed visibility boundaries.
+- Consequences:
+  - Managers and accountants now get one embedded in-app notification block on `/` without adding a
+    separate notifications route tree.
+  - Notification storage remains operationally simple because reads come from one `notifications`
+    table and digests are computed on demand from current vacancy/task state.
+  - Future outbound delivery channels, template systems, broader role coverage, or async delivery
+    infrastructure can be layered later without reopening the current read/update contract.

--- a/docs/architecture/decomposition.md
+++ b/docs/architecture/decomposition.md
@@ -1,7 +1,7 @@
 # Architecture Decomposition
 
 ## Last Updated
-- Date: 2026-03-11
+- Date: 2026-03-13
 - Updated by: architect + backend-engineer
 
 This document breaks the system architecture from high-level domains into smaller technical units.
@@ -40,7 +40,7 @@ industries rather than only IT roles.
 | Employee Profile Service | Employee | Employee identity and profile lifecycle | REST |
 | Onboarding Service | Employee | Onboarding templates, tasks and status tracking | REST + async |
 | Workflow Automation Service | HR Operations | Rule engine and triggered HR tasks | Event-driven |
-| Notification Service | Platform | Email/in-app notifications and templates | Async jobs |
+| Notification Service | Platform | Recipient-scoped in-app notifications and on-demand digests in v1; outbound templates/channels later | REST |
 | Audit Service | Platform | Immutable security and business audit logs | Event ingestion |
 | Reporting Service | Analytics | KPI aggregation and dashboards | Read APIs |
 | Accounting Export Service | Finance Adapter | Controlled export for accounting workflows | File/API adapter |
@@ -97,6 +97,16 @@ industries rather than only IT roles.
 - Access Policy Module:
   map validated role claims to RBAC permission checks.
 
+### 6. Notification Service
+- Recipient Resolver Module:
+  map vacancy ownership and onboarding assignment changes to manager/accountant staff recipients.
+- In-App Store Module:
+  persist deduped recipient-scoped notification rows.
+- Digest Read Model Module:
+  compute unread counts plus manager/accountant task or vacancy summary counters on demand.
+- Delivery Policy Module:
+  keep v1 fail-closed and in-app only; defer outbound channels/templates.
+
 ## Data Decomposition
 
 | Data Group | Primary Owner Service | Storage Type | Notes |
@@ -108,6 +118,7 @@ industries rather than only IT roles.
 | Interview events and feedback | Interview Service | PostgreSQL | Audit-linked |
 | Employee profiles | Employee Profile Service | PostgreSQL | Created post-hire |
 | Onboarding tasks | Onboarding Service | PostgreSQL | Linked to employee profile |
+| In-app notifications | Notification Service | PostgreSQL | Recipient-scoped, deduped, and read-tracked |
 | Automation executions | Workflow Automation Service | PostgreSQL | Used for KPI and incident analysis |
 | Audit events | Audit Service | Append-only storage | Compliance evidence |
 | Auth denylist markers (`jti`/`sid`) | Auth and Access Service | Redis | Valid tokens are not persisted server-side |
@@ -141,7 +152,7 @@ industries rather than only IT roles.
 - Workflow Automation Service (expanded rules)
 - Reporting Service
 - Accounting Export Service
-- Notification Service (full template coverage)
+- Notification Service (in-app + digest baseline, outbound/template coverage later)
 
 ## Ownership Decomposition (Suggested)
 

--- a/docs/architecture/diagrams.md
+++ b/docs/architecture/diagrams.md
@@ -1,7 +1,7 @@
 # Architecture Diagrams
 
 ## Last Updated
-- Date: 2026-03-12
+- Date: 2026-03-13
 - Updated by: architect + backend-engineer + frontend-engineer
 
 This file is the canonical diagram set for the system. Update diagrams whenever architecture, data flow, or critical business flow changes.
@@ -49,6 +49,7 @@ flowchart TB
     REC[Recruitment Services]
     SCOREDOM[Match Scoring Service]
     EMPDOM[Employee Services]
+    NOTIFY[Notification Service]
     HROPS[HR Automation Services]
     WORKERS[Background Workers]
     ANALYTICS[Reporting and KPI Services]
@@ -75,6 +76,7 @@ flowchart TB
   API --> REC
   API --> SCOREDOM
   API --> EMPDOM
+  API --> NOTIFY
   API --> HROPS
   API --> ANALYTICS
   WORKERS --> POLICY
@@ -86,12 +88,14 @@ flowchart TB
   REC -.imports.-> COREPKG
   SCOREDOM -.imports.-> COREPKG
   EMPDOM -.imports.-> COREPKG
+  NOTIFY -.imports.-> COREPKG
   HROPS -.imports.-> COREPKG
   ANALYTICS -.imports.-> COREPKG
 
   REC --> DB
   SCOREDOM --> DB
   EMPDOM --> DB
+  NOTIFY --> DB
   HROPS --> DB
   ANALYTICS --> DB
   AUDIT --> DB
@@ -473,6 +477,49 @@ sequenceDiagram
   FIN->>AUD: accounting_export:download success
   FIN-->>API: Attachment bytes + filename
   API-->>UI: Browser download starts
+```
+
+## Diagram 9C: Role-Specific Notification Sequence
+
+```mermaid
+sequenceDiagram
+  participant STAFF as HR/Admin
+  participant API as API Gateway
+  participant VAC as Vacancy Service
+  participant EMP as Onboarding Task Service
+  participant NOTIFY as Notification Service
+  participant DB as PostgreSQL
+  participant USER as Manager or Accountant
+  participant UI as React.js + TypeScript UI
+
+  alt Vacancy ownership change
+    STAFF->>API: PATCH /api/v1/vacancies/{vacancy_id}
+    API->>VAC: Apply `hiring_manager_staff_id` update
+    VAC->>NOTIFY: Emit manager notification when owner changed
+  else Onboarding assignment change
+    STAFF->>API: PATCH /api/v1/onboarding/runs/{onboarding_id}/tasks/{task_id}
+    API->>EMP: Apply assignment/status/SLA patch
+    EMP->>NOTIFY: Emit manager/accountant notification when recipients changed
+  end
+  NOTIFY->>DB: Persist deduped `notifications` rows in the same transaction
+
+  USER->>UI: Open `/`
+  UI->>API: GET /api/v1/notifications/digest
+  API->>NOTIFY: Validate recipient scope + compute digest on demand
+  NOTIFY->>DB: Load unread rows + current vacancy/task counters
+  NOTIFY-->>API: digest payload
+  API-->>UI: Render summary chips
+
+  UI->>API: GET /api/v1/notifications?status=unread&limit&offset
+  API->>NOTIFY: Validate recipient scope + list unread items
+  NOTIFY-->>API: recipient-owned notifications only
+  API-->>UI: Render unread notifications
+
+  USER->>UI: Mark one notification as read
+  UI->>API: POST /api/v1/notifications/{notification_id}/read
+  API->>NOTIFY: Re-validate `recipient_staff_id=<actor>`
+  NOTIFY->>DB: Set `read_at` for that recipient row
+  API-->>UI: Updated read state
 ```
 
 ## Diagram 10: Deployment and Trust Boundaries

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,7 +1,7 @@
 # Architecture Overview
 
 ## Last Updated
-- Date: 2026-03-12
+- Date: 2026-03-13
 - Updated by: architect + backend-engineer + frontend-engineer
 
 ## System Context
@@ -49,6 +49,7 @@ flowchart LR
 | Employee Domain | Durable hire-conversion handoff, explicit employee profile bootstrap, onboarding workflows, employee self-service onboarding portal, and HR/manager onboarding progress visibility | Hire conversion handoff, profile/bootstrap/template/portal/dashboard requests | Employee handoff rows, employee profiles, onboarding runs/templates/tasks, employee-facing onboarding views, and staff/manager onboarding progress read models | hr-tech |
 | HR Operations Domain | HR process automation and workflow execution | Rules and triggers | Automated tasks, status updates | hr-ops |
 | Finance Domain Adapter | Accounting-facing data exchange | Payroll/accounting requests | Exported records and statuses | finance-tech |
+| Notification Domain | Recipient-scoped in-app notifications and server-computed digests for manager/accountant workspaces | Vacancy ownership changes, onboarding assignment changes, protected notification reads | Dedupe-safe notification rows, unread/read state, digest counters, and embedded workspace notification blocks | platform |
 | AI Adapter | External model integration for CV analysis and match scoring | CV files, vacancy profiles, scoring prompts | Structured candidate insights and score responses | ai-platform |
 | Integration Layer | External connector abstraction | Internal events/commands | Google Calendar actions | platform |
 | Reporting and Audit | KPI tracking and compliance evidence | Domain events | Dashboards, audit logs | data-platform |
@@ -92,13 +93,15 @@ flowchart LR
    recruitment domain loads only vacancies where `vacancies.hiring_manager_staff_id=<actor>` ->
    latest pipeline transitions, candidate counts, and active interviews build a deterministic hiring summary and vacancy list ->
    `GET /api/v1/vacancies/{vacancy_id}/manager-workspace/candidates` re-validates the selected vacancy scope and returns a read-only candidate/pipeline snapshot ->
-   the same page reuses the onboarding dashboard block from `/api/v1/onboarding/runs*`.
+   the same page reuses the onboarding dashboard block from `/api/v1/onboarding/runs*` plus
+   `GET /api/v1/notifications*` for unread manager notifications and digest counters.
 6. Accountant Workspace Flow:
    accountant opens `/` -> frontend resolves `AccountantWorkspacePage` ->
    `GET /api/v1/accounting/workspace` validates `accounting:read` ->
    finance adapter loads `employee_profiles + onboarding_runs + onboarding_tasks` from the employee domain ->
    finance adapter keeps only runs with `assigned_role=accountant` or `assigned_staff_id=<actor>` ->
-   the same filtered row model is reused for paginated UI reads and `GET /api/v1/accounting/workspace/export?format=csv|xlsx` attachments.
+   the same filtered row model is reused for paginated UI reads and `GET /api/v1/accounting/workspace/export?format=csv|xlsx` attachments, while
+   `GET /api/v1/notifications*` adds unread accountant notifications plus digest counters.
 7. HR Automation Flow:
    rule trigger -> workflow engine -> task creation/assignment -> status update and reporting.
 8. Public Candidate Apply Flow:
@@ -115,6 +118,13 @@ flowchart LR
    user opens a critical frontend route -> Sentry tags `workspace`/`role`/`route` are emitted ->
    shared HTTP client captures request failures with route metadata -> top-level render boundary
    captures React render failures -> Sentry stores tagged events with environment/release/tracing context.
+13. Role-Specific Notification Flow:
+   HR/admin updates `vacancies.hiring_manager_staff_id` or onboarding task assignment metadata ->
+   notification domain resolves only active manager/accountant recipients ->
+   deduped `notifications` rows are persisted in the same request transaction ->
+   recipient opens `/` -> `GET /api/v1/notifications/digest` computes summary counters on demand ->
+   `GET /api/v1/notifications?status=unread` returns recipient-owned unread items ->
+   `POST /api/v1/notifications/{notification_id}/read` marks only that recipient row as read.
 
 ## Data Boundaries
 - Source of truth entities:
@@ -164,6 +174,11 @@ flowchart LR
   the employee-facing completion state read from `/api/v1/employees/me/onboarding`; HR/admin and
   managers consume the same durable task rows through `/api/v1/onboarding/runs*` without a
   separate reporting table in this slice.
+- Notification artifacts:
+  `notifications` rows keyed by `notification_id`, including recipient subject/role snapshots,
+  source identifiers, dedupe keys, human-readable title/body copy, structured payload JSON,
+  created timestamp, and optional `read_at`; manager/accountant digests reuse these rows plus live
+  vacancy/task reads without a scheduler or outbound delivery table in this slice.
 - Accountant workspace export artifacts:
   the finance adapter derives accountant-visible rows directly from `employee_profiles`,
   `onboarding_runs`, and `onboarding_tasks`; visibility stays fail-closed on accountant
@@ -203,6 +218,11 @@ flowchart LR
   `hrm_backend/finance` owns read-only accountant workspace APIs on `/api/v1/accounting/workspace`
   and `/api/v1/accounting/workspace/export`, gated by `accounting:read` and fail-closed
   accountant task assignment visibility while reusing employee-domain persistence models directly.
+- Implemented notifications boundary:
+  `hrm_backend/notifications` owns recipient-scoped in-app notification APIs on
+  `/api/v1/notifications*`, persists deduped `notifications` rows, computes digests on demand, and
+  is emitted only from existing vacancy ownership and onboarding task-assignment seams without
+  adding outbound channels, schedulers, or a separate event bus in this slice.
 - Environment baseline: Docker + Docker Compose for deterministic local/dev and CI-aligned stack startup.
 - Compose baseline services: `frontend`, `backend`, `backend-worker`, `postgres`, `postgres-init`, `backend-migrate`, `redis`, `minio`, `minio-init`.
 - Compose bootstrap baseline: `postgres-init`, `backend-migrate`, and `minio-init` are one-shot prerequisites before steady-state services are considered ready.
@@ -261,6 +281,8 @@ flowchart LR
 - First-time employee self-service access currently relies on exact e-mail reconciliation when
   `employee_profiles.staff_account_id` is still null; ambiguous duplicate e-mail data fails closed
   with an identity-conflict error until HR cleans the source records.
+- Notification coverage is intentionally narrow in v1: only in-app delivery plus manager/accountant
+  recipients are implemented, so other roles and outbound channels still require a later ADR.
 - Integration instability risk with calendar sync edge cases.
 - Optional compose-local Ollama verification now removes the external-host dependency for real scoring checks, but first-run bootstrap can be slower because the model pull is explicit and persistent-volume backed.
 - Compliance risk if country-specific legal acts are not mapped early.

--- a/docs/project/frontend-requirements.md
+++ b/docs/project/frontend-requirements.md
@@ -1,8 +1,8 @@
 # Frontend Requirements (React.js)
 
 ## Last Updated
-- Date: 2026-03-11
-- Updated by: architect + frontend-engineer
+- Date: 2026-03-13
+- Updated by: architect + backend-engineer + frontend-engineer
 
 ## Fixed Technical Requirement
 - Frontend must be implemented using `React.js` + `TypeScript`.
@@ -242,6 +242,29 @@
 - Emit canonical Sentry tags for `/` based on resolved role:
   - `workspace=accountant` for accountant workspace.
 - Keep auth, CORS, employee self-service routes, HR/manager route topology, and generic reporting/export infrastructure unchanged in this slice.
+
+## TASK-09-04 Baseline
+- Keep the existing route topology intact; do not add a notifications-only path.
+- Reuse the existing `/` role split:
+  - `manager` keeps `ManagerWorkspacePage` on `/`;
+  - `accountant` keeps `AccountantWorkspacePage` on `/`.
+- Read in-app notifications through dedicated recipient-scoped APIs:
+  - `GET /api/v1/notifications?status=unread|all&limit&offset`
+  - `GET /api/v1/notifications/digest`
+  - `POST /api/v1/notifications/{notification_id}/read`
+- Workspace UX requirements:
+  - render a localized notifications block inside both manager and accountant workspaces;
+  - show digest summary chips plus the latest unread notification list;
+  - support `Mark as read` without page navigation;
+  - render localized loading, empty, and `401/403/404/422/generic` error states.
+- Scope restrictions for this slice:
+  - in-app notifications only;
+  - mandatory recipient roles limited to `manager` and `accountant`;
+  - digest is server-computed on demand only;
+  - do not add email, SMS, webhooks, outbox, scheduler, or template-editor UI.
+- Keep invite delivery manual:
+  `candidate_invite_url` sharing remains outside this slice and stays staff-driven.
+- Keep auth, CORS, HR/accountant/manager route semantics, public candidate transport, and existing workspace pages unchanged outside the embedded notifications block.
 
 ## Library Baseline (Popular Ready-Made Stack)
 - UI components: Material UI (MUI).

--- a/docs/project/tasks.md
+++ b/docs/project/tasks.md
@@ -50,6 +50,7 @@
 | TASK-07-04 | implemented/local-onboarding-dashboard-slice | `GET /api/v1/onboarding/runs*` now exposes HR/admin read-all plus manager-scoped onboarding progress visibility, with the dashboard embedded on `/` for HR and reused as the onboarding block inside the existing manager workspace on the same `/` route |
 | TASK-09-01 | implemented/local-manager-workspace-slice | Manager users now land on `/` in a read-only hiring + onboarding workspace backed by manager-scoped vacancy APIs, explicit `vacancies.hiring_manager_staff_id` ownership, and the reused onboarding dashboard block, while HR/admin keep the existing recruitment workspace on `/` |
 | TASK-09-03 | done/closed | GitHub issue #96 closed; merged in `main` via PR #114 (`c237296`) with accountant workspace routing on `/`, assignment-scoped `/api/v1/accounting/workspace*`, controlled CSV/XLSX exports, and solo-mode architecture self-review workflow alignment |
+| TASK-09-04 | implemented/local-notification-slice | Manager/accountant workspaces on `/` now embed recipient-scoped in-app notifications backed by `/api/v1/notifications*`, deduped fail-closed reads/updates, on-demand digest counters, regenerated OpenAPI/frontend types, architecture docs, and backend/frontend coverage; compose migration and runtime refresh pass locally |
 | COMPLIANCE-01 | planned | EPIC-13 article-level legal mapping and evidence pack track |
 
 ## 2026-03-12 Delivery Control Notes
@@ -88,6 +89,7 @@
 - `TASK-09-01` is now implemented as the additive manager workspace follow-on slice: managers use the existing `/` route for one read-only hiring + onboarding workspace, vacancy hiring visibility is scoped by explicit `vacancies.hiring_manager_staff_id`, and onboarding visibility stays task-assignment-scoped through the existing onboarding APIs.
 - `TASK-09-03` is now implemented as the additive accountant workspace follow-on slice: accountants use the existing `/` route for one read-only finance workspace, visibility stays limited to accountant-assigned onboarding tasks, and controlled CSV/XLSX exports reuse the same filtered row model without adding generic reporting infrastructure.
 - `TASK-09-03` post-merge closeout is complete: GitHub issue `#96` is closed, PR #114 (`c237296`) is merged in `main`, and this backlog snapshot is synchronized to the merged state.
+- `TASK-09-04` is now implemented in repo as the additive notifications follow-on slice: managers and accountants keep the existing `/` route semantics, reads stay fail-closed on `recipient_staff_id`, notifications emit only from vacancy ownership and onboarding assignment changes, and the digest remains server-computed on demand without adding outbound delivery infrastructure.
 - The remaining follow-on work after the onboarding-dashboard and manager-workspace slices is limited to the other phase-2 role workspaces, notifications, reporting, and admin/ops backlog, not baseline scheduling, registration, feedback transport, or candidate-facing offer decisions.
 - Existing auth/CORS/public candidate transport assumptions stay unchanged across the observability and compliance follow-on slices.
 
@@ -105,22 +107,23 @@
 - `TASK-07-04` is no longer active queue work; the implemented source of truth is the repo-backed onboarding progress dashboard on `/api/v1/onboarding/runs*`, embedded for HR on `/` and reused inside the manager workspace on the existing `/` route.
 - `TASK-09-01` is no longer active queue work; the implemented source of truth is the repo-backed manager workspace on `/` plus manager-scoped vacancy read endpoints on the existing `/api/v1/vacancies` namespace.
 - `TASK-09-03` is no longer active queue work; the implemented source of truth is the repo-backed accountant workspace on `/` plus assignment-scoped finance read/export endpoints on `/api/v1/accounting/workspace*`.
+- `TASK-09-04` is no longer active queue work; the implemented source of truth is the repo-backed recipient-scoped notification API on `/api/v1/notifications*` plus the embedded manager/accountant notifications block on the existing `/` route.
 - The remaining candidate-domain follow-on work after `TASK-03-08` and `TASK-04-06` is limited to
   later ops/reporting slices, not baseline parsed-profile structure or scoring-quality tooling.
 
 ## Normalized Open Backlog Snapshot
 
-- Normalized open backlog count: `16` tasks.
+- Normalized open backlog count: `15` tasks.
 - This count excludes tasks already implemented in repo but retained in the historical planning tables below for lineage.
 - Repo backlog state now excludes `TASK-12-02`, and GitHub issue `#85` is closed following PR #105 (`a67bb8c`).
-- Issue `#58` remains an umbrella `COMPLIANCE-01` tracking issue and is not included in the normalized `16`-task count.
+- Issue `#58` remains an umbrella `COMPLIANCE-01` tracking issue and is not included in the normalized `15`-task count.
 - Current open backlog by delivery wave:
   - Wave 2 platform/ops/reporting: `TASK-02-04`, `ADMIN-04`, `ADMIN-05`, `TASK-08-01`, `TASK-08-02`, `TASK-08-03`, `TASK-08-04`, `TASK-10-01`, `TASK-10-02`, `TASK-10-03`, `TASK-10-04`, `TASK-13-03`, `TASK-13-04`
-  - Wave 3 phase-2 workspaces: `TASK-09-02`, `TASK-09-04`, `TASK-11-12`
+  - Wave 3 phase-2 workspaces: `TASK-09-02`, `TASK-11-12`
 
 | Order | Task ID | Why Now |
 | --- | --- | --- |
-| A-1 | TASK-09-04 | Role-specific notifications are now the next unblocked follow-on slice because the accountant workspace is implemented, while leader KPI visibility still depends on `TASK-10-02` |
+| A-1 | TASK-10-01 | KPI aggregation is now the next unblocked prerequisite because the remaining leader workspace slice (`TASK-09-02`) still depends on KPI snapshot/reporting read models |
 
 - Execution rule for follow-on interview work: keep the implemented `/` and `/candidate?interviewToken=...` topology, candidate-auth exclusion, and token-based public transport unchanged unless a separate ADR reopens that scope.
 

--- a/docs/testing/strategy.md
+++ b/docs/testing/strategy.md
@@ -536,6 +536,35 @@ Acceptance rules for the implementation slice:
   - `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend pytest -q`
   - `./scripts/check-docs-structure.sh`
 
+## Role-Specific Notifications Verification (`TASK-09-04`)
+
+Current implementation coverage includes at minimum:
+
+| Capability | Unit Coverage | Integration/Smoke Coverage | Required Evidence |
+| --- | --- | --- | --- |
+| Notification emitters fan out to manager/accountant recipients and dedupe repeated writes | `apps/backend/tests/unit/notifications/test_notification_service.py` | `apps/backend/tests/integration/notifications/test_notification_api.py` | vacancy ownership and onboarding assignment changes create one recipient-scoped in-app row per newly visible recipient, while repeated writes do not duplicate rows |
+| Notification reads and mark-read writes stay fail-closed on `recipient_staff_id=<current subject>` | `apps/backend/tests/unit/notifications/test_notification_service.py`, `apps/backend/tests/unit/rbac/test_rbac.py` | `apps/backend/tests/integration/notifications/test_notification_api.py` | out-of-scope roles get `403`, wrong recipients get `404 notification_not_found`, and only recipient-owned rows change to `read` |
+| Digest counters stay role-specific and server-computed on demand | `apps/backend/tests/unit/notifications/test_notification_service.py` | `apps/backend/tests/integration/notifications/test_notification_api.py` | manager digests include owned-open-vacancy counts, accountant digests do not, and task counters reflect current assignment scope |
+| Embedded manager/accountant notifications UI renders loading, empty, success, and mark-read paths | `apps/frontend/src/components/NotificationsPanel.test.tsx`, `apps/frontend/src/pages/ManagerWorkspacePage.test.tsx`, `apps/frontend/src/pages/AccountantWorkspacePage.test.tsx` | N/A | both `/` workspaces render the shared notifications block, localized summary chips, unread items, and `Mark as read` without route changes |
+| OpenAPI freeze and generated frontend types stay synced with the notification contract | `npm --prefix apps/frontend run api:types:check` | `./scripts/check-openapi-freeze.sh` | notification endpoints and schemas exist in `docs/api/openapi.frozen.json` and `apps/frontend/src/api/generated/openapi-types.ts` |
+
+Acceptance rules for the implementation slice:
+- Keep route topology unchanged; notifications stay embedded inside the existing `/` manager/accountant workspaces.
+- Keep delivery in-app only; do not add email, SMS, webhooks, outbox, scheduler, event-bus, or template-editor behavior.
+- Keep reads and updates fail-closed on `recipient_staff_id=<current subject>`.
+- Emit notifications only on assignment or ownership change and keep dedupe mandatory.
+- Keep candidate invite delivery manual-only and do not alter interview invite transport.
+- Minimum verification set:
+  - `./scripts/generate-openapi-frozen.sh`
+  - `./scripts/check-openapi-freeze.sh`
+  - `npm --prefix apps/frontend run api:types:generate`
+  - `npm --prefix apps/frontend run api:types:check`
+  - `npm --prefix apps/frontend run lint`
+  - `npm --prefix apps/frontend run test -- --run`
+  - `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend ruff check .`
+  - `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend pytest -q`
+  - `./scripts/check-docs-structure.sh`
+
 ## Offer Workflow Verification (`TASK-06-01`)
 
 Current implementation coverage includes at minimum:


### PR DESCRIPTION
## Summary
- implement recipient-scoped in-app notifications and on-demand digests for manager and accountant workspaces
- add backend notifications package, migration, RBAC/routes, vacancy ownership and onboarding assignment emitters, OpenAPI freeze, and generated frontend types
- embed localized notifications UI on the existing / manager and accountant workspaces and update ADR, diagrams, testing strategy, and backlog snapshot

## Verification
- ./scripts/generate-openapi-frozen.sh
- ./scripts/check-openapi-freeze.sh
- npm --prefix apps/frontend run api:types:check
- npm --prefix apps/frontend run lint
- npm --prefix apps/frontend run test -- --run
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend ruff check .
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend pytest -q
- ./scripts/check-docs-structure.sh
- docker compose up -d --build
- docker compose ps

## Risks
- notifications remain intentionally limited to in-app delivery for manager and accountant roles
- digest is computed on demand from live vacancy and onboarding state, without async materialization
- candidate invite delivery remains manual-only

## Architecture Self-Review
- the slice stays additive, keeps existing route semantics, preserves fail-closed recipient visibility, and does not introduce outbound channels, scheduler, outbox, or event-bus infrastructure