### PR TITLE
TASK-10-01: monthly KPI snapshots foundation

### DIFF
--- a/apps/backend/alembic/versions/20260313_000021_kpi_snapshots.py
+++ b/apps/backend/alembic/versions/20260313_000021_kpi_snapshots.py
@@ -1,0 +1,42 @@
+"""Create KPI snapshot storage table."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260313000021"
+down_revision = "20260313000020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create KPI snapshot table and supporting indexes."""
+    op.create_table(
+        "kpi_snapshots",
+        sa.Column("snapshot_id", sa.String(length=36), nullable=False),
+        sa.Column("period_month", sa.Date(), nullable=False),
+        sa.Column("metric_key", sa.String(length=64), nullable=False),
+        sa.Column("metric_value", sa.Integer(), nullable=False),
+        sa.Column("generated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("snapshot_id"),
+        sa.UniqueConstraint(
+            "period_month",
+            "metric_key",
+            name="ux_kpi_snapshots_period_metric",
+        ),
+    )
+    op.create_index(
+        "ix_kpi_snapshots_period_month",
+        "kpi_snapshots",
+        ["period_month"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop KPI snapshot table and supporting indexes."""
+    op.drop_index("ix_kpi_snapshots_period_month", table_name="kpi_snapshots")
+    op.drop_table("kpi_snapshots")

--- a/apps/backend/src/hrm_backend/main.py
+++ b/apps/backend/src/hrm_backend/main.py
@@ -17,6 +17,7 @@ from hrm_backend.interviews.routers.v1 import public_router as interview_public_
 from hrm_backend.interviews.routers.v1 import router as interview_router
 from hrm_backend.notifications.routers.v1 import router as notification_router
 from hrm_backend.rbac import ROLE_PERMISSION_MATRIX
+from hrm_backend.reporting.routers.v1 import router as reporting_router
 from hrm_backend.scoring.routers.v1 import router as scoring_router
 from hrm_backend.settings import get_settings
 from hrm_backend.vacancies.routers.v1 import router as vacancy_router
@@ -37,6 +38,7 @@ app.include_router(candidate_public_router)
 app.include_router(employee_router)
 app.include_router(finance_router)
 app.include_router(notification_router)
+app.include_router(reporting_router)
 app.include_router(vacancy_router)
 app.include_router(scoring_router)
 app.include_router(interview_router)

--- a/apps/backend/src/hrm_backend/rbac.py
+++ b/apps/backend/src/hrm_backend/rbac.py
@@ -61,6 +61,8 @@ Permission = Literal[
     "candidate_cv:parse",
     "analytics:read",
     "accounting:read",
+    "kpi_snapshot:read",
+    "kpi_snapshot:rebuild",
 ]
 
 ROLE_PERMISSION_MATRIX: Final[dict[Role, set[Permission]]] = {
@@ -101,6 +103,8 @@ ROLE_PERMISSION_MATRIX: Final[dict[Role, set[Permission]]] = {
         "interview:manage",
         "analytics:read",
         "accounting:read",
+        "kpi_snapshot:read",
+        "kpi_snapshot:rebuild",
     },
     "hr": {
         "admin:employee_key:create",

--- a/apps/backend/src/hrm_backend/reporting/__init__.py
+++ b/apps/backend/src/hrm_backend/reporting/__init__.py
@@ -1,0 +1,1 @@
+"""Reporting and KPI snapshot foundation package."""

--- a/apps/backend/src/hrm_backend/reporting/dao/__init__.py
+++ b/apps/backend/src/hrm_backend/reporting/dao/__init__.py
@@ -1,0 +1,6 @@
+"""DAO helpers for KPI snapshot reporting."""
+
+from hrm_backend.reporting.dao.kpi_aggregation_dao import KpiAggregationDAO
+from hrm_backend.reporting.dao.kpi_snapshot_dao import KpiSnapshotDAO
+
+__all__ = ["KpiAggregationDAO", "KpiSnapshotDAO"]

--- a/apps/backend/src/hrm_backend/reporting/dao/kpi_aggregation_dao.py
+++ b/apps/backend/src/hrm_backend/reporting/dao/kpi_aggregation_dao.py
@@ -1,0 +1,127 @@
+"""Read-only aggregation queries for KPI snapshot generation."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from hrm_backend.employee.models.hire_conversion import HireConversion
+from hrm_backend.employee.models.onboarding import OnboardingRun, OnboardingTask
+from hrm_backend.interviews.models.interview import Interview
+from hrm_backend.vacancies.models.offer import Offer
+from hrm_backend.vacancies.models.pipeline_transition import PipelineTransition
+from hrm_backend.vacancies.models.vacancy import Vacancy
+
+
+class KpiAggregationDAO:
+    """Aggregate KPI counts from durable transactional tables."""
+
+    def __init__(self, session: Session) -> None:
+        """Initialize aggregation DAO.
+
+        Args:
+            session: Active SQLAlchemy session.
+        """
+        self._session = session
+
+    def count_vacancies_created(self, *, start_at: datetime, end_at: datetime) -> int:
+        """Count vacancies created inside the provided window."""
+        return _count(
+            self._session.query(func.count(Vacancy.vacancy_id))
+            .filter(Vacancy.created_at >= start_at, Vacancy.created_at < end_at)
+            .scalar()
+        )
+
+    def count_candidates_applied(self, *, start_at: datetime, end_at: datetime) -> int:
+        """Count candidate applications based on pipeline transitions to `applied`."""
+        return _count(
+            self._session.query(func.count(PipelineTransition.transition_id))
+            .filter(
+                PipelineTransition.to_stage == "applied",
+                PipelineTransition.transitioned_at >= start_at,
+                PipelineTransition.transitioned_at < end_at,
+            )
+            .scalar()
+        )
+
+    def count_interviews_scheduled(self, *, start_at: datetime, end_at: datetime) -> int:
+        """Count interviews scheduled (created) inside the provided window."""
+        return _count(
+            self._session.query(func.count(Interview.interview_id))
+            .filter(Interview.created_at >= start_at, Interview.created_at < end_at)
+            .scalar()
+        )
+
+    def count_offers_sent(self, *, start_at: datetime, end_at: datetime) -> int:
+        """Count offers sent inside the provided window."""
+        return _count(
+            self._session.query(func.count(Offer.offer_id))
+            .filter(
+                Offer.sent_at.is_not(None),
+                Offer.sent_at >= start_at,
+                Offer.sent_at < end_at,
+            )
+            .scalar()
+        )
+
+    def count_offers_accepted(self, *, start_at: datetime, end_at: datetime) -> int:
+        """Count offers accepted inside the provided window."""
+        return _count(
+            self._session.query(func.count(Offer.offer_id))
+            .filter(
+                Offer.status == "accepted",
+                Offer.decision_at.is_not(None),
+                Offer.decision_at >= start_at,
+                Offer.decision_at < end_at,
+            )
+            .scalar()
+        )
+
+    def count_hires(self, *, start_at: datetime, end_at: datetime) -> int:
+        """Count hires based on durable hire conversion rows."""
+        return _count(
+            self._session.query(func.count(HireConversion.conversion_id))
+            .filter(
+                HireConversion.converted_at >= start_at,
+                HireConversion.converted_at < end_at,
+            )
+            .scalar()
+        )
+
+    def count_onboarding_started(self, *, start_at: datetime, end_at: datetime) -> int:
+        """Count onboarding runs started inside the provided window."""
+        return _count(
+            self._session.query(func.count(OnboardingRun.onboarding_id))
+            .filter(
+                OnboardingRun.started_at >= start_at,
+                OnboardingRun.started_at < end_at,
+            )
+            .scalar()
+        )
+
+    def count_onboarding_tasks_completed(self, *, start_at: datetime, end_at: datetime) -> int:
+        """Count onboarding tasks completed inside the provided window."""
+        return _count(
+            self._session.query(func.count(OnboardingTask.task_id))
+            .filter(
+                OnboardingTask.status == "completed",
+                OnboardingTask.completed_at.is_not(None),
+                OnboardingTask.completed_at >= start_at,
+                OnboardingTask.completed_at < end_at,
+            )
+            .scalar()
+        )
+
+
+def _count(value: int | None) -> int:
+    """Normalize nullable SQL count results into a stable integer.
+
+    Args:
+        value: Raw count returned from SQLAlchemy.
+
+    Returns:
+        int: Normalized non-null count.
+    """
+    return int(value or 0)

--- a/apps/backend/src/hrm_backend/reporting/dao/kpi_snapshot_dao.py
+++ b/apps/backend/src/hrm_backend/reporting/dao/kpi_snapshot_dao.py
@@ -1,0 +1,63 @@
+"""Data-access helpers for KPI snapshot persistence."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date
+
+from sqlalchemy.orm import Session
+
+from hrm_backend.reporting.models.kpi_snapshot import KpiSnapshot
+
+
+class KpiSnapshotDAO:
+    """Persist and query monthly KPI snapshots."""
+
+    def __init__(self, session: Session) -> None:
+        """Initialize DAO with an active SQLAlchemy session.
+
+        Args:
+            session: Active SQLAlchemy session.
+        """
+        self._session = session
+
+    def list_by_period_month(self, *, period_month: date) -> list[KpiSnapshot]:
+        """Return KPI snapshot rows for the provided month.
+
+        Args:
+            period_month: First day of the month to read.
+
+        Returns:
+            list[KpiSnapshot]: Snapshot rows ordered by metric key.
+        """
+        return list(
+            self._session.query(KpiSnapshot)
+            .filter(KpiSnapshot.period_month == period_month)
+            .order_by(KpiSnapshot.metric_key.asc(), KpiSnapshot.snapshot_id.asc())
+            .all()
+        )
+
+    def replace_monthly_snapshots(
+        self,
+        *,
+        period_month: date,
+        snapshots: Sequence[KpiSnapshot],
+        commit: bool = True,
+    ) -> None:
+        """Replace all KPI snapshots for one month in a single transaction.
+
+        Args:
+            period_month: First day of the month to replace.
+            snapshots: Snapshot rows to insert.
+            commit: When True, commit immediately; otherwise flush for external transaction control.
+        """
+        self._session.query(KpiSnapshot).filter(
+            KpiSnapshot.period_month == period_month
+        ).delete(synchronize_session=False)
+        for snapshot in snapshots:
+            self._session.add(snapshot)
+        if commit:
+            self._session.commit()
+            return
+
+        self._session.flush()

--- a/apps/backend/src/hrm_backend/reporting/dependencies/__init__.py
+++ b/apps/backend/src/hrm_backend/reporting/dependencies/__init__.py
@@ -1,0 +1,5 @@
+"""Dependency providers for reporting services."""
+
+from hrm_backend.reporting.dependencies.reporting import get_kpi_snapshot_service
+
+__all__ = ["get_kpi_snapshot_service"]

--- a/apps/backend/src/hrm_backend/reporting/dependencies/reporting.py
+++ b/apps/backend/src/hrm_backend/reporting/dependencies/reporting.py
@@ -1,0 +1,38 @@
+"""Dependency providers for KPI snapshot reporting services."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from hrm_backend.audit.dependencies.audit import get_audit_service
+from hrm_backend.audit.services.audit_service import AuditService
+from hrm_backend.core.db.session import get_db_session
+from hrm_backend.reporting.dao.kpi_aggregation_dao import KpiAggregationDAO
+from hrm_backend.reporting.dao.kpi_snapshot_dao import KpiSnapshotDAO
+from hrm_backend.reporting.services.kpi_snapshot_service import KpiSnapshotService
+
+SessionDependency = Annotated[Session, Depends(get_db_session)]
+AuditServiceDependency = Annotated[AuditService, Depends(get_audit_service)]
+
+
+def get_kpi_snapshot_service(
+    session: SessionDependency,
+    audit_service: AuditServiceDependency,
+) -> KpiSnapshotService:
+    """Build KPI snapshot service dependency.
+
+    Args:
+        session: Active SQLAlchemy session.
+        audit_service: Audit service for KPI access events.
+
+    Returns:
+        KpiSnapshotService: Ready KPI snapshot service.
+    """
+    return KpiSnapshotService(
+        snapshot_dao=KpiSnapshotDAO(session=session),
+        aggregation_dao=KpiAggregationDAO(session=session),
+        audit_service=audit_service,
+    )

--- a/apps/backend/src/hrm_backend/reporting/models/__init__.py
+++ b/apps/backend/src/hrm_backend/reporting/models/__init__.py
@@ -1,0 +1,5 @@
+"""SQLAlchemy models for reporting and KPI snapshots."""
+
+from hrm_backend.reporting.models.kpi_snapshot import KpiSnapshot
+
+__all__ = ["KpiSnapshot"]

--- a/apps/backend/src/hrm_backend/reporting/models/kpi_snapshot.py
+++ b/apps/backend/src/hrm_backend/reporting/models/kpi_snapshot.py
@@ -1,0 +1,48 @@
+"""KPI snapshot persistence model."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from uuid import uuid4
+
+from sqlalchemy import Date, DateTime, Index, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from hrm_backend.core.models.base import Base
+
+
+class KpiSnapshot(Base):
+    """Monthly KPI snapshot row for a single metric.
+
+    Attributes:
+        snapshot_id: Unique snapshot row identifier.
+        period_month: First day of the month that this snapshot represents.
+        metric_key: Stable KPI metric identifier.
+        metric_value: Aggregated metric value for the selected month.
+        generated_at: Timestamp when the snapshot was generated.
+    """
+
+    __tablename__ = "kpi_snapshots"
+    __table_args__ = (
+        Index(
+            "ux_kpi_snapshots_period_metric",
+            "period_month",
+            "metric_key",
+            unique=True,
+        ),
+        Index("ix_kpi_snapshots_period_month", "period_month"),
+    )
+
+    snapshot_id: Mapped[str] = mapped_column(
+        String(36),
+        primary_key=True,
+        default=lambda: str(uuid4()),
+    )
+    period_month: Mapped[date] = mapped_column(Date, nullable=False)
+    metric_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    metric_value: Mapped[int] = mapped_column(Integer, nullable=False)
+    generated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )

--- a/apps/backend/src/hrm_backend/reporting/routers/__init__.py
+++ b/apps/backend/src/hrm_backend/reporting/routers/__init__.py
@@ -1,0 +1,1 @@
+"""Reporting routers package."""

--- a/apps/backend/src/hrm_backend/reporting/routers/v1.py
+++ b/apps/backend/src/hrm_backend/reporting/routers/v1.py
@@ -1,0 +1,72 @@
+"""Versioned HTTP routes for KPI snapshot reporting."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+
+from hrm_backend.auth.dependencies.auth import get_current_auth_context
+from hrm_backend.auth.schemas.token_claims import AuthContext
+from hrm_backend.rbac import Role, require_permission
+from hrm_backend.reporting.dependencies.reporting import get_kpi_snapshot_service
+from hrm_backend.reporting.schemas.kpi_snapshot import (
+    KpiSnapshotReadResponse,
+    KpiSnapshotRebuildRequest,
+)
+from hrm_backend.reporting.services.kpi_snapshot_service import KpiSnapshotService
+from hrm_backend.reporting.utils.dates import ensure_month_start
+
+router = APIRouter(prefix="/api/v1/reporting/kpi-snapshots", tags=["reporting"])
+KpiSnapshotServiceDependency = Annotated[
+    KpiSnapshotService,
+    Depends(get_kpi_snapshot_service),
+]
+CurrentAuthContext = Annotated[AuthContext, Depends(get_current_auth_context)]
+KpiSnapshotReadRole = Annotated[Role, Depends(require_permission("kpi_snapshot:read"))]
+KpiSnapshotRebuildRole = Annotated[Role, Depends(require_permission("kpi_snapshot:rebuild"))]
+PeriodMonthQuery = Annotated[date, Query()]
+
+
+def _resolve_period_month(period_month: PeriodMonthQuery) -> date:
+    """Validate and normalize the period month query parameter."""
+    try:
+        return ensure_month_start(period_month)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post("/rebuild", response_model=KpiSnapshotReadResponse)
+def rebuild_kpi_snapshot(
+    payload: KpiSnapshotRebuildRequest,
+    request: Request,
+    _: KpiSnapshotRebuildRole,
+    auth_context: CurrentAuthContext,
+    service: KpiSnapshotServiceDependency,
+) -> KpiSnapshotReadResponse:
+    """Rebuild KPI snapshot rows for a single month."""
+    return service.rebuild_monthly_snapshot(
+        period_month=payload.period_month,
+        auth_context=auth_context,
+        request=request,
+    )
+
+
+@router.get("", response_model=KpiSnapshotReadResponse)
+def read_kpi_snapshot(
+    request: Request,
+    _: KpiSnapshotReadRole,
+    auth_context: CurrentAuthContext,
+    service: KpiSnapshotServiceDependency,
+    period_month: Annotated[date, Depends(_resolve_period_month)],
+) -> KpiSnapshotReadResponse:
+    """Read KPI snapshot rows for a single month."""
+    return service.get_monthly_snapshot(
+        period_month=period_month,
+        auth_context=auth_context,
+        request=request,
+    )

--- a/apps/backend/src/hrm_backend/reporting/schemas/__init__.py
+++ b/apps/backend/src/hrm_backend/reporting/schemas/__init__.py
@@ -1,0 +1,17 @@
+"""Pydantic schemas for reporting and KPI snapshots."""
+
+from hrm_backend.reporting.schemas.kpi_snapshot import (
+    KPIMetricKey,
+    KpiSnapshotMetric,
+    KpiSnapshotQuery,
+    KpiSnapshotReadResponse,
+    KpiSnapshotRebuildRequest,
+)
+
+__all__ = [
+    "KPIMetricKey",
+    "KpiSnapshotMetric",
+    "KpiSnapshotQuery",
+    "KpiSnapshotReadResponse",
+    "KpiSnapshotRebuildRequest",
+]

--- a/apps/backend/src/hrm_backend/reporting/schemas/kpi_snapshot.py
+++ b/apps/backend/src/hrm_backend/reporting/schemas/kpi_snapshot.py
@@ -1,0 +1,68 @@
+"""Schemas for KPI snapshot read and rebuild APIs."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from hrm_backend.reporting.utils.dates import ensure_month_start
+
+KPIMetricKey = Literal[
+    "vacancies_created_count",
+    "candidates_applied_count",
+    "interviews_scheduled_count",
+    "offers_sent_count",
+    "offers_accepted_count",
+    "hires_count",
+    "onboarding_started_count",
+    "onboarding_tasks_completed_count",
+]
+
+
+class KpiSnapshotRebuildRequest(BaseModel):
+    """Payload for requesting a KPI snapshot rebuild for one month."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    period_month: date
+
+    @field_validator("period_month")
+    @classmethod
+    def validate_period_month(cls, value: date) -> date:
+        """Ensure the period month is provided as the first day of month."""
+        return ensure_month_start(value)
+
+
+class KpiSnapshotQuery(BaseModel):
+    """Query parameters for monthly KPI snapshot reads."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    period_month: date
+
+    @field_validator("period_month")
+    @classmethod
+    def validate_period_month(cls, value: date) -> date:
+        """Ensure the period month is provided as the first day of month."""
+        return ensure_month_start(value)
+
+
+class KpiSnapshotMetric(BaseModel):
+    """Metric payload for one KPI snapshot row."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    metric_key: KPIMetricKey
+    metric_value: int = Field(ge=0)
+    generated_at: datetime | None = None
+
+
+class KpiSnapshotReadResponse(BaseModel):
+    """Monthly KPI snapshot response payload."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    period_month: date
+    metrics: list[KpiSnapshotMetric]

--- a/apps/backend/src/hrm_backend/reporting/services/__init__.py
+++ b/apps/backend/src/hrm_backend/reporting/services/__init__.py
@@ -1,0 +1,5 @@
+"""Reporting service package."""
+
+from hrm_backend.reporting.services.kpi_snapshot_service import KpiSnapshotService
+
+__all__ = ["KpiSnapshotService"]

--- a/apps/backend/src/hrm_backend/reporting/services/kpi_snapshot_service.py
+++ b/apps/backend/src/hrm_backend/reporting/services/kpi_snapshot_service.py
@@ -1,0 +1,188 @@
+"""Business service for KPI snapshot aggregation and reads."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+from fastapi import Request
+
+from hrm_backend.audit.services.audit_service import AuditService, actor_from_auth_context
+from hrm_backend.auth.schemas.token_claims import AuthContext
+from hrm_backend.reporting.dao.kpi_aggregation_dao import KpiAggregationDAO
+from hrm_backend.reporting.dao.kpi_snapshot_dao import KpiSnapshotDAO
+from hrm_backend.reporting.models.kpi_snapshot import KpiSnapshot
+from hrm_backend.reporting.schemas.kpi_snapshot import (
+    KpiSnapshotMetric,
+    KpiSnapshotReadResponse,
+)
+from hrm_backend.reporting.utils.dates import month_bounds
+from hrm_backend.reporting.utils.metrics import KPI_METRIC_KEYS
+
+
+class KpiSnapshotService:
+    """Aggregate and read monthly KPI snapshots."""
+
+    def __init__(
+        self,
+        *,
+        snapshot_dao: KpiSnapshotDAO,
+        aggregation_dao: KpiAggregationDAO,
+        audit_service: AuditService,
+    ) -> None:
+        """Initialize KPI snapshot service dependencies.
+
+        Args:
+            snapshot_dao: DAO for KPI snapshot persistence.
+            aggregation_dao: DAO for aggregation reads across domain tables.
+            audit_service: Audit service used to record KPI snapshot access.
+        """
+        self._snapshot_dao = snapshot_dao
+        self._aggregation_dao = aggregation_dao
+        self._audit_service = audit_service
+
+    def rebuild_monthly_snapshot(
+        self,
+        *,
+        period_month: date,
+        auth_context: AuthContext,
+        request: Request,
+    ) -> KpiSnapshotReadResponse:
+        """Rebuild and replace KPI snapshot rows for one calendar month.
+
+        Args:
+            period_month: First day of the month to rebuild.
+            auth_context: Authenticated actor context for audit logging.
+            request: Active FastAPI request.
+
+        Returns:
+            KpiSnapshotReadResponse: Rebuilt KPI snapshot payload.
+        """
+        start_at, end_at = month_bounds(period_month)
+        generated_at = datetime.now(UTC)
+        metrics_by_key = {
+            "vacancies_created_count": self._aggregation_dao.count_vacancies_created(
+                start_at=start_at,
+                end_at=end_at,
+            ),
+            "candidates_applied_count": self._aggregation_dao.count_candidates_applied(
+                start_at=start_at,
+                end_at=end_at,
+            ),
+            "interviews_scheduled_count": self._aggregation_dao.count_interviews_scheduled(
+                start_at=start_at,
+                end_at=end_at,
+            ),
+            "offers_sent_count": self._aggregation_dao.count_offers_sent(
+                start_at=start_at,
+                end_at=end_at,
+            ),
+            "offers_accepted_count": self._aggregation_dao.count_offers_accepted(
+                start_at=start_at,
+                end_at=end_at,
+            ),
+            "hires_count": self._aggregation_dao.count_hires(
+                start_at=start_at,
+                end_at=end_at,
+            ),
+            "onboarding_started_count": self._aggregation_dao.count_onboarding_started(
+                start_at=start_at,
+                end_at=end_at,
+            ),
+            "onboarding_tasks_completed_count": (
+                self._aggregation_dao.count_onboarding_tasks_completed(
+                    start_at=start_at,
+                    end_at=end_at,
+                )
+            ),
+        }
+
+        snapshots = [
+            KpiSnapshot(
+                period_month=period_month,
+                metric_key=metric_key,
+                metric_value=metrics_by_key[metric_key],
+                generated_at=generated_at,
+            )
+            for metric_key in KPI_METRIC_KEYS
+        ]
+        self._snapshot_dao.replace_monthly_snapshots(
+            period_month=period_month,
+            snapshots=snapshots,
+        )
+
+        actor_sub, actor_role = actor_from_auth_context(auth_context)
+        self._audit_service.record_api_event(
+            action="kpi_snapshot:rebuild",
+            resource_type="kpi_snapshot",
+            result="success",
+            request=request,
+            actor_sub=actor_sub,
+            actor_role=actor_role,
+            resource_id=period_month.isoformat(),
+        )
+        return KpiSnapshotReadResponse(
+            period_month=period_month,
+            metrics=[
+                KpiSnapshotMetric(
+                    metric_key=metric_key,
+                    metric_value=metrics_by_key[metric_key],
+                    generated_at=generated_at,
+                )
+                for metric_key in KPI_METRIC_KEYS
+            ],
+        )
+
+    def get_monthly_snapshot(
+        self,
+        *,
+        period_month: date,
+        auth_context: AuthContext,
+        request: Request,
+    ) -> KpiSnapshotReadResponse:
+        """Read KPI snapshot rows for a month without live aggregation.
+
+        Args:
+            period_month: First day of the month to read.
+            auth_context: Authenticated actor context for audit logging.
+            request: Active FastAPI request.
+
+        Returns:
+            KpiSnapshotReadResponse: Snapshot payload for the month or empty result when missing.
+        """
+        rows = self._snapshot_dao.list_by_period_month(period_month=period_month)
+        if not rows:
+            actor_sub, actor_role = actor_from_auth_context(auth_context)
+            self._audit_service.record_api_event(
+                action="kpi_snapshot:read",
+                resource_type="kpi_snapshot",
+                result="success",
+                request=request,
+                actor_sub=actor_sub,
+                actor_role=actor_role,
+                resource_id=period_month.isoformat(),
+            )
+            return KpiSnapshotReadResponse(period_month=period_month, metrics=[])
+
+        rows_by_key = {row.metric_key: row for row in rows}
+        metrics = []
+        for metric_key in KPI_METRIC_KEYS:
+            row = rows_by_key.get(metric_key)
+            metrics.append(
+                KpiSnapshotMetric(
+                    metric_key=metric_key,
+                    metric_value=0 if row is None else row.metric_value,
+                    generated_at=None if row is None else row.generated_at,
+                )
+            )
+
+        actor_sub, actor_role = actor_from_auth_context(auth_context)
+        self._audit_service.record_api_event(
+            action="kpi_snapshot:read",
+            resource_type="kpi_snapshot",
+            result="success",
+            request=request,
+            actor_sub=actor_sub,
+            actor_role=actor_role,
+            resource_id=period_month.isoformat(),
+        )
+        return KpiSnapshotReadResponse(period_month=period_month, metrics=metrics)

--- a/apps/backend/src/hrm_backend/reporting/utils/__init__.py
+++ b/apps/backend/src/hrm_backend/reporting/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Reporting utils package."""

--- a/apps/backend/src/hrm_backend/reporting/utils/dates.py
+++ b/apps/backend/src/hrm_backend/reporting/utils/dates.py
@@ -1,0 +1,40 @@
+"""Helpers for KPI snapshot monthly date windows."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, time
+
+
+def month_bounds(period_month: date) -> tuple[datetime, datetime]:
+    """Return UTC datetime bounds for the provided month.
+
+    Args:
+        period_month: First day of the month.
+
+    Returns:
+        tuple[datetime, datetime]: Inclusive start and exclusive end timestamps in UTC.
+    """
+    start = datetime.combine(period_month, time.min, tzinfo=UTC)
+    if period_month.month == 12:
+        next_month = date(period_month.year + 1, 1, 1)
+    else:
+        next_month = date(period_month.year, period_month.month + 1, 1)
+    end = datetime.combine(next_month, time.min, tzinfo=UTC)
+    return start, end
+
+
+def ensure_month_start(period_month: date) -> date:
+    """Validate that the provided date is the first day of a month.
+
+    Args:
+        period_month: Date to validate.
+
+    Returns:
+        date: The same date when valid.
+
+    Raises:
+        ValueError: When the date is not the first day of the month.
+    """
+    if period_month.day != 1:
+        raise ValueError("period_month must be the first day of the month")
+    return period_month

--- a/apps/backend/src/hrm_backend/reporting/utils/metrics.py
+++ b/apps/backend/src/hrm_backend/reporting/utils/metrics.py
@@ -1,0 +1,27 @@
+"""KPI metric registry for reporting snapshots."""
+
+from __future__ import annotations
+
+KPI_METRIC_KEYS: tuple[str, ...] = (
+    "vacancies_created_count",
+    "candidates_applied_count",
+    "interviews_scheduled_count",
+    "offers_sent_count",
+    "offers_accepted_count",
+    "hires_count",
+    "onboarding_started_count",
+    "onboarding_tasks_completed_count",
+)
+KPI_METRIC_KEY_SET = frozenset(KPI_METRIC_KEYS)
+
+
+def is_supported_metric(metric_key: str) -> bool:
+    """Check whether a metric key is part of the KPI snapshot registry.
+
+    Args:
+        metric_key: Metric identifier to validate.
+
+    Returns:
+        bool: True when the metric key is supported by KPI snapshots.
+    """
+    return metric_key in KPI_METRIC_KEY_SET

--- a/apps/backend/tests/integration/reporting/test_kpi_snapshot_api.py
+++ b/apps/backend/tests/integration/reporting/test_kpi_snapshot_api.py
@@ -1,0 +1,352 @@
+"""Integration tests for KPI snapshot reporting APIs."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from hrm_backend.auth.dependencies.auth import get_current_auth_context
+from hrm_backend.auth.schemas.token_claims import AuthContext
+from hrm_backend.candidates.models.profile import CandidateProfile
+from hrm_backend.core.models.base import Base
+from hrm_backend.employee.models.hire_conversion import HireConversion
+from hrm_backend.employee.models.onboarding import OnboardingRun, OnboardingTask
+from hrm_backend.employee.models.profile import EmployeeProfile
+from hrm_backend.interviews.models.interview import Interview
+from hrm_backend.main import app
+from hrm_backend.settings import AppSettings, get_settings
+from hrm_backend.vacancies.models.offer import Offer
+from hrm_backend.vacancies.models.pipeline_transition import PipelineTransition
+from hrm_backend.vacancies.models.vacancy import Vacancy
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture()
+def sqlite_database_url(tmp_path: Path) -> str:
+    """Provide temporary SQLite URL for KPI snapshot integration tests."""
+    return f"sqlite+pysqlite:///{tmp_path / 'kpi_snapshots_api.db'}"
+
+
+@pytest.fixture()
+def configured_app(sqlite_database_url: str):
+    """Configure app dependency overrides for KPI snapshot API tests."""
+    settings = AppSettings(
+        database_url=sqlite_database_url,
+        redis_url="redis://localhost:6379/15",
+        jwt_secret="integration-secret-with-minimum-32-bytes",
+    )
+    context_holder = {
+        "context": AuthContext(
+            subject_id=uuid4(),
+            role="admin",
+            session_id=uuid4(),
+            token_id=uuid4(),
+            expires_at=9999999999,
+        )
+    }
+
+    def _get_settings_override() -> AppSettings:
+        return settings
+
+    def _get_auth_context_override() -> AuthContext:
+        return context_holder["context"]
+
+    app.dependency_overrides[get_settings] = _get_settings_override
+    app.dependency_overrides[get_current_auth_context] = _get_auth_context_override
+
+    engine = create_engine(sqlite_database_url, future=True)
+    Base.metadata.create_all(engine)
+    try:
+        yield app, context_holder, engine
+    finally:
+        app.dependency_overrides.pop(get_settings, None)
+        app.dependency_overrides.pop(get_current_auth_context, None)
+        engine.dispose()
+
+
+@pytest.fixture()
+async def api_client(configured_app) -> AsyncClient:
+    """Provide async API client for KPI snapshot integration tests."""
+    configured, *_ = configured_app
+    async with AsyncClient(
+        transport=ASGITransport(app=configured),
+        base_url="http://testserver",
+    ) as client:
+        yield client
+
+
+def _seed_kpi_sources(engine) -> None:
+    """Insert one row per KPI source inside March 2026."""
+    vacancy_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    candidate_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+    offer_id = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+    transition_applied_id = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+    transition_hired_id = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+    conversion_id = "ffffffff-ffff-4fff-8fff-ffffffffffff"
+    employee_id = "11111111-2222-4333-8444-555555555555"
+    onboarding_id = "66666666-7777-4888-8999-000000000000"
+    task_id = "12121212-3434-4567-8999-121212121212"
+
+    with Session(engine) as session:
+        session.add(
+            Vacancy(
+                vacancy_id=vacancy_id,
+                title="Platform Engineer",
+                description="Build platform foundations.",
+                department="Engineering",
+                status="open",
+                created_at=datetime(2026, 3, 5, 9, 0, tzinfo=UTC),
+                updated_at=datetime(2026, 3, 5, 9, 0, tzinfo=UTC),
+            )
+        )
+        session.add(
+            CandidateProfile(
+                candidate_id=candidate_id,
+                owner_subject_id="public",
+                first_name="Ada",
+                last_name="Lovelace",
+                email="ada@example.com",
+                phone=None,
+                location=None,
+                current_title=None,
+                extra_data={},
+                created_at=datetime(2026, 3, 6, 9, 0, tzinfo=UTC),
+                updated_at=datetime(2026, 3, 6, 9, 0, tzinfo=UTC),
+            )
+        )
+        session.add(
+            PipelineTransition(
+                transition_id=transition_applied_id,
+                vacancy_id=vacancy_id,
+                candidate_id=candidate_id,
+                from_stage=None,
+                to_stage="applied",
+                reason="public_application",
+                changed_by_sub="public",
+                changed_by_role="public",
+                transitioned_at=datetime(2026, 3, 6, 10, 0, tzinfo=UTC),
+            )
+        )
+        session.add(
+            Interview(
+                interview_id="99999999-aaaa-4bbb-8ccc-999999999999",
+                vacancy_id=vacancy_id,
+                candidate_id=candidate_id,
+                status="scheduled",
+                calendar_sync_status="pending",
+                schedule_version=1,
+                scheduled_start_at=datetime(2026, 3, 10, 10, 0, tzinfo=UTC),
+                scheduled_end_at=datetime(2026, 3, 10, 11, 0, tzinfo=UTC),
+                timezone="UTC",
+                location_kind="video",
+                location_details=None,
+                interviewer_staff_ids_json=["22222222-2222-4222-8222-222222222222"],
+                calendar_event_id=None,
+                candidate_token_nonce=None,
+                candidate_token_hash=None,
+                candidate_token_expires_at=None,
+                candidate_response_status="pending",
+                candidate_response_note=None,
+                cancelled_by=None,
+                cancel_reason_code=None,
+                calendar_sync_reason_code=None,
+                calendar_sync_error_detail=None,
+                created_by_staff_id="33333333-3333-4333-8333-333333333333",
+                updated_by_staff_id="33333333-3333-4333-8333-333333333333",
+                created_at=datetime(2026, 3, 7, 9, 0, tzinfo=UTC),
+                updated_at=datetime(2026, 3, 7, 9, 0, tzinfo=UTC),
+                last_synced_at=None,
+            )
+        )
+        session.add(
+            Offer(
+                offer_id=offer_id,
+                vacancy_id=vacancy_id,
+                candidate_id=candidate_id,
+                status="accepted",
+                terms_summary="Base offer",
+                proposed_start_date=None,
+                expires_at=None,
+                note=None,
+                sent_at=datetime(2026, 3, 12, 9, 0, tzinfo=UTC),
+                sent_by_staff_id="44444444-4444-4444-8444-444444444444",
+                decision_at=datetime(2026, 3, 15, 9, 0, tzinfo=UTC),
+                decision_note=None,
+                decision_recorded_by_staff_id="44444444-4444-4444-8444-444444444444",
+                created_at=datetime(2026, 3, 11, 9, 0, tzinfo=UTC),
+                updated_at=datetime(2026, 3, 15, 9, 0, tzinfo=UTC),
+            )
+        )
+        session.add(
+            PipelineTransition(
+                transition_id=transition_hired_id,
+                vacancy_id=vacancy_id,
+                candidate_id=candidate_id,
+                from_stage="offer",
+                to_stage="hired",
+                reason=None,
+                changed_by_sub="44444444-4444-4444-8444-444444444444",
+                changed_by_role="hr",
+                transitioned_at=datetime(2026, 3, 16, 9, 0, tzinfo=UTC),
+            )
+        )
+        session.add(
+            HireConversion(
+                conversion_id=conversion_id,
+                vacancy_id=vacancy_id,
+                candidate_id=candidate_id,
+                offer_id=offer_id,
+                hired_transition_id=transition_hired_id,
+                status="ready",
+                candidate_snapshot_json={"first_name": "Ada", "last_name": "Lovelace"},
+                offer_snapshot_json={"status": "accepted"},
+                converted_at=datetime(2026, 3, 16, 10, 0, tzinfo=UTC),
+                converted_by_staff_id="44444444-4444-4444-8444-444444444444",
+            )
+        )
+        session.add(
+            EmployeeProfile(
+                employee_id=employee_id,
+                hire_conversion_id=conversion_id,
+                vacancy_id=vacancy_id,
+                candidate_id=candidate_id,
+                first_name="Ada",
+                last_name="Lovelace",
+                email="ada@example.com",
+                phone=None,
+                location=None,
+                current_title=None,
+                extra_data_json={},
+                offer_terms_summary="Base offer",
+                start_date=None,
+                staff_account_id=None,
+                created_by_staff_id="44444444-4444-4444-8444-444444444444",
+                created_at=datetime(2026, 3, 16, 12, 0, tzinfo=UTC),
+                updated_at=datetime(2026, 3, 16, 12, 0, tzinfo=UTC),
+            )
+        )
+        session.add(
+            OnboardingRun(
+                onboarding_id=onboarding_id,
+                employee_id=employee_id,
+                hire_conversion_id=conversion_id,
+                status="started",
+                started_at=datetime(2026, 3, 17, 9, 0, tzinfo=UTC),
+                started_by_staff_id="44444444-4444-4444-8444-444444444444",
+            )
+        )
+        session.add(
+            OnboardingTask(
+                task_id=task_id,
+                onboarding_id=onboarding_id,
+                template_id="22222222-3333-4444-8555-666666666666",
+                template_item_id="77777777-8888-4999-8aaa-bbbbbbbbbbbb",
+                code="welcome",
+                title="Welcome",
+                description=None,
+                sort_order=10,
+                is_required=True,
+                status="completed",
+                assigned_role=None,
+                assigned_staff_id=None,
+                due_at=None,
+                completed_at=datetime(2026, 3, 18, 9, 0, tzinfo=UTC),
+                created_at=datetime(2026, 3, 17, 9, 0, tzinfo=UTC),
+                updated_at=datetime(2026, 3, 18, 9, 0, tzinfo=UTC),
+            )
+        )
+        session.commit()
+
+
+async def test_admin_can_rebuild_and_read_kpi_snapshots(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
+    """Verify admin can rebuild and read KPI snapshot rows."""
+    _, _, engine = configured_app
+    _seed_kpi_sources(engine)
+
+    rebuild_response = await api_client.post(
+        "/api/v1/reporting/kpi-snapshots/rebuild",
+        json={"period_month": "2026-03-01"},
+    )
+    assert rebuild_response.status_code == 200
+    payload = rebuild_response.json()
+    assert payload["period_month"] == "2026-03-01"
+    assert len(payload["metrics"]) == 8
+
+    read_response = await api_client.get(
+        "/api/v1/reporting/kpi-snapshots",
+        params={"period_month": "2026-03-01"},
+    )
+    assert read_response.status_code == 200
+    read_payload = read_response.json()
+    assert len(read_payload["metrics"]) == 8
+    vacancy_metric = next(
+        item for item in read_payload["metrics"] if item["metric_key"] == "vacancies_created_count"
+    )
+    assert vacancy_metric["metric_value"] == 1
+
+
+async def test_kpi_snapshot_read_returns_empty_payload_when_missing(
+    api_client: AsyncClient,
+) -> None:
+    """Verify read API returns empty metrics when snapshot month is missing."""
+    read_response = await api_client.get(
+        "/api/v1/reporting/kpi-snapshots",
+        params={"period_month": "2026-02-01"},
+    )
+    assert read_response.status_code == 200
+    payload = read_response.json()
+    assert payload["metrics"] == []
+
+
+async def test_kpi_snapshot_rbac_is_fail_closed(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
+    """Verify non-admin roles are denied for KPI snapshot endpoints."""
+    _, context_holder, _ = configured_app
+    context_holder["context"] = AuthContext(
+        subject_id=uuid4(),
+        role="leader",
+        session_id=uuid4(),
+        token_id=uuid4(),
+        expires_at=9999999999,
+    )
+
+    read_response = await api_client.get(
+        "/api/v1/reporting/kpi-snapshots",
+        params={"period_month": "2026-03-01"},
+    )
+    assert read_response.status_code == 403
+
+    rebuild_response = await api_client.post(
+        "/api/v1/reporting/kpi-snapshots/rebuild",
+        json={"period_month": "2026-03-01"},
+    )
+    assert rebuild_response.status_code == 403
+
+
+async def test_kpi_snapshot_invalid_month_returns_422(
+    api_client: AsyncClient,
+) -> None:
+    """Verify invalid period month values return 422 responses."""
+    rebuild_response = await api_client.post(
+        "/api/v1/reporting/kpi-snapshots/rebuild",
+        json={"period_month": "2026-03-15"},
+    )
+    assert rebuild_response.status_code == 422
+
+    read_response = await api_client.get(
+        "/api/v1/reporting/kpi-snapshots",
+        params={"period_month": "2026-03-15"},
+    )
+    assert read_response.status_code == 422

--- a/apps/backend/tests/unit/reporting/test_kpi_snapshot_service.py
+++ b/apps/backend/tests/unit/reporting/test_kpi_snapshot_service.py
@@ -1,0 +1,348 @@
+"""Unit tests for KPI snapshot aggregation behavior."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from starlette.requests import Request
+
+from hrm_backend.auth.schemas.token_claims import AuthContext
+from hrm_backend.candidates.models.profile import CandidateProfile
+from hrm_backend.core.models.base import Base
+from hrm_backend.employee.models.hire_conversion import HireConversion
+from hrm_backend.employee.models.onboarding import OnboardingRun, OnboardingTask
+from hrm_backend.employee.models.profile import EmployeeProfile
+from hrm_backend.interviews.models.interview import Interview
+from hrm_backend.reporting.dao.kpi_aggregation_dao import KpiAggregationDAO
+from hrm_backend.reporting.dao.kpi_snapshot_dao import KpiSnapshotDAO
+from hrm_backend.reporting.models.kpi_snapshot import KpiSnapshot
+from hrm_backend.reporting.services.kpi_snapshot_service import KpiSnapshotService
+from hrm_backend.reporting.utils.metrics import KPI_METRIC_KEYS
+from hrm_backend.vacancies.models.offer import Offer
+from hrm_backend.vacancies.models.pipeline_transition import PipelineTransition
+from hrm_backend.vacancies.models.vacancy import Vacancy
+
+
+class _AuditServiceStub:
+    """Audit double that stores KPI audit events in memory."""
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, object]] = []
+
+    def record_api_event(self, **payload: object) -> None:
+        """Capture audit payloads for assertions."""
+        self.events.append(payload)
+
+
+def _build_request(path: str, method: str = "GET") -> Request:
+    """Create a minimal Starlette request object for service calls."""
+    return Request(
+        {
+            "type": "http",
+            "method": method,
+            "path": path,
+            "headers": [],
+            "client": ("127.0.0.1", 8000),
+        }
+    )
+
+
+def _build_auth_context(role: str = "admin") -> AuthContext:
+    """Create deterministic auth context for KPI service tests."""
+    return AuthContext(
+        subject_id=UUID("11111111-1111-4111-8111-111111111111"),
+        role=role,
+        session_id=uuid4(),
+        token_id=uuid4(),
+        expires_at=9999999999,
+    )
+
+
+def _build_service(session: Session, audit_service: _AuditServiceStub) -> KpiSnapshotService:
+    """Construct KPI snapshot service with test dependencies."""
+    return KpiSnapshotService(
+        snapshot_dao=KpiSnapshotDAO(session=session),
+        aggregation_dao=KpiAggregationDAO(session=session),
+        audit_service=audit_service,
+    )
+
+
+def _seed_kpi_sources(session: Session) -> None:
+    """Insert one row per KPI source inside March 2026."""
+    vacancy_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    candidate_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+    offer_id = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+    transition_applied_id = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+    transition_hired_id = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+    conversion_id = "ffffffff-ffff-4fff-8fff-ffffffffffff"
+    employee_id = "11111111-2222-4333-8444-555555555555"
+    onboarding_id = "66666666-7777-4888-8999-000000000000"
+    task_id = "12121212-3434-4567-8999-121212121212"
+
+    vacancy = Vacancy(
+        vacancy_id=vacancy_id,
+        title="Platform Engineer",
+        description="Build platform foundations.",
+        department="Engineering",
+        status="open",
+        created_at=datetime(2026, 3, 5, 9, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 3, 5, 9, 0, tzinfo=UTC),
+    )
+    candidate = CandidateProfile(
+        candidate_id=candidate_id,
+        owner_subject_id="public",
+        first_name="Ada",
+        last_name="Lovelace",
+        email="ada@example.com",
+        phone=None,
+        location=None,
+        current_title=None,
+        extra_data={},
+        created_at=datetime(2026, 3, 6, 9, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 3, 6, 9, 0, tzinfo=UTC),
+    )
+    transition_applied = PipelineTransition(
+        transition_id=transition_applied_id,
+        vacancy_id=vacancy_id,
+        candidate_id=candidate_id,
+        from_stage=None,
+        to_stage="applied",
+        reason="public_application",
+        changed_by_sub="public",
+        changed_by_role="public",
+        transitioned_at=datetime(2026, 3, 6, 10, 0, tzinfo=UTC),
+    )
+    interview = Interview(
+        interview_id="99999999-aaaa-4bbb-8ccc-999999999999",
+        vacancy_id=vacancy_id,
+        candidate_id=candidate_id,
+        status="scheduled",
+        calendar_sync_status="pending",
+        schedule_version=1,
+        scheduled_start_at=datetime(2026, 3, 10, 10, 0, tzinfo=UTC),
+        scheduled_end_at=datetime(2026, 3, 10, 11, 0, tzinfo=UTC),
+        timezone="UTC",
+        location_kind="video",
+        location_details=None,
+        interviewer_staff_ids_json=["22222222-2222-4222-8222-222222222222"],
+        calendar_event_id=None,
+        candidate_token_nonce=None,
+        candidate_token_hash=None,
+        candidate_token_expires_at=None,
+        candidate_response_status="pending",
+        candidate_response_note=None,
+        cancelled_by=None,
+        cancel_reason_code=None,
+        calendar_sync_reason_code=None,
+        calendar_sync_error_detail=None,
+        created_by_staff_id="33333333-3333-4333-8333-333333333333",
+        updated_by_staff_id="33333333-3333-4333-8333-333333333333",
+        created_at=datetime(2026, 3, 7, 9, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 3, 7, 9, 0, tzinfo=UTC),
+        last_synced_at=None,
+    )
+    offer = Offer(
+        offer_id=offer_id,
+        vacancy_id=vacancy_id,
+        candidate_id=candidate_id,
+        status="accepted",
+        terms_summary="Base offer",
+        proposed_start_date=None,
+        expires_at=None,
+        note=None,
+        sent_at=datetime(2026, 3, 12, 9, 0, tzinfo=UTC),
+        sent_by_staff_id="44444444-4444-4444-8444-444444444444",
+        decision_at=datetime(2026, 3, 15, 9, 0, tzinfo=UTC),
+        decision_note=None,
+        decision_recorded_by_staff_id="44444444-4444-4444-8444-444444444444",
+        created_at=datetime(2026, 3, 11, 9, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 3, 15, 9, 0, tzinfo=UTC),
+    )
+    transition_hired = PipelineTransition(
+        transition_id=transition_hired_id,
+        vacancy_id=vacancy_id,
+        candidate_id=candidate_id,
+        from_stage="offer",
+        to_stage="hired",
+        reason=None,
+        changed_by_sub="44444444-4444-4444-8444-444444444444",
+        changed_by_role="hr",
+        transitioned_at=datetime(2026, 3, 16, 9, 0, tzinfo=UTC),
+    )
+    conversion = HireConversion(
+        conversion_id=conversion_id,
+        vacancy_id=vacancy_id,
+        candidate_id=candidate_id,
+        offer_id=offer_id,
+        hired_transition_id=transition_hired_id,
+        status="ready",
+        candidate_snapshot_json={"first_name": "Ada", "last_name": "Lovelace"},
+        offer_snapshot_json={"status": "accepted"},
+        converted_at=datetime(2026, 3, 16, 10, 0, tzinfo=UTC),
+        converted_by_staff_id="44444444-4444-4444-8444-444444444444",
+    )
+    employee_profile = EmployeeProfile(
+        employee_id=employee_id,
+        hire_conversion_id=conversion_id,
+        vacancy_id=vacancy_id,
+        candidate_id=candidate_id,
+        first_name="Ada",
+        last_name="Lovelace",
+        email="ada@example.com",
+        phone=None,
+        location=None,
+        current_title=None,
+        extra_data_json={},
+        offer_terms_summary="Base offer",
+        start_date=None,
+        staff_account_id=None,
+        created_by_staff_id="44444444-4444-4444-8444-444444444444",
+        created_at=datetime(2026, 3, 16, 12, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 3, 16, 12, 0, tzinfo=UTC),
+    )
+    onboarding_run = OnboardingRun(
+        onboarding_id=onboarding_id,
+        employee_id=employee_id,
+        hire_conversion_id=conversion_id,
+        status="started",
+        started_at=datetime(2026, 3, 17, 9, 0, tzinfo=UTC),
+        started_by_staff_id="44444444-4444-4444-8444-444444444444",
+    )
+    onboarding_task = OnboardingTask(
+        task_id=task_id,
+        onboarding_id=onboarding_id,
+        template_id="22222222-3333-4444-8555-666666666666",
+        template_item_id="77777777-8888-4999-8aaa-bbbbbbbbbbbb",
+        code="welcome",
+        title="Welcome",
+        description=None,
+        sort_order=10,
+        is_required=True,
+        status="completed",
+        assigned_role=None,
+        assigned_staff_id=None,
+        due_at=None,
+        completed_at=datetime(2026, 3, 18, 9, 0, tzinfo=UTC),
+        created_at=datetime(2026, 3, 17, 9, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 3, 18, 9, 0, tzinfo=UTC),
+    )
+
+    session.add_all(
+        [
+            vacancy,
+            candidate,
+            transition_applied,
+            interview,
+            offer,
+            transition_hired,
+            conversion,
+            employee_profile,
+            onboarding_run,
+            onboarding_task,
+        ]
+    )
+    session.commit()
+
+
+def test_kpi_snapshot_rebuild_aggregates_all_metrics() -> None:
+    """Verify KPI snapshot rebuild aggregates counts from all source domains."""
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    audit_service = _AuditServiceStub()
+
+    with Session(engine) as session:
+        _seed_kpi_sources(session)
+        service = _build_service(session, audit_service)
+        response = service.rebuild_monthly_snapshot(
+            period_month=date(2026, 3, 1),
+            auth_context=_build_auth_context(),
+            request=_build_request("/api/v1/reporting/kpi-snapshots/rebuild", method="POST"),
+        )
+
+        assert {item.metric_key: item.metric_value for item in response.metrics} == {
+            "vacancies_created_count": 1,
+            "candidates_applied_count": 1,
+            "interviews_scheduled_count": 1,
+            "offers_sent_count": 1,
+            "offers_accepted_count": 1,
+            "hires_count": 1,
+            "onboarding_started_count": 1,
+            "onboarding_tasks_completed_count": 1,
+        }
+
+
+def test_kpi_snapshot_rebuild_zero_fills_for_empty_month() -> None:
+    """Verify KPI snapshot rebuild materializes zero values when no data exists."""
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    audit_service = _AuditServiceStub()
+
+    with Session(engine) as session:
+        service = _build_service(session, audit_service)
+        response = service.rebuild_monthly_snapshot(
+            period_month=date(2026, 4, 1),
+            auth_context=_build_auth_context(),
+            request=_build_request("/api/v1/reporting/kpi-snapshots/rebuild", method="POST"),
+        )
+
+        assert len(response.metrics) == len(KPI_METRIC_KEYS)
+        assert all(item.metric_value == 0 for item in response.metrics)
+
+
+def test_kpi_snapshot_rebuild_is_idempotent_and_replaces_month() -> None:
+    """Verify rebuild is deterministic and replaces monthly rows atomically."""
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    audit_service = _AuditServiceStub()
+
+    with Session(engine) as session:
+        _seed_kpi_sources(session)
+        service = _build_service(session, audit_service)
+        first = service.rebuild_monthly_snapshot(
+            period_month=date(2026, 3, 1),
+            auth_context=_build_auth_context(),
+            request=_build_request("/api/v1/reporting/kpi-snapshots/rebuild", method="POST"),
+        )
+        second = service.rebuild_monthly_snapshot(
+            period_month=date(2026, 3, 1),
+            auth_context=_build_auth_context(),
+            request=_build_request("/api/v1/reporting/kpi-snapshots/rebuild", method="POST"),
+        )
+
+        assert {item.metric_key: item.metric_value for item in first.metrics} == {
+            item.metric_key: item.metric_value for item in second.metrics
+        }
+
+        session.add(
+            Vacancy(
+                vacancy_id="99999999-9999-4999-8999-999999999999",
+                title="Another role",
+                description="Extra role",
+                department="Engineering",
+                status="open",
+                created_at=datetime(2026, 3, 20, 9, 0, tzinfo=UTC),
+                updated_at=datetime(2026, 3, 20, 9, 0, tzinfo=UTC),
+            )
+        )
+        session.commit()
+
+        third = service.rebuild_monthly_snapshot(
+            period_month=date(2026, 3, 1),
+            auth_context=_build_auth_context(),
+            request=_build_request("/api/v1/reporting/kpi-snapshots/rebuild", method="POST"),
+        )
+
+        vacancy_metric = next(
+            item for item in third.metrics if item.metric_key == "vacancies_created_count"
+        )
+        assert vacancy_metric.metric_value == 2
+
+        snapshot_rows = (
+            session.query(KpiSnapshot)
+            .filter(KpiSnapshot.period_month == date(2026, 3, 1))
+            .all()
+        )
+        assert len(snapshot_rows) == len(KPI_METRIC_KEYS)

--- a/apps/frontend/src/api/generated/openapi-types.ts
+++ b/apps/frontend/src/api/generated/openapi-types.ts
@@ -786,6 +786,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/reporting/kpi-snapshots": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Read Kpi Snapshot
+         * @description Read KPI snapshot rows for a single month.
+         */
+        get: operations["read_kpi_snapshot_api_v1_reporting_kpi_snapshots_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/reporting/kpi-snapshots/rebuild": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Rebuild Kpi Snapshot
+         * @description Rebuild KPI snapshot rows for a single month.
+         */
+        post: operations["rebuild_kpi_snapshot_api_v1_reporting_kpi_snapshots_rebuild_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/vacancies": {
         parameters: {
             query?: never;
@@ -2276,6 +2316,45 @@ export interface components {
             scheduled_start_local: string;
             /** Timezone */
             timezone: string;
+        };
+        /**
+         * KpiSnapshotMetric
+         * @description Metric payload for one KPI snapshot row.
+         */
+        KpiSnapshotMetric: {
+            /** Generated At */
+            generated_at?: string | null;
+            /**
+             * Metric Key
+             * @enum {string}
+             */
+            metric_key: "vacancies_created_count" | "candidates_applied_count" | "interviews_scheduled_count" | "offers_sent_count" | "offers_accepted_count" | "hires_count" | "onboarding_started_count" | "onboarding_tasks_completed_count";
+            /** Metric Value */
+            metric_value: number;
+        };
+        /**
+         * KpiSnapshotReadResponse
+         * @description Monthly KPI snapshot response payload.
+         */
+        KpiSnapshotReadResponse: {
+            /** Metrics */
+            metrics: components["schemas"]["KpiSnapshotMetric"][];
+            /**
+             * Period Month
+             * Format: date
+             */
+            period_month: string;
+        };
+        /**
+         * KpiSnapshotRebuildRequest
+         * @description Payload for requesting a KPI snapshot rebuild for one month.
+         */
+        KpiSnapshotRebuildRequest: {
+            /**
+             * Period Month
+             * Format: date
+             */
+            period_month: string;
         };
         /**
          * LoginRequest
@@ -4898,6 +4977,70 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PublicInterviewRegistrationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    read_kpi_snapshot_api_v1_reporting_kpi_snapshots_get: {
+        parameters: {
+            query: {
+                period_month: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["KpiSnapshotReadResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    rebuild_kpi_snapshot_api_v1_reporting_kpi_snapshots_rebuild_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["KpiSnapshotRebuildRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["KpiSnapshotReadResponse"];
                 };
             };
             /** @description Validation Error */

--- a/docs/api/openapi.frozen.json
+++ b/docs/api/openapi.frozen.json
@@ -2581,6 +2581,89 @@
         "title": "InterviewRescheduleRequest",
         "type": "object"
       },
+      "KpiSnapshotMetric": {
+        "additionalProperties": false,
+        "description": "Metric payload for one KPI snapshot row.",
+        "properties": {
+          "generated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Generated At"
+          },
+          "metric_key": {
+            "enum": [
+              "vacancies_created_count",
+              "candidates_applied_count",
+              "interviews_scheduled_count",
+              "offers_sent_count",
+              "offers_accepted_count",
+              "hires_count",
+              "onboarding_started_count",
+              "onboarding_tasks_completed_count"
+            ],
+            "title": "Metric Key",
+            "type": "string"
+          },
+          "metric_value": {
+            "minimum": 0.0,
+            "title": "Metric Value",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "metric_key",
+          "metric_value"
+        ],
+        "title": "KpiSnapshotMetric",
+        "type": "object"
+      },
+      "KpiSnapshotReadResponse": {
+        "additionalProperties": false,
+        "description": "Monthly KPI snapshot response payload.",
+        "properties": {
+          "metrics": {
+            "items": {
+              "$ref": "#/components/schemas/KpiSnapshotMetric"
+            },
+            "title": "Metrics",
+            "type": "array"
+          },
+          "period_month": {
+            "format": "date",
+            "title": "Period Month",
+            "type": "string"
+          }
+        },
+        "required": [
+          "period_month",
+          "metrics"
+        ],
+        "title": "KpiSnapshotReadResponse",
+        "type": "object"
+      },
+      "KpiSnapshotRebuildRequest": {
+        "additionalProperties": false,
+        "description": "Payload for requesting a KPI snapshot rebuild for one month.",
+        "properties": {
+          "period_month": {
+            "format": "date",
+            "title": "Period Month",
+            "type": "string"
+          }
+        },
+        "required": [
+          "period_month"
+        ],
+        "title": "KpiSnapshotRebuildRequest",
+        "type": "object"
+      },
       "LoginRequest": {
         "additionalProperties": false,
         "description": "Input payload for staff login.\n\nSupports identifier/password staff password flow.",
@@ -8158,6 +8241,102 @@
         "summary": "Request Public Reschedule",
         "tags": [
           "interviews"
+        ]
+      }
+    },
+    "/api/v1/reporting/kpi-snapshots": {
+      "get": {
+        "description": "Read KPI snapshot rows for a single month.",
+        "operationId": "read_kpi_snapshot_api_v1_reporting_kpi_snapshots_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "period_month",
+            "required": true,
+            "schema": {
+              "format": "date",
+              "title": "Period Month",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KpiSnapshotReadResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Read Kpi Snapshot",
+        "tags": [
+          "reporting"
+        ]
+      }
+    },
+    "/api/v1/reporting/kpi-snapshots/rebuild": {
+      "post": {
+        "description": "Rebuild KPI snapshot rows for a single month.",
+        "operationId": "rebuild_kpi_snapshot_api_v1_reporting_kpi_snapshots_rebuild_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KpiSnapshotRebuildRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KpiSnapshotReadResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Rebuild Kpi Snapshot",
+        "tags": [
+          "reporting"
         ]
       }
     },

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -48,6 +48,7 @@ Use this log for decisions that change interfaces, data models, deployment topol
 | ADR-0041 | 2026-03-12 | accepted | Introduce explicit vacancy ownership and dedicated manager workspace reads on `/` | architect + backend-engineer + frontend-engineer | manager workspace visibility policy, vacancy ownership signal, frontend route semantics |
 | ADR-0042 | 2026-03-13 | accepted | Add accountant workspace + dual-format controlled export as a thin finance adapter over onboarding data | architect + backend-engineer + frontend-engineer | finance adapter boundary, controlled exports, frontend route semantics, observability |
 | ADR-0043 | 2026-03-13 | accepted | Add recipient-scoped in-app notifications and on-demand digests for manager/accountant workspaces | architect + backend-engineer + frontend-engineer | notification package boundary, recipient visibility policy, frontend embedded workspaces, OpenAPI contract |
+| ADR-0044 | 2026-03-13 | accepted | Introduce monthly KPI snapshot foundation with on-demand rebuild | architect + backend-engineer | reporting package, KPI data model, analytics access policy |
 ## ADR-0001
 - Context: Project is at bootstrap stage and lacks durable knowledge artifacts.
 - Decision: Standardize docs structure under `docs/`, enforce updates per task, and keep agent workflow under `.ai/`.
@@ -913,3 +914,16 @@ Use this log for decisions that change interfaces, data models, deployment topol
     table and digests are computed on demand from current vacancy/task state.
   - Future outbound delivery channels, template systems, broader role coverage, or async delivery
     infrastructure can be layered later without reopening the current read/update contract.
+
+## ADR-0044
+- Context: `TASK-10-01` requires KPI reporting without relying on the deferred automation engine and without adding schedulers or event-bus dependencies.
+- Decision:
+  - Introduce a reporting package with monthly KPI snapshots stored in `kpi_snapshots`.
+  - Rebuild snapshots explicitly via server-side service call (and admin-only API surface in v1).
+  - Aggregate only from existing durable domain tables (vacancies, pipeline transitions, interviews, offers, hire conversions, onboarding runs/tasks).
+  - Keep one global monthly scope in v1 (no team/department dimensions) and materialize zero rows for months with no data.
+  - If no snapshot exists for a requested month, return an empty deterministic payload instead of live aggregation.
+- Consequences:
+  - KPI reporting is deterministic, idempotent, and does not require async schedulers or event streams.
+  - Leader-facing reads are deferred to a follow-up slice; current API is admin-only to keep exposure tight.
+  - Automation-specific KPI coverage remains explicitly out of scope until the automation engine is implemented.

--- a/docs/architecture/decomposition.md
+++ b/docs/architecture/decomposition.md
@@ -20,7 +20,7 @@ industries rather than only IT roles.
 | Platform | Identity, access, audit, notifications, integrations | All roles | Phase 1 |
 | Core Foundation | Shared technical primitives reused by all backend domains | Backend teams | Phase 1-2 |
 | Intelligence | CV analysis and recommendation support | HR, managers | Phase 1 |
-| Analytics | KPI and operational reporting | HR, leaders, managers | Phase 2 |
+| Analytics | KPI and operational reporting (monthly snapshots in v1) | HR, leaders, managers | Phase 1-2 |
 
 ## Level 2: Service Decomposition
 
@@ -42,7 +42,7 @@ industries rather than only IT roles.
 | Workflow Automation Service | HR Operations | Rule engine and triggered HR tasks | Event-driven |
 | Notification Service | Platform | Recipient-scoped in-app notifications and on-demand digests in v1; outbound templates/channels later | REST |
 | Audit Service | Platform | Immutable security and business audit logs | Event ingestion |
-| Reporting Service | Analytics | KPI aggregation and dashboards | Read APIs |
+| Reporting Service | Analytics | Monthly KPI snapshots (on-demand rebuild) and dashboards | Read/maintenance APIs |
 | Accounting Export Service | Finance Adapter | Controlled export for accounting workflows | File/API adapter |
 
 ## Level 3: Internal Module Decomposition (Priority Services)
@@ -119,6 +119,7 @@ industries rather than only IT roles.
 | Employee profiles | Employee Profile Service | PostgreSQL | Created post-hire |
 | Onboarding tasks | Onboarding Service | PostgreSQL | Linked to employee profile |
 | In-app notifications | Notification Service | PostgreSQL | Recipient-scoped, deduped, and read-tracked |
+| KPI snapshots | Reporting Service | PostgreSQL | Monthly snapshots keyed by `period_month + metric_key`, rebuilt on demand |
 | Automation executions | Workflow Automation Service | PostgreSQL | Used for KPI and incident analysis |
 | Audit events | Audit Service | Append-only storage | Compliance evidence |
 | Auth denylist markers (`jti`/`sid`) | Auth and Access Service | Redis | Valid tokens are not persisted server-side |
@@ -144,13 +145,14 @@ industries rather than only IT roles.
 - Interview Service
 - Calendar Sync Service (Google Calendar)
 - Audit Service
+- Reporting Service (monthly KPI snapshot foundation, admin-only API)
 
 ### Phase 2: Manager/Employee/Accountant/Leader Expansion
 - Frontend App (React.js + TypeScript) expansion: manager/employee/accountant/leader workspaces
 - Employee Profile Service
 - Onboarding Service
 - Workflow Automation Service (expanded rules)
-- Reporting Service
+- Reporting Service (leader/manager dashboards and expanded KPI scope)
 - Accounting Export Service
 - Notification Service (in-app + digest baseline, outbound/template coverage later)
 

--- a/docs/architecture/diagrams.md
+++ b/docs/architecture/diagrams.md
@@ -932,3 +932,34 @@ flowchart LR
 
   CONFIG[VITE_SENTRY_* env config] --> SENTRY
 ```
+
+## Diagram 23: KPI Snapshot Aggregation Flow (TASK-10-01)
+
+```mermaid
+flowchart LR
+  subgraph Domains[Transactional Domains]
+    VAC[Vacancies]
+    PIPE[Pipeline Transitions]
+    INT[Interviews]
+    OFFER[Offers]
+    HIRE[Hire Conversions]
+    ONB[Onboarding Runs/Tasks]
+  end
+
+  subgraph Reporting[Reporting]
+    REBUILD[Admin Rebuild Request]
+    AGG[KPI Aggregation Service]
+    SNAP[(kpi_snapshots)]
+    READ[Snapshot Read API]
+  end
+
+  REBUILD --> AGG
+  VAC --> AGG
+  PIPE --> AGG
+  INT --> AGG
+  OFFER --> AGG
+  HIRE --> AGG
+  ONB --> AGG
+  AGG --> SNAP
+  READ --> SNAP
+```

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -52,7 +52,7 @@ flowchart LR
 | Notification Domain | Recipient-scoped in-app notifications and server-computed digests for manager/accountant workspaces | Vacancy ownership changes, onboarding assignment changes, protected notification reads | Dedupe-safe notification rows, unread/read state, digest counters, and embedded workspace notification blocks | platform |
 | AI Adapter | External model integration for CV analysis and match scoring | CV files, vacancy profiles, scoring prompts | Structured candidate insights and score responses | ai-platform |
 | Integration Layer | External connector abstraction | Internal events/commands | Google Calendar actions | platform |
-| Reporting and Audit | KPI tracking and compliance evidence | Domain events | Dashboards, audit logs | data-platform |
+| Reporting and Audit | Monthly KPI snapshots and compliance evidence | Durable domain tables, audit events | KPI snapshots, audit logs | data-platform |
 
 ## Key Flows
 1. Candidate Screening Flow:
@@ -125,6 +125,11 @@ flowchart LR
    recipient opens `/` -> `GET /api/v1/notifications/digest` computes summary counters on demand ->
    `GET /api/v1/notifications?status=unread` returns recipient-owned unread items ->
    `POST /api/v1/notifications/{notification_id}/read` marks only that recipient row as read.
+14. KPI Snapshot Rebuild Flow:
+   admin triggers explicit rebuild -> reporting service reads durable vacancy/pipeline/interview/offer/employee
+   tables for the requested calendar month -> KPI counts are computed server-side ->
+   `kpi_snapshots` rows for the month are replaced atomically -> admin reads stored snapshot via
+   `/api/v1/reporting/kpi-snapshots` (no live aggregation and no scheduler).
 
 ## Data Boundaries
 - Source of truth entities:
@@ -179,6 +184,10 @@ flowchart LR
   source identifiers, dedupe keys, human-readable title/body copy, structured payload JSON,
   created timestamp, and optional `read_at`; manager/accountant digests reuse these rows plus live
   vacancy/task reads without a scheduler or outbound delivery table in this slice.
+- KPI snapshot artifacts:
+  `kpi_snapshots` rows keyed by `period_month + metric_key`, including aggregated `metric_value`
+  and `generated_at` timestamps; rows are rebuilt explicitly from durable domain tables and are
+  never computed on read paths in v1.
 - Accountant workspace export artifacts:
   the finance adapter derives accountant-visible rows directly from `employee_profiles`,
   `onboarding_runs`, and `onboarding_tasks`; visibility stays fail-closed on accountant

--- a/docs/project/rbac-matrix.md
+++ b/docs/project/rbac-matrix.md
@@ -1,12 +1,12 @@
 # RBAC Role Matrix (Phase 1 Baseline)
 
 ## Last Updated
-- Date: 2026-03-11
-- Updated by: backend-engineer + frontend-engineer
+- Date: 2026-03-13
+- Updated by: backend-engineer
 
 This matrix is the access baseline for `TASK-01-01`, `TASK-01-02`, `TASK-01-03`,
 `TASK-03-01`, `TASK-03-02`, `TASK-03-03`, `TASK-02-01`, `TASK-02-02`, `TASK-06-03`,
-`TASK-07-01`, `TASK-07-02`, `TASK-07-03`, and `TASK-07-04`.
+`TASK-07-01`, `TASK-07-02`, `TASK-07-03`, `TASK-07-04`, and `TASK-10-01`.
 Enforcement source of truth:
 - `apps/backend/src/hrm_backend/rbac.py`
 - `apps/backend/src/hrm_backend/auth/`
@@ -60,6 +60,8 @@ Enforcement source of truth:
 | `interview:manage` | yes | yes | yes | no | no | no |
 | `analytics:read` | yes | yes | yes | yes | yes | yes |
 | `accounting:read` | yes | no | no | no | no | yes |
+| `kpi_snapshot:read` | yes | no | no | no | no | no |
+| `kpi_snapshot:rebuild` | yes | no | no | no | no | no |
 
 Public endpoint outside RBAC matrix:
 - `POST /api/v1/vacancies/{vacancy_id}/applications` is anonymous (`actor_sub=null` in audit context).
@@ -87,6 +89,7 @@ Public endpoint outside RBAC matrix:
   Manager users can observe onboarding progress only through the dedicated read routes above.
 - Onboarding checklist template management routes are staff-only and currently limited to `admin/hr`.
   Manager-facing template management remains out of scope.
+- KPI snapshot read/rebuild routes are admin-only in v1.
 - Employee self-service onboarding routes are limited to the `employee` role:
   - `GET /api/v1/employees/me/onboarding`
   - `PATCH /api/v1/employees/me/onboarding/tasks/{task_id}`

--- a/docs/project/tasks.md
+++ b/docs/project/tasks.md
@@ -51,6 +51,7 @@
 | TASK-09-01 | implemented/local-manager-workspace-slice | Manager users now land on `/` in a read-only hiring + onboarding workspace backed by manager-scoped vacancy APIs, explicit `vacancies.hiring_manager_staff_id` ownership, and the reused onboarding dashboard block, while HR/admin keep the existing recruitment workspace on `/` |
 | TASK-09-03 | done/closed | GitHub issue #96 closed; merged in `main` via PR #114 (`c237296`) with accountant workspace routing on `/`, assignment-scoped `/api/v1/accounting/workspace*`, controlled CSV/XLSX exports, and solo-mode architecture self-review workflow alignment |
 | TASK-09-04 | done/closed | GitHub issue #97 closed; merged in `main` via PR #116 (`966f3a8`) with recipient-scoped `/api/v1/notifications*`, embedded manager/accountant notifications UI on `/`, fail-closed read/update scope, on-demand digests, regenerated OpenAPI/frontend types, and synced architecture/test docs |
+| TASK-10-01 | implemented/local-kpi-snapshot-slice | Monthly KPI snapshots with admin-only rebuild/read API, reporting package, migration, unit/integration tests, and updated OpenAPI/frontend types are implemented in repo |
 | COMPLIANCE-01 | planned | EPIC-13 article-level legal mapping and evidence pack track |
 
 ## 2026-03-12 Delivery Control Notes
@@ -108,22 +109,23 @@
 - `TASK-09-01` is no longer active queue work; the implemented source of truth is the repo-backed manager workspace on `/` plus manager-scoped vacancy read endpoints on the existing `/api/v1/vacancies` namespace.
 - `TASK-09-03` is no longer active queue work; the implemented source of truth is the repo-backed accountant workspace on `/` plus assignment-scoped finance read/export endpoints on `/api/v1/accounting/workspace*`.
 - `TASK-09-04` is no longer active queue work; the implemented source of truth is the repo-backed recipient-scoped notification API on `/api/v1/notifications*` plus the embedded manager/accountant notifications block on the existing `/` route.
+- `TASK-10-01` is no longer active queue work; the implemented source of truth is the repo-backed monthly KPI snapshot foundation with admin-only rebuild/read APIs.
 - The remaining candidate-domain follow-on work after `TASK-03-08` and `TASK-04-06` is limited to
   later ops/reporting slices, not baseline parsed-profile structure or scoring-quality tooling.
 
 ## Normalized Open Backlog Snapshot
 
-- Normalized open backlog count: `15` tasks.
+- Normalized open backlog count: `14` tasks.
 - This count excludes tasks already implemented in repo but retained in the historical planning tables below for lineage.
 - Repo backlog state now excludes `TASK-12-02`, and GitHub issue `#85` is closed following PR #105 (`a67bb8c`).
 - Issue `#58` remains an umbrella `COMPLIANCE-01` tracking issue and is not included in the normalized `15`-task count.
 - Current open backlog by delivery wave:
-  - Wave 2 platform/ops/reporting: `TASK-02-04`, `ADMIN-04`, `ADMIN-05`, `TASK-08-01`, `TASK-08-02`, `TASK-08-03`, `TASK-08-04`, `TASK-10-01`, `TASK-10-02`, `TASK-10-03`, `TASK-10-04`, `TASK-13-03`, `TASK-13-04`
+  - Wave 2 platform/ops/reporting: `TASK-02-04`, `ADMIN-04`, `ADMIN-05`, `TASK-08-01`, `TASK-08-02`, `TASK-08-03`, `TASK-08-04`, `TASK-10-02`, `TASK-10-03`, `TASK-10-04`, `TASK-13-03`, `TASK-13-04`
   - Wave 3 phase-2 workspaces: `TASK-09-02`, `TASK-11-12`
 
 | Order | Task ID | Why Now |
 | --- | --- | --- |
-| A-1 | TASK-10-01 | KPI aggregation is now the next unblocked prerequisite because the remaining leader workspace slice (`TASK-09-02`) still depends on KPI snapshot/reporting read models |
+| A-1 | TASK-10-02 | Follow-on KPI snapshot reads/leader exposure now that the monthly snapshot foundation is implemented |
 
 - Execution rule for follow-on interview work: keep the implemented `/` and `/candidate?interviewToken=...` topology, candidate-auth exclusion, and token-based public transport unchanged unless a separate ADR reopens that scope.
 

--- a/docs/testing/strategy.md
+++ b/docs/testing/strategy.md
@@ -173,6 +173,15 @@ apps/backend/tests/
 | Evidence traceability + analysis read contract (`TASK-03-06`) | `tests/unit/candidates/test_cv_parsing_normalization.py` (field-level evidence snippets/offsets) | `tests/integration/candidates/test_candidate_api.py` + `tests/integration/candidates/test_cv_parsing_jobs.py` | `GET /api/v1/candidates/{candidate_id}/cv/analysis` and `GET /api/v1/public/cv-parsing-jobs/{job_id}/analysis` return structured profile + evidence; pre-ready path returns `409` |
 | RBAC + audit coverage for recruitment endpoints | `tests/unit/rbac/test_rbac.py` | `tests/integration/security/test_audit_enforcement.py` + recruitment integration suites | `allowed/denied/success/failure` audit records in `audit_events` |
 
+## Reporting KPI Snapshot Verification (TASK-10-01)
+
+| Capability | Unit Coverage | Integration Coverage | Required Evidence |
+| --- | --- | --- | --- |
+| KPI aggregation per source table | `tests/unit/reporting/test_kpi_snapshot_service.py` | `tests/integration/reporting/test_kpi_snapshot_api.py` | `uv run --project apps/backend pytest -q` |
+| Zero-fill semantics + idempotent rebuild | `tests/unit/reporting/test_kpi_snapshot_service.py` | `tests/integration/reporting/test_kpi_snapshot_api.py` | snapshot rows remain deterministic across rebuilds |
+| Read API returns empty payload when snapshot is missing | N/A | `tests/integration/reporting/test_kpi_snapshot_api.py` | `metrics=[]` for missing months |
+| RBAC fail-closed access for KPI endpoints | N/A | `tests/integration/reporting/test_kpi_snapshot_api.py` | `403` for non-admin roles |
+
 ## Frontend Login UX Verification (TASK-11-13)
 
 | Capability | Unit Coverage | Integration/Smoke Coverage | Required Evidence |


### PR DESCRIPTION
# Pull Request

## Summary
- Add monthly KPI snapshot foundation with admin-only rebuild/read API, reporting package, migration, and unit/integration coverage.
- Update OpenAPI freeze + frontend generated types and sync architecture/testing docs.

## Linked Tasks
- TASK-10-01
- Closes #22

## Verification
- [x] Backend lint passed (`uv run --project apps/backend ruff check .`)
- [x] Backend tests passed (`uv run --project apps/backend pytest -q`)
- [ ] Frontend lint passed (`npm --prefix apps/frontend run lint`)
- [ ] Frontend tests passed (`npm --prefix apps/frontend run test`)
- [x] Docs check passed (`./scripts/check-docs-structure.sh`)
- [x] OpenAPI freeze check passed (`./scripts/check-openapi-freeze.sh`)
- [x] Frontend API types check passed (`npm --prefix apps/frontend run api:types:check`)
- [x] Docker compose up/ps (`docker compose up -d --build`, `docker compose ps`)

## Definition of Done
- [x] Acceptance criteria for linked TASK-* are met.
- [x] Tests updated for new/changed behavior (happy path + failure path).
- [x] Public APIs/modules/classes/functions include detailed docstrings.
- [x] Only essential non-obvious comments are added (no AI-style comments).
- [x] Architecture/flow changes reflected in `docs/architecture/diagrams.md`.
- [x] Documentation updated in the same PR (project/architecture/operations/testing as needed).
- [x] Security/compliance impact assessed (Belarus/Russia personal data requirements).
- [x] Best practices from `docs/engineering/best-practices.md` followed.

## Risks and Follow-ups
- Risk: KPI snapshots are admin-only and require explicit rebuild; missing rebuilds return empty payloads by design.
- Follow-up: TASK-10-02 for leader exposure and reporting expansion.
