### PR TITLE
TASK-10-02: leader KPI snapshot read

### DIFF
--- a/apps/backend/src/hrm_backend/rbac.py
+++ b/apps/backend/src/hrm_backend/rbac.py
@@ -156,6 +156,7 @@ ROLE_PERMISSION_MATRIX: Final[dict[Role, set[Permission]]] = {
         "vacancy:read",
         "pipeline:read",
         "analytics:read",
+        "kpi_snapshot:read",
     },
     "accountant": {
         "accounting:read",

--- a/apps/backend/tests/integration/reporting/test_kpi_snapshot_api.py
+++ b/apps/backend/tests/integration/reporting/test_kpi_snapshot_api.py
@@ -308,11 +308,35 @@ async def test_kpi_snapshot_read_returns_empty_payload_when_missing(
     assert payload["metrics"] == []
 
 
-async def test_kpi_snapshot_rbac_is_fail_closed(
+async def test_kpi_snapshot_read_does_not_fallback_to_live_aggregation(
     configured_app,
     api_client: AsyncClient,
 ) -> None:
-    """Verify non-admin roles are denied for KPI snapshot endpoints."""
+    """Verify read API returns empty payload even when source data exists."""
+    _, context_holder, engine = configured_app
+    _seed_kpi_sources(engine)
+    context_holder["context"] = AuthContext(
+        subject_id=uuid4(),
+        role="leader",
+        session_id=uuid4(),
+        token_id=uuid4(),
+        expires_at=9999999999,
+    )
+
+    read_response = await api_client.get(
+        "/api/v1/reporting/kpi-snapshots",
+        params={"period_month": "2026-03-01"},
+    )
+    assert read_response.status_code == 200
+    payload = read_response.json()
+    assert payload["metrics"] == []
+
+
+async def test_kpi_snapshot_rbac_allows_leader_reads_and_denies_rebuild(
+    configured_app,
+    api_client: AsyncClient,
+) -> None:
+    """Verify leader can read KPI snapshots but cannot rebuild them."""
     _, context_holder, _ = configured_app
     context_holder["context"] = AuthContext(
         subject_id=uuid4(),
@@ -326,13 +350,36 @@ async def test_kpi_snapshot_rbac_is_fail_closed(
         "/api/v1/reporting/kpi-snapshots",
         params={"period_month": "2026-03-01"},
     )
-    assert read_response.status_code == 403
+    assert read_response.status_code == 200
 
     rebuild_response = await api_client.post(
         "/api/v1/reporting/kpi-snapshots/rebuild",
         json={"period_month": "2026-03-01"},
     )
     assert rebuild_response.status_code == 403
+
+
+@pytest.mark.parametrize("role", ["hr", "manager", "employee", "accountant"])
+async def test_kpi_snapshot_read_denies_non_privileged_roles(
+    configured_app,
+    api_client: AsyncClient,
+    role: str,
+) -> None:
+    """Verify non-privileged roles are denied KPI snapshot reads."""
+    _, context_holder, _ = configured_app
+    context_holder["context"] = AuthContext(
+        subject_id=uuid4(),
+        role=role,  # type: ignore[arg-type]
+        session_id=uuid4(),
+        token_id=uuid4(),
+        expires_at=9999999999,
+    )
+
+    read_response = await api_client.get(
+        "/api/v1/reporting/kpi-snapshots",
+        params={"period_month": "2026-03-01"},
+    )
+    assert read_response.status_code == 403
 
 
 async def test_kpi_snapshot_invalid_month_returns_422(

--- a/apps/backend/tests/unit/rbac/test_rbac.py
+++ b/apps/backend/tests/unit/rbac/test_rbac.py
@@ -152,6 +152,22 @@ def test_employee_can_access_and_update_self_service_portal_permissions() -> Non
     assert update_decision.allowed is True
 
 
+def test_leader_can_read_kpi_snapshot_permission() -> None:
+    """Verify leader role can read monthly KPI snapshot reports."""
+    decision = evaluate_permission(role="leader", permission="kpi_snapshot:read")
+
+    assert decision.allowed is True
+
+
+def test_leader_is_denied_for_kpi_snapshot_rebuild_permission() -> None:
+    """Verify leader role cannot rebuild KPI snapshots."""
+    decision = evaluate_permission(role="leader", permission="kpi_snapshot:rebuild")
+
+    assert decision.allowed is False
+    assert decision.reason is not None
+    assert "kpi_snapshot:rebuild" in decision.reason
+
+
 def test_manager_is_denied_for_employee_key_list_permission() -> None:
     """Verify manager role is denied for employee-key list permission."""
     decision = evaluate_permission(role="manager", permission="admin:employee_key:list")

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -49,6 +49,7 @@ Use this log for decisions that change interfaces, data models, deployment topol
 | ADR-0042 | 2026-03-13 | accepted | Add accountant workspace + dual-format controlled export as a thin finance adapter over onboarding data | architect + backend-engineer + frontend-engineer | finance adapter boundary, controlled exports, frontend route semantics, observability |
 | ADR-0043 | 2026-03-13 | accepted | Add recipient-scoped in-app notifications and on-demand digests for manager/accountant workspaces | architect + backend-engineer + frontend-engineer | notification package boundary, recipient visibility policy, frontend embedded workspaces, OpenAPI contract |
 | ADR-0044 | 2026-03-13 | accepted | Introduce monthly KPI snapshot foundation with on-demand rebuild | architect + backend-engineer | reporting package, KPI data model, analytics access policy |
+| ADR-0045 | 2026-03-13 | accepted | Expose KPI snapshot reads to leaders while keeping rebuild admin-only | architect + backend-engineer | reporting access policy, RBAC, API read surface |
 ## ADR-0001
 - Context: Project is at bootstrap stage and lacks durable knowledge artifacts.
 - Decision: Standardize docs structure under `docs/`, enforce updates per task, and keep agent workflow under `.ai/`.
@@ -916,6 +917,7 @@ Use this log for decisions that change interfaces, data models, deployment topol
     infrastructure can be layered later without reopening the current read/update contract.
 
 ## ADR-0044
+- Status note: leader/admin snapshot read access is updated in ADR-0045.
 - Context: `TASK-10-01` requires KPI reporting without relying on the deferred automation engine and without adding schedulers or event-bus dependencies.
 - Decision:
   - Introduce a reporting package with monthly KPI snapshots stored in `kpi_snapshots`.
@@ -927,3 +929,17 @@ Use this log for decisions that change interfaces, data models, deployment topol
   - KPI reporting is deterministic, idempotent, and does not require async schedulers or event streams.
   - Leader-facing reads are deferred to a follow-up slice; current API is admin-only to keep exposure tight.
   - Automation-specific KPI coverage remains explicitly out of scope until the automation engine is implemented.
+
+## ADR-0045
+- Context: `TASK-10-02` needs leader/admin visibility over existing monthly KPI snapshots without introducing
+  automation metrics, schedulers, or live aggregation fallback.
+- Decision:
+  - Keep `kpi_snapshot:rebuild` admin-only.
+  - Allow leaders to read `/api/v1/reporting/kpi-snapshots` for stored monthly snapshots.
+  - Keep read paths deterministic: missing months return an empty payload; no live aggregation fallback.
+  - Defer automation-specific KPI tracking until `TASK-08-*` delivers the automation engine.
+- Consequences:
+  - Leaders can access monthly KPI snapshots without widening rebuild authority.
+  - Read operations remain fast and predictable because they are served only from stored snapshots.
+  - Missing months stay empty until an admin rebuilds the snapshot.
+  - Automation KPI coverage remains deferred and requires a later ADR when automation tracking lands.

--- a/docs/architecture/decomposition.md
+++ b/docs/architecture/decomposition.md
@@ -20,7 +20,7 @@ industries rather than only IT roles.
 | Platform | Identity, access, audit, notifications, integrations | All roles | Phase 1 |
 | Core Foundation | Shared technical primitives reused by all backend domains | Backend teams | Phase 1-2 |
 | Intelligence | CV analysis and recommendation support | HR, managers | Phase 1 |
-| Analytics | KPI and operational reporting (monthly snapshots in v1) | HR, leaders, managers | Phase 1-2 |
+| Analytics | KPI and operational reporting (monthly snapshots in v1) | Admin, leaders | Phase 1-2 |
 
 ## Level 2: Service Decomposition
 
@@ -42,7 +42,7 @@ industries rather than only IT roles.
 | Workflow Automation Service | HR Operations | Rule engine and triggered HR tasks | Event-driven |
 | Notification Service | Platform | Recipient-scoped in-app notifications and on-demand digests in v1; outbound templates/channels later | REST |
 | Audit Service | Platform | Immutable security and business audit logs | Event ingestion |
-| Reporting Service | Analytics | Monthly KPI snapshots (on-demand rebuild) and dashboards | Read/maintenance APIs |
+| Reporting Service | Analytics | Monthly KPI snapshots (admin rebuild, leader/admin read) and dashboards | Read/maintenance APIs |
 | Accounting Export Service | Finance Adapter | Controlled export for accounting workflows | File/API adapter |
 
 ## Level 3: Internal Module Decomposition (Priority Services)
@@ -145,7 +145,7 @@ industries rather than only IT roles.
 - Interview Service
 - Calendar Sync Service (Google Calendar)
 - Audit Service
-- Reporting Service (monthly KPI snapshot foundation, admin-only API)
+- Reporting Service (monthly KPI snapshot foundation, admin rebuild + leader/admin read API)
 
 ### Phase 2: Manager/Employee/Accountant/Leader Expansion
 - Frontend App (React.js + TypeScript) expansion: manager/employee/accountant/leader workspaces

--- a/docs/architecture/diagrams.md
+++ b/docs/architecture/diagrams.md
@@ -2,7 +2,7 @@
 
 ## Last Updated
 - Date: 2026-03-13
-- Updated by: architect + backend-engineer + frontend-engineer
+- Updated by: architect + backend-engineer
 
 This file is the canonical diagram set for the system. Update diagrams whenever architecture, data flow, or critical business flow changes.
 
@@ -950,7 +950,7 @@ flowchart LR
     REBUILD[Admin Rebuild Request]
     AGG[KPI Aggregation Service]
     SNAP[(kpi_snapshots)]
-    READ[Snapshot Read API]
+  READ[Snapshot Read API (leader/admin)]
   end
 
   REBUILD --> AGG

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Last Updated
 - Date: 2026-03-13
-- Updated by: architect + backend-engineer + frontend-engineer
+- Updated by: architect + backend-engineer
 
 ## System Context
 HRM platform for Belarus and Russia that supports candidate selection across professions and
@@ -52,7 +52,7 @@ flowchart LR
 | Notification Domain | Recipient-scoped in-app notifications and server-computed digests for manager/accountant workspaces | Vacancy ownership changes, onboarding assignment changes, protected notification reads | Dedupe-safe notification rows, unread/read state, digest counters, and embedded workspace notification blocks | platform |
 | AI Adapter | External model integration for CV analysis and match scoring | CV files, vacancy profiles, scoring prompts | Structured candidate insights and score responses | ai-platform |
 | Integration Layer | External connector abstraction | Internal events/commands | Google Calendar actions | platform |
-| Reporting and Audit | Monthly KPI snapshots and compliance evidence | Durable domain tables, audit events | KPI snapshots, audit logs | data-platform |
+| Reporting and Audit | Monthly KPI snapshots with leader/admin reads and compliance evidence | Durable domain tables, audit events | KPI snapshots, audit logs | data-platform |
 
 ## Key Flows
 1. Candidate Screening Flow:
@@ -128,7 +128,7 @@ flowchart LR
 14. KPI Snapshot Rebuild Flow:
    admin triggers explicit rebuild -> reporting service reads durable vacancy/pipeline/interview/offer/employee
    tables for the requested calendar month -> KPI counts are computed server-side ->
-   `kpi_snapshots` rows for the month are replaced atomically -> admin reads stored snapshot via
+   `kpi_snapshots` rows for the month are replaced atomically -> leader/admin read stored snapshot via
    `/api/v1/reporting/kpi-snapshots` (no live aggregation and no scheduler).
 
 ## Data Boundaries

--- a/docs/project/rbac-matrix.md
+++ b/docs/project/rbac-matrix.md
@@ -60,7 +60,7 @@ Enforcement source of truth:
 | `interview:manage` | yes | yes | yes | no | no | no |
 | `analytics:read` | yes | yes | yes | yes | yes | yes |
 | `accounting:read` | yes | no | no | no | no | yes |
-| `kpi_snapshot:read` | yes | no | no | no | no | no |
+| `kpi_snapshot:read` | yes | no | no | no | yes | no |
 | `kpi_snapshot:rebuild` | yes | no | no | no | no | no |
 
 Public endpoint outside RBAC matrix:

--- a/docs/testing/strategy.md
+++ b/docs/testing/strategy.md
@@ -180,7 +180,8 @@ apps/backend/tests/
 | KPI aggregation per source table | `tests/unit/reporting/test_kpi_snapshot_service.py` | `tests/integration/reporting/test_kpi_snapshot_api.py` | `uv run --project apps/backend pytest -q` |
 | Zero-fill semantics + idempotent rebuild | `tests/unit/reporting/test_kpi_snapshot_service.py` | `tests/integration/reporting/test_kpi_snapshot_api.py` | snapshot rows remain deterministic across rebuilds |
 | Read API returns empty payload when snapshot is missing | N/A | `tests/integration/reporting/test_kpi_snapshot_api.py` | `metrics=[]` for missing months |
-| RBAC fail-closed access for KPI endpoints | N/A | `tests/integration/reporting/test_kpi_snapshot_api.py` | `403` for non-admin roles |
+| Read API does not fallback to live aggregation | N/A | `tests/integration/reporting/test_kpi_snapshot_api.py` | `metrics=[]` even when source data exists and snapshots are missing |
+| RBAC for KPI endpoints (leader/admin read, admin rebuild) | N/A | `tests/integration/reporting/test_kpi_snapshot_api.py` | leader `200` read, leader `403` rebuild, non-privileged roles `403` read |
 
 ## Frontend Login UX Verification (TASK-11-13)
 


### PR DESCRIPTION
## Summary
- Allow `leader` to read stored KPI snapshots while keeping rebuild admin-only.
- Add RBAC + integration coverage for leader reads, non-privileged denies, and no live aggregation fallback.
- Update architecture/testing docs and record ADR-0045.

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend ruff check .`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend pytest -q`
- `./scripts/check-docs-structure.sh`
- `docker compose up -d --build`
- `docker compose ps`

## Docs
- Updated: `docs/architecture/decisions.md` (ADR-0045)
- Updated: `docs/architecture/overview.md`
- Updated: `docs/architecture/decomposition.md`
- Updated: `docs/architecture/diagrams.md`
- Updated: `docs/testing/strategy.md`
- Updated: `docs/project/rbac-matrix.md`

## Notes
- KPI snapshot read remains deterministic: missing month returns empty payload, no live aggregation.
- Rebuild remains `admin`-only.

## Warnings
- Pytest reported deprecation warnings from passlib/argon2 and Starlette 422 constant.
