### PR TITLE
ci: add change-aware test selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+env:
+  CI_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+  CI_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
 jobs:
   docs-check:
     runs-on: ubuntu-latest
@@ -22,11 +26,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect backend scope
+        id: backend_scope
+        run: |
+          modes="$(python3 scripts/ci/select_ci_modes.py backend --base-sha "${CI_BASE_SHA}" --head-sha "${CI_HEAD_SHA}")"
+          echo "modes=${modes}" >> "$GITHUB_OUTPUT"
+      - name: Skip backend job
+        if: steps.backend_scope.outputs.modes == 'skip'
+        run: echo "No backend-relevant files changed; skipping backend job."
       - name: Setup uv
+        if: steps.backend_scope.outputs.modes != 'skip'
         uses: astral-sh/setup-uv@v5
       - name: Setup Python
+        if: steps.backend_scope.outputs.modes != 'skip'
         run: uv python install 3.12
       - name: Cache uv
+        if: steps.backend_scope.outputs.modes != 'skip'
         uses: actions/cache@v4
         with:
           path: ~/.cache/uv
@@ -34,26 +51,154 @@ jobs:
           restore-keys: |
             uv-${{ runner.os }}-
       - name: Sync backend dependencies
+        if: steps.backend_scope.outputs.modes != 'skip'
         run: uv sync --project apps/backend --frozen || uv sync --project apps/backend
+      - name: Check OpenAPI freeze
+        if: steps.backend_scope.outputs.modes != 'skip'
+        run: ./scripts/check-openapi-freeze.sh
       - name: Lint backend
+        if: steps.backend_scope.outputs.modes != 'skip' && steps.backend_scope.outputs.modes != 'freeze_only'
         run: uv run --project apps/backend ruff check .
       - name: Test backend
-        run: uv run --project apps/backend pytest -q
-      - name: Check OpenAPI freeze
-        run: ./scripts/check-openapi-freeze.sh
+        if: steps.backend_scope.outputs.modes != 'skip' && steps.backend_scope.outputs.modes != 'freeze_only'
+        env:
+          BACKEND_CI_MODES: ${{ steps.backend_scope.outputs.modes }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import subprocess
+          import sys
+
+          modes = [mode for mode in os.environ["BACKEND_CI_MODES"].split(",") if mode]
+          if "full" in modes:
+              command = ["uv", "run", "--project", "apps/backend", "pytest", "-q"]
+          else:
+              targets_by_mode = {
+                  "core": [
+                      "apps/backend/tests/unit/core",
+                      "apps/backend/tests/unit/rbac",
+                      "apps/backend/tests/unit/test_cors.py",
+                      "apps/backend/tests/integration/auth/test_auth_stack.py",
+                      "apps/backend/tests/integration/security/test_audit_enforcement.py",
+                  ],
+                  "rbac": ["apps/backend/tests/unit/rbac"],
+                  "security": [
+                      "apps/backend/tests/unit/rbac",
+                      "apps/backend/tests/unit/test_cors.py",
+                      "apps/backend/tests/integration/auth/test_auth_stack.py",
+                      "apps/backend/tests/integration/security/test_audit_enforcement.py",
+                  ],
+                  "auth": [
+                      "apps/backend/tests/unit/auth",
+                      "apps/backend/tests/unit/rbac",
+                      "apps/backend/tests/unit/test_cors.py",
+                      "apps/backend/tests/integration/auth",
+                      "apps/backend/tests/integration/security/test_audit_enforcement.py",
+                  ],
+                  "admin": [
+                      "apps/backend/tests/unit/admin",
+                      "apps/backend/tests/unit/rbac",
+                      "apps/backend/tests/integration/admin",
+                      "apps/backend/tests/integration/security/test_audit_enforcement.py",
+                  ],
+                  "audit": [
+                      "apps/backend/tests/unit/audit",
+                      "apps/backend/tests/integration/audit",
+                  ],
+                  "automation": [
+                      "apps/backend/tests/unit/automation",
+                      "apps/backend/tests/integration/automation",
+                      "apps/backend/tests/integration/employee/test_onboarding_task_api.py",
+                      "apps/backend/tests/integration/vacancies/test_vacancy_pipeline_api.py",
+                      "apps/backend/tests/unit/reporting/test_kpi_snapshot_service.py",
+                      "apps/backend/tests/integration/reporting/test_kpi_snapshot_api.py",
+                  ],
+                  "reporting": [
+                      "apps/backend/tests/unit/reporting",
+                      "apps/backend/tests/integration/reporting",
+                  ],
+                  "candidates": [
+                      "apps/backend/tests/unit/candidates",
+                      "apps/backend/tests/integration/candidates",
+                      "apps/backend/tests/integration/vacancies/test_public_apply_hardening.py",
+                  ],
+                  "vacancies": [
+                      "apps/backend/tests/unit/vacancies",
+                      "apps/backend/tests/integration/vacancies",
+                  ],
+                  "interviews": [
+                      "apps/backend/tests/unit/interviews",
+                      "apps/backend/tests/integration/interviews",
+                      "apps/backend/tests/integration/vacancies/test_vacancy_pipeline_api.py",
+                  ],
+                  "employee": [
+                      "apps/backend/tests/unit/employee",
+                      "apps/backend/tests/integration/employee",
+                  ],
+                  "finance": [
+                      "apps/backend/tests/unit/finance",
+                      "apps/backend/tests/integration/finance",
+                  ],
+                  "notifications": [
+                      "apps/backend/tests/unit/notifications",
+                      "apps/backend/tests/integration/notifications",
+                  ],
+                  "scoring": [
+                      "apps/backend/tests/unit/scoring",
+                      "apps/backend/tests/integration/scoring",
+                  ],
+                  "platform": ["apps/backend/tests/unit/platform"],
+                }
+
+              targets: list[str] = []
+              for mode in modes:
+                  targets.extend(targets_by_mode.get(mode, []))
+
+              deduped_targets = list(dict.fromkeys(targets))
+              if not deduped_targets:
+                  print(
+                      "No targeted backend pytest paths matched CI modes; falling back to full suite.",
+                      file=sys.stderr,
+                  )
+                  command = ["uv", "run", "--project", "apps/backend", "pytest", "-q"]
+              else:
+                  command = [
+                      "uv",
+                      "run",
+                      "--project",
+                      "apps/backend",
+                      "pytest",
+                      "-q",
+                      *deduped_targets,
+                  ]
+
+          raise SystemExit(subprocess.call(command))
+          PY
 
   frontend:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect frontend scope
+        id: frontend_scope
+        run: |
+          modes="$(python3 scripts/ci/select_ci_modes.py frontend --base-sha "${CI_BASE_SHA}" --head-sha "${CI_HEAD_SHA}")"
+          echo "modes=${modes}" >> "$GITHUB_OUTPUT"
+      - name: Skip frontend job
+        if: steps.frontend_scope.outputs.modes == 'skip'
+        run: echo "No frontend-relevant files changed; skipping frontend job."
       - name: Setup Node
+        if: steps.frontend_scope.outputs.modes != 'skip'
         uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: apps/frontend/package-lock.json
       - name: Install frontend dependencies
+        if: steps.frontend_scope.outputs.modes != 'skip'
         run: |
           if [ -f apps/frontend/package-lock.json ]; then
             npm --prefix apps/frontend ci
@@ -61,11 +206,122 @@ jobs:
             npm --prefix apps/frontend install
           fi
       - name: Check frontend API types
+        if: steps.frontend_scope.outputs.modes == 'types_only' || contains(steps.frontend_scope.outputs.modes, 'contract')
         run: npm --prefix apps/frontend run api:types:check
       - name: Lint frontend
+        if: steps.frontend_scope.outputs.modes != 'skip' && steps.frontend_scope.outputs.modes != 'types_only'
         run: npm --prefix apps/frontend run lint
       - name: Test frontend
-        run: npm --prefix apps/frontend run test -- --run
+        if: steps.frontend_scope.outputs.modes != 'skip' && steps.frontend_scope.outputs.modes != 'types_only'
+        env:
+          FRONTEND_CI_MODES: ${{ steps.frontend_scope.outputs.modes }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import subprocess
+          import sys
+
+          modes = [mode for mode in os.environ["FRONTEND_CI_MODES"].split(",") if mode]
+          if "full" in modes:
+              command = ["npm", "--prefix", "apps/frontend", "run", "test", "--", "--run"]
+          else:
+              targets_by_mode = {
+                  "all_pages": [
+                      "apps/frontend/src/App.test.tsx",
+                      "apps/frontend/src/app/auth/session.test.ts",
+                      "apps/frontend/src/app/i18n.ts",
+                      "apps/frontend/src/app/observability/AppErrorBoundary.test.tsx",
+                      "apps/frontend/src/app/router.admin.test.tsx",
+                      "apps/frontend/src/app/router.auth.test.tsx",
+                      "apps/frontend/src/app/router.employee.test.tsx",
+                      "apps/frontend/src/app/router.leader.test.tsx",
+                      "apps/frontend/src/app/router.observability.test.tsx",
+                      "apps/frontend/src/components/NotificationsPanel.test.tsx",
+                  ],
+                  "api": [
+                      "apps/frontend/src/api/auth.test.ts",
+                      "apps/frontend/src/api/httpClient.test.ts",
+                      "apps/frontend/src/api/typedClient.test.ts",
+                      "apps/frontend/src/app/auth/session.test.ts",
+                  ],
+                  "login": [
+                      "apps/frontend/src/app/router.auth.test.tsx",
+                      "apps/frontend/src/pages/LoginPage.test.tsx",
+                  ],
+                  "candidate": [
+                      "apps/frontend/src/app/router.observability.test.tsx",
+                      "apps/frontend/src/pages/CandidatePage.test.tsx",
+                  ],
+                  "hr": [
+                      "apps/frontend/src/app/router.observability.test.tsx",
+                      "apps/frontend/src/pages/HrDashboardPage.test.tsx",
+                  ],
+                  "leader": [
+                      "apps/frontend/src/app/router.auth.test.tsx",
+                      "apps/frontend/src/app/router.leader.test.tsx",
+                      "apps/frontend/src/app/router.observability.test.tsx",
+                      "apps/frontend/src/pages/LeaderWorkspacePage.test.tsx",
+                  ],
+                  "manager": [
+                      "apps/frontend/src/components/NotificationsPanel.test.tsx",
+                      "apps/frontend/src/app/router.auth.test.tsx",
+                      "apps/frontend/src/app/router.observability.test.tsx",
+                      "apps/frontend/src/pages/ManagerWorkspacePage.test.tsx",
+                  ],
+                  "employee": [
+                      "apps/frontend/src/app/router.observability.test.tsx",
+                      "apps/frontend/src/app/router.employee.test.tsx",
+                      "apps/frontend/src/pages/EmployeeOnboardingPage.test.tsx",
+                  ],
+                  "accountant": [
+                      "apps/frontend/src/components/NotificationsPanel.test.tsx",
+                      "apps/frontend/src/app/router.auth.test.tsx",
+                      "apps/frontend/src/app/router.observability.test.tsx",
+                      "apps/frontend/src/pages/AccountantWorkspacePage.test.tsx",
+                  ],
+                  "admin": [
+                      "apps/frontend/src/app/router.admin.test.tsx",
+                      "apps/frontend/src/app/router.observability.test.tsx",
+                      "apps/frontend/src/pages/AdminEmployeeKeysManagementPage.test.tsx",
+                      "apps/frontend/src/pages/AdminStaffManagementPage.test.tsx",
+                  ],
+                  "notifications": [
+                      "apps/frontend/src/components/NotificationsPanel.test.tsx",
+                      "apps/frontend/src/pages/AccountantWorkspacePage.test.tsx",
+                      "apps/frontend/src/pages/ManagerWorkspacePage.test.tsx",
+                  ],
+                  "observability": [
+                      "apps/frontend/src/api/httpClient.test.ts",
+                      "apps/frontend/src/app/observability/AppErrorBoundary.test.tsx",
+                      "apps/frontend/src/app/router.observability.test.tsx",
+                  ],
+              }
+
+              targets: list[str] = []
+              for mode in modes:
+                  targets.extend(targets_by_mode.get(mode, []))
+
+              deduped_targets = list(dict.fromkeys(targets))
+              if not deduped_targets:
+                  print(
+                      "No targeted frontend Vitest paths matched CI modes; falling back to full suite.",
+                      file=sys.stderr,
+                  )
+                  command = ["npm", "--prefix", "apps/frontend", "run", "test", "--", "--run"]
+              else:
+                  command = [
+                      "npm",
+                      "--prefix",
+                      "apps/frontend",
+                      "run",
+                      "test",
+                      "--",
+                      "--run",
+                      *deduped_targets,
+                  ]
+
+          raise SystemExit(subprocess.call(command))
+          PY
 
   browser-smoke:
     runs-on: ubuntu-latest
@@ -73,16 +329,29 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect browser scope
+        id: browser_scope
+        run: |
+          modes="$(python3 scripts/ci/select_ci_modes.py browser --base-sha "${CI_BASE_SHA}" --head-sha "${CI_HEAD_SHA}")"
+          echo "modes=${modes}" >> "$GITHUB_OUTPUT"
+      - name: Skip browser smoke
+        if: steps.browser_scope.outputs.modes == 'skip'
+        run: echo "No browser-smoke-relevant files changed; skipping browser smoke."
       - name: Verify Chrome availability
+        if: steps.browser_scope.outputs.modes != 'skip'
         run: |
           google-chrome --version \
             || google-chrome-stable --version \
             || chromium-browser --version \
             || chromium --version
       - name: Start compose stack
+        if: steps.browser_scope.outputs.modes != 'skip'
         run: docker compose up -d --build
       - name: Run compose browser smoke
+        if: steps.browser_scope.outputs.modes != 'skip'
         run: ./scripts/smoke-compose.sh
       - name: Teardown compose stack
-        if: always()
+        if: always() && steps.browser_scope.outputs.modes != 'skip'
         run: docker compose down -v

--- a/apps/backend/tests/unit/test_ci_select_modes.py
+++ b/apps/backend/tests/unit/test_ci_select_modes.py
@@ -1,0 +1,117 @@
+"""Regression tests for the change-aware CI selector.
+
+The GitHub Actions workflow depends on this helper to decide when to skip jobs
+and when to narrow test targets. These tests keep the path-to-mode mapping
+stable for the most important slices.
+"""
+
+from __future__ import annotations
+
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SELECTOR_PATH = REPO_ROOT / "scripts" / "ci" / "select_ci_modes.py"
+
+
+def _load_selector_module():
+    """Load the CI selector script as a Python module."""
+    spec = spec_from_file_location("ci_select_ci_modes", SELECTOR_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load selector module from {SELECTOR_PATH}")
+    module = module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_backend_automation_changes_select_reporting_and_automation() -> None:
+    """Automation executor changes should pull automation and reporting coverage."""
+    selector = _load_selector_module()
+
+    selection = selector._select_backend_modes(
+        [
+            "apps/backend/src/hrm_backend/automation/services/executor.py",
+            "apps/backend/src/hrm_backend/reporting/services/kpi_snapshot_service.py",
+        ]
+    )
+
+    assert selection.render() == "automation,reporting"
+
+
+def test_backend_openapi_only_changes_select_freeze_only() -> None:
+    """Frozen OpenAPI drift alone should run the freeze check only."""
+    selector = _load_selector_module()
+
+    selection = selector._select_backend_modes(["docs/api/openapi.frozen.json"])
+
+    assert selection.render() == "freeze_only"
+
+
+def test_backend_workflow_changes_force_full_suite() -> None:
+    """CI workflow edits should keep the backend job on the safe full path."""
+    selector = _load_selector_module()
+
+    selection = selector._select_backend_modes([".github/workflows/ci.yml"])
+
+    assert selection.render() == "full"
+
+
+def test_frontend_session_changes_select_shared_routes_and_api_tests() -> None:
+    """Auth session changes should run shared route tests and API client coverage."""
+    selector = _load_selector_module()
+
+    selection = selector._select_frontend_modes(
+        [
+            "apps/frontend/src/app/auth/session.ts",
+            "apps/frontend/src/api/auth.ts",
+        ]
+    )
+
+    assert selection.render() == "all_pages,api,login"
+
+
+def test_frontend_openapi_only_changes_select_types_only() -> None:
+    """Frozen OpenAPI drift alone should run the generated-type check only."""
+    selector = _load_selector_module()
+
+    selection = selector._select_frontend_modes(["docs/api/openapi.frozen.json"])
+
+    assert selection.render() == "types_only"
+
+
+def test_frontend_generated_types_only_changes_select_types_only() -> None:
+    """Regenerated frontend types alone should run the generated-type check only."""
+    selector = _load_selector_module()
+
+    selection = selector._select_frontend_modes(
+        ["apps/frontend/src/api/generated/openapi-types.ts"]
+    )
+
+    assert selection.render() == "types_only"
+
+
+def test_frontend_leader_page_changes_select_leader_tests() -> None:
+    """Leader page changes should stay scoped to the leader workspace tests."""
+    selector = _load_selector_module()
+
+    selection = selector._select_frontend_modes(
+        [
+            "apps/frontend/src/pages/LeaderWorkspacePage.tsx",
+            "apps/frontend/src/api/kpiSnapshots.ts",
+        ]
+    )
+
+    assert selection.render() == "leader"
+
+
+def test_browser_smoke_runs_for_login_and_candidate_apply_paths() -> None:
+    """Auth and candidate apply edits should keep browser smoke enabled."""
+    selector = _load_selector_module()
+
+    assert selector._should_run_browser_smoke(["apps/frontend/src/pages/LoginPage.tsx"]) is True
+    assert selector._should_run_browser_smoke(["apps/frontend/src/pages/CandidatePage.tsx"]) is True
+    assert selector._should_run_browser_smoke(
+        ["apps/frontend/src/pages/LeaderWorkspacePage.tsx"]
+    ) is False

--- a/docs/operations/github-workflow.md
+++ b/docs/operations/github-workflow.md
@@ -1,7 +1,7 @@
 # GitHub Workflow and Branch Protection
 
 ## Last Updated
-- Date: 2026-03-13
+- Date: 2026-03-19
 - Updated by: coordinator + backend-engineer
 
 ## Branching Model
@@ -16,8 +16,11 @@
 - Current repository mode: solo delivery (`0` required approving reviews).
 - Team-target policy (when multiple maintainers are active): minimum 2 reviewers (tech owner + domain owner).
 - Required CI checks: `docs-check`, `backend`, `frontend`, `browser-smoke`.
+  The job names stay stable for branch protection, but the backend/frontend/browser jobs are
+  path-aware and may skip unrelated scopes or narrow test targets based on changed files.
 - Squash merge by default to keep history clean.
-- CI uses dependency caches (uv + npm) keyed on lockfiles to reduce runtime without changing test scope.
+- CI uses dependency caches (uv + npm) keyed on lockfiles and change-aware selectors in
+  `scripts/ci/select_ci_modes.py` to reduce runtime without changing the required check names.
 
 ## Protected Branch Setup (GitHub)
 - Protect `main` branch.

--- a/docs/testing/strategy.md
+++ b/docs/testing/strategy.md
@@ -63,6 +63,27 @@ apps/backend/tests/
 - Frontend typed contract generation must run from frozen spec:
   - `npm --prefix apps/frontend run api:types:generate`
 
+## Selective CI Policy
+- GitHub Actions uses `scripts/ci/select_ci_modes.py` to classify changed files before the
+  expensive backend, frontend, and browser smoke jobs start.
+- Required checks remain the same names for branch protection:
+  `docs-check`, `backend`, `frontend`, `browser-smoke`.
+- Backend job policy:
+  - `freeze_only` means only the OpenAPI freeze check should run.
+  - domain modes map to targeted pytest trees for the changed backend package.
+  - cross-cutting runtime/bootstrap changes fall back to `full`.
+- Frontend job policy:
+  - `types_only` means the generated OpenAPI type check should run without Vitest.
+  - `contract` changes keep `api:types:check` enabled even when page tests are also selected.
+  - domain modes map to targeted Vitest files instead of the whole frontend suite.
+- Browser smoke policy:
+  - the compose/browser smoke job only runs for auth, admin, candidate apply, CI-infra, and
+    compose/runtime changes that actually touch the flows it verifies.
+- When a task touches only one domain, prefer the same targeted verification locally instead of the
+  entire suite; reserve the full-suite commands for cross-cutting changes.
+- Selector regression coverage:
+  - `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend pytest -q apps/backend/tests/unit/test_ci_select_modes.py`
+
 ## Automation Rule Engine Verification (TASK-08-01/08-02/08-03/08-04)
 - Evaluator + executor + metric writer unit coverage:
   - `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend pytest -q apps/backend/tests/unit/automation`

--- a/scripts/ci/select_ci_modes.py
+++ b/scripts/ci/select_ci_modes.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""Select CI execution modes from changed file paths.
+
+The script prints a comma-separated list of modes for the requested job scope:
+
+- ``backend`` -> ``skip``, ``freeze_only``, domain modes, or ``full``
+- ``frontend`` -> ``skip``, ``types_only``, contract and domain modes, or ``full``
+- ``browser`` -> ``run`` or ``skip``
+
+The GitHub Actions workflow maps the emitted modes to concrete commands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Selection:
+    """Selection result for one CI job scope."""
+
+    modes: tuple[str, ...]
+
+    def render(self) -> str:
+        """Render the selection as a comma-separated string or ``skip``."""
+        return "skip" if not self.modes else ",".join(self.modes)
+
+
+BACKEND_FULL_PATTERNS = (
+    ".github/workflows/**",
+    "scripts/ci/**",
+    "scripts/check-openapi-freeze.sh",
+    "scripts/generate-openapi-frozen.sh",
+    "apps/backend/alembic/**",
+    "apps/backend/pyproject.toml",
+    "apps/backend/uv.lock",
+    "apps/backend/src/hrm_backend/api/**",
+    "apps/backend/src/hrm_backend/main.py",
+    "apps/backend/src/hrm_backend/settings.py",
+)
+BACKEND_RELEVANT_PATTERNS = (
+    "apps/backend/src/hrm_backend/**",
+    "apps/backend/tests/**",
+)
+BACKEND_CORE_PATTERNS = (
+    "apps/backend/src/hrm_backend/core/**",
+    "apps/backend/tests/unit/core/**",
+)
+BACKEND_RBAC_PATTERNS = (
+    "apps/backend/src/hrm_backend/rbac.py",
+    "apps/backend/tests/unit/rbac/**",
+)
+BACKEND_SECURITY_PATTERNS = (
+    "apps/backend/tests/unit/test_cors.py",
+    "apps/backend/tests/integration/auth/**",
+    "apps/backend/tests/integration/security/**",
+)
+BACKEND_AUTH_PATTERNS = (
+    "apps/backend/src/hrm_backend/auth/**",
+    "apps/backend/tests/unit/auth/**",
+    "apps/backend/tests/integration/auth/**",
+)
+BACKEND_ADMIN_PATTERNS = (
+    "apps/backend/src/hrm_backend/admin/**",
+    "apps/backend/tests/unit/admin/**",
+    "apps/backend/tests/integration/admin/**",
+)
+BACKEND_AUDIT_PATTERNS = (
+    "apps/backend/src/hrm_backend/audit/**",
+    "apps/backend/tests/unit/audit/**",
+    "apps/backend/tests/integration/audit/**",
+)
+BACKEND_AUTOMATION_PATTERNS = (
+    "apps/backend/src/hrm_backend/automation/**",
+    "apps/backend/tests/unit/automation/**",
+    "apps/backend/tests/integration/automation/**",
+    "apps/backend/tests/integration/employee/test_onboarding_task_api.py",
+    "apps/backend/tests/integration/vacancies/test_vacancy_pipeline_api.py",
+)
+BACKEND_REPORTING_PATTERNS = (
+    "apps/backend/src/hrm_backend/reporting/**",
+    "apps/backend/tests/unit/reporting/**",
+    "apps/backend/tests/integration/reporting/**",
+)
+BACKEND_CANDIDATE_PATTERNS = (
+    "apps/backend/src/hrm_backend/candidates/**",
+    "apps/backend/tests/unit/candidates/**",
+    "apps/backend/tests/integration/candidates/**",
+    "apps/backend/tests/integration/vacancies/test_public_apply_hardening.py",
+)
+BACKEND_VACANCY_PATTERNS = (
+    "apps/backend/src/hrm_backend/vacancies/**",
+    "apps/backend/tests/unit/vacancies/**",
+    "apps/backend/tests/integration/vacancies/**",
+)
+BACKEND_INTERVIEW_PATTERNS = (
+    "apps/backend/src/hrm_backend/interviews/**",
+    "apps/backend/tests/unit/interviews/**",
+    "apps/backend/tests/integration/interviews/**",
+    "apps/backend/tests/integration/vacancies/test_vacancy_pipeline_api.py",
+)
+BACKEND_EMPLOYEE_PATTERNS = (
+    "apps/backend/src/hrm_backend/employee/**",
+    "apps/backend/tests/unit/employee/**",
+    "apps/backend/tests/integration/employee/**",
+)
+BACKEND_FINANCE_PATTERNS = (
+    "apps/backend/src/hrm_backend/finance/**",
+    "apps/backend/tests/unit/finance/**",
+    "apps/backend/tests/integration/finance/**",
+)
+BACKEND_NOTIFICATION_PATTERNS = (
+    "apps/backend/src/hrm_backend/notifications/**",
+    "apps/backend/tests/unit/notifications/**",
+    "apps/backend/tests/integration/notifications/**",
+)
+BACKEND_SCORING_PATTERNS = (
+    "apps/backend/src/hrm_backend/scoring/**",
+    "apps/backend/tests/unit/scoring/**",
+    "apps/backend/tests/integration/scoring/**",
+)
+BACKEND_PLATFORM_PATTERNS = ("apps/backend/tests/unit/platform/**",)
+
+FRONTEND_FULL_PATTERNS = (
+    ".github/workflows/**",
+    "scripts/ci/**",
+    "apps/frontend/package.json",
+    "apps/frontend/src/App.tsx",
+    "apps/frontend/src/api/index.ts",
+    "apps/frontend/src/app/guards/**",
+    "apps/frontend/src/app/router.tsx",
+    "apps/frontend/src/main.tsx",
+    "apps/frontend/vite.config.*",
+)
+FRONTEND_RELEVANT_PATTERNS = (
+    "apps/frontend/src/**",
+)
+FRONTEND_CONTRACT_PATTERNS = (
+    "apps/frontend/src/api/generated/openapi-types.ts",
+    "docs/api/openapi.frozen.json",
+)
+FRONTEND_ALL_PAGES_PATTERNS = (
+    "apps/frontend/src/App.test.tsx",
+    "apps/frontend/src/api/auth.ts",
+    "apps/frontend/src/api/httpClient.ts",
+    "apps/frontend/src/api/typedClient.ts",
+    "apps/frontend/src/app/auth/session.ts",
+    "apps/frontend/src/app/i18n.ts",
+    "apps/frontend/src/app/observability/AppErrorBoundary.*",
+    "apps/frontend/src/app/router.*.test.tsx",
+    "apps/frontend/src/components/**",
+)
+FRONTEND_API_PATTERNS = (
+    "apps/frontend/src/api/auth.test.ts",
+    "apps/frontend/src/api/auth.ts",
+    "apps/frontend/src/api/httpClient.test.ts",
+    "apps/frontend/src/api/httpClient.ts",
+    "apps/frontend/src/api/typedClient.test.ts",
+    "apps/frontend/src/api/typedClient.ts",
+    "apps/frontend/src/app/auth/session.test.ts",
+    "apps/frontend/src/app/auth/session.ts",
+)
+FRONTEND_LOGIN_PATTERNS = (
+    "apps/frontend/src/api/auth.ts",
+    "apps/frontend/src/app/auth/session.ts",
+    "apps/frontend/src/app/router.auth.test.tsx",
+    "apps/frontend/src/pages/LoginPage.*",
+)
+FRONTEND_CANDIDATE_PATTERNS = (
+    "apps/frontend/src/api/candidateAnalysis.ts",
+    "apps/frontend/src/api/candidateApplications.ts",
+    "apps/frontend/src/api/candidateProfiles.ts",
+    "apps/frontend/src/app/candidate/applicationContext.ts",
+    "apps/frontend/src/pages/CandidatePage.*",
+)
+FRONTEND_HR_PATTERNS = (
+    "apps/frontend/src/api/candidateAnalysis.ts",
+    "apps/frontend/src/api/candidateProfiles.ts",
+    "apps/frontend/src/api/interviews.ts",
+    "apps/frontend/src/api/matchScores.ts",
+    "apps/frontend/src/api/offers.ts",
+    "apps/frontend/src/api/vacancies.ts",
+    "apps/frontend/src/pages/HrDashboardPage.*",
+)
+FRONTEND_LEADER_PATTERNS = (
+    "apps/frontend/src/api/kpiSnapshots.ts",
+    "apps/frontend/src/pages/LeaderWorkspacePage.*",
+)
+FRONTEND_MANAGER_PATTERNS = (
+    "apps/frontend/src/api/managerWorkspace.ts",
+    "apps/frontend/src/api/notifications.ts",
+    "apps/frontend/src/api/onboardingDashboard.ts",
+    "apps/frontend/src/components/NotificationsPanel.*",
+    "apps/frontend/src/pages/ManagerWorkspacePage.*",
+)
+FRONTEND_EMPLOYEE_PATTERNS = (
+    "apps/frontend/src/api/employeeOnboarding.ts",
+    "apps/frontend/src/app/guards/EmployeeGuard.tsx",
+    "apps/frontend/src/app/router.employee.test.tsx",
+    "apps/frontend/src/pages/EmployeeOnboardingPage.*",
+)
+FRONTEND_ACCOUNTANT_PATTERNS = (
+    "apps/frontend/src/api/accountingWorkspace.ts",
+    "apps/frontend/src/api/notifications.ts",
+    "apps/frontend/src/components/NotificationsPanel.*",
+    "apps/frontend/src/pages/AccountantWorkspacePage.*",
+)
+FRONTEND_ADMIN_PATTERNS = (
+    "apps/frontend/src/api/adminEmployeeKeys.ts",
+    "apps/frontend/src/api/adminStaff.ts",
+    "apps/frontend/src/app/guards/AdminGuard.tsx",
+    "apps/frontend/src/app/router.admin.test.tsx",
+    "apps/frontend/src/pages/AdminEmployeeKeysManagementPage.*",
+    "apps/frontend/src/pages/AdminStaffManagementPage.*",
+)
+FRONTEND_NOTIFICATION_PATTERNS = (
+    "apps/frontend/src/api/notifications.ts",
+    "apps/frontend/src/components/NotificationsPanel.*",
+)
+FRONTEND_OBSERVABILITY_PATTERNS = (
+    "apps/frontend/src/api/httpClient.test.ts",
+    "apps/frontend/src/api/httpClient.ts",
+    "apps/frontend/src/app/observability/AppErrorBoundary.*",
+    "apps/frontend/src/app/router.observability.test.tsx",
+)
+
+
+def main() -> int:
+    """Entry point for change-aware CI scope selection."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "scope",
+        choices=("backend", "frontend", "browser"),
+        help="CI scope to evaluate.",
+    )
+    parser.add_argument(
+        "--base-sha",
+        default="",
+        help="Base commit SHA used to compute the diff.",
+    )
+    parser.add_argument(
+        "--head-sha",
+        default="",
+        help="Head commit SHA used to compute the diff.",
+    )
+    args = parser.parse_args()
+
+    changed_files = _changed_files(base_sha=args.base_sha, head_sha=args.head_sha)
+    if args.scope == "backend":
+        print(_select_backend_modes(changed_files).render())
+    elif args.scope == "frontend":
+        print(_select_frontend_modes(changed_files).render())
+    else:
+        print("run" if _should_run_browser_smoke(changed_files) else "skip")
+    return 0
+
+
+def _changed_files(*, base_sha: str, head_sha: str) -> list[str]:
+    """Return changed files between two commits.
+
+    The function prefers the merge-base diff so pull requests and push builds both
+    resolve to the real changed set instead of a synthetic merge commit view.
+    """
+    if not base_sha or not head_sha:
+        return []
+
+    merge_base = _run_git(["merge-base", base_sha, head_sha])
+    diff_base = merge_base or base_sha
+    diff_output = _run_git(["diff", "--name-only", f"{diff_base}...{head_sha}"])
+    return [line for line in diff_output.splitlines() if line]
+
+
+def _run_git(args: list[str]) -> str:
+    """Run one git command and return stdout as text."""
+    result = subprocess.run(
+        ["git", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def _select_backend_modes(changed_files: list[str]) -> Selection:
+    """Map backend changes to targeted pytest scopes."""
+    if not changed_files:
+        return Selection(())
+
+    if _any_match(changed_files, BACKEND_FULL_PATTERNS):
+        return Selection(("full",))
+
+    if _any_match(changed_files, ("docs/api/openapi.frozen.json",)) and not _any_match(
+        changed_files,
+        BACKEND_RELEVANT_PATTERNS,
+    ):
+        return Selection(("freeze_only",))
+
+    modes: set[str] = set()
+
+    if _any_match(changed_files, BACKEND_CORE_PATTERNS):
+        modes.update({"core", "rbac", "security"})
+
+    if _any_match(changed_files, BACKEND_RBAC_PATTERNS):
+        modes.update({"rbac", "security"})
+
+    if _any_match(changed_files, BACKEND_SECURITY_PATTERNS):
+        modes.add("security")
+
+    if _any_match(changed_files, BACKEND_AUTH_PATTERNS):
+        modes.update({"auth", "rbac", "security"})
+
+    if _any_match(changed_files, BACKEND_ADMIN_PATTERNS):
+        modes.update({"admin", "rbac", "security"})
+
+    if _any_match(changed_files, BACKEND_AUDIT_PATTERNS):
+        modes.add("audit")
+
+    if _any_match(changed_files, BACKEND_AUTOMATION_PATTERNS):
+        modes.update({"automation", "reporting"})
+
+    if _any_match(changed_files, BACKEND_REPORTING_PATTERNS):
+        modes.add("reporting")
+
+    if _any_match(changed_files, BACKEND_CANDIDATE_PATTERNS):
+        modes.add("candidates")
+
+    if _any_match(changed_files, BACKEND_VACANCY_PATTERNS):
+        modes.add("vacancies")
+
+    if _any_match(changed_files, BACKEND_INTERVIEW_PATTERNS):
+        modes.add("interviews")
+
+    if _any_match(changed_files, BACKEND_EMPLOYEE_PATTERNS):
+        modes.add("employee")
+
+    if _any_match(changed_files, BACKEND_FINANCE_PATTERNS):
+        modes.add("finance")
+
+    if _any_match(changed_files, BACKEND_NOTIFICATION_PATTERNS):
+        modes.add("notifications")
+
+    if _any_match(changed_files, BACKEND_SCORING_PATTERNS):
+        modes.add("scoring")
+
+    if _any_match(changed_files, BACKEND_PLATFORM_PATTERNS):
+        modes.add("platform")
+
+    if not modes and _any_match(changed_files, BACKEND_RELEVANT_PATTERNS):
+        return Selection(("full",))
+
+    ordered = (
+        "core",
+        "rbac",
+        "security",
+        "auth",
+        "admin",
+        "audit",
+        "automation",
+        "reporting",
+        "candidates",
+        "vacancies",
+        "interviews",
+        "employee",
+        "finance",
+        "notifications",
+        "scoring",
+        "platform",
+    )
+    return Selection(tuple(mode for mode in ordered if mode in modes))
+
+
+def _select_frontend_modes(changed_files: list[str]) -> Selection:
+    """Map frontend changes to targeted Vitest scopes."""
+    if not changed_files:
+        return Selection(())
+
+    if all(
+        any(fnmatch.fnmatchcase(path, pattern) for pattern in FRONTEND_CONTRACT_PATTERNS)
+        for path in changed_files
+    ):
+        return Selection(("types_only",))
+
+    if _any_match(changed_files, FRONTEND_FULL_PATTERNS):
+        return Selection(("full",))
+
+    contract_changed = _any_match(changed_files, FRONTEND_CONTRACT_PATTERNS)
+
+    modes: set[str] = set()
+
+    if _any_match(changed_files, FRONTEND_ALL_PAGES_PATTERNS):
+        modes.add("all_pages")
+
+    if _any_match(changed_files, FRONTEND_API_PATTERNS):
+        modes.update({"api", "all_pages"})
+
+    if _any_match(changed_files, FRONTEND_LOGIN_PATTERNS):
+        modes.update({"login", "all_pages", "api"})
+
+    if _any_match(changed_files, FRONTEND_CANDIDATE_PATTERNS):
+        modes.add("candidate")
+
+    if _any_match(changed_files, FRONTEND_HR_PATTERNS):
+        modes.add("hr")
+
+    if _any_match(changed_files, FRONTEND_LEADER_PATTERNS):
+        modes.add("leader")
+
+    if _any_match(changed_files, FRONTEND_MANAGER_PATTERNS):
+        modes.update({"manager", "notifications"})
+
+    if _any_match(changed_files, FRONTEND_EMPLOYEE_PATTERNS):
+        modes.add("employee")
+
+    if _any_match(changed_files, FRONTEND_ACCOUNTANT_PATTERNS):
+        modes.update({"accountant", "notifications"})
+
+    if _any_match(changed_files, FRONTEND_ADMIN_PATTERNS):
+        modes.add("admin")
+
+    if _any_match(changed_files, FRONTEND_NOTIFICATION_PATTERNS):
+        modes.add("notifications")
+
+    if _any_match(changed_files, FRONTEND_OBSERVABILITY_PATTERNS):
+        modes.add("observability")
+
+    if contract_changed:
+        modes.add("contract")
+
+    if not modes and _any_match(changed_files, FRONTEND_RELEVANT_PATTERNS):
+        return Selection(("full",))
+
+    ordered = (
+        "types_only",
+        "contract",
+        "full",
+        "all_pages",
+        "api",
+        "login",
+        "candidate",
+        "hr",
+        "leader",
+        "manager",
+        "employee",
+        "accountant",
+        "admin",
+        "notifications",
+        "observability",
+    )
+    return Selection(tuple(mode for mode in ordered if mode in modes))
+
+
+def _should_run_browser_smoke(changed_files: list[str]) -> bool:
+    """Return whether browser smoke should run for the changed files."""
+    if not changed_files:
+        return False
+
+    browser_paths = [
+        ".github/workflows/**",
+        "apps/backend/alembic/**",
+        "apps/backend/src/hrm_backend/admin/**",
+        "apps/backend/src/hrm_backend/auth/**",
+        "apps/backend/src/hrm_backend/candidates/**",
+        "apps/backend/src/hrm_backend/main.py",
+        "apps/backend/src/hrm_backend/settings.py",
+        "apps/backend/src/hrm_backend/vacancies/**",
+        "apps/frontend/src/App.tsx",
+        "apps/frontend/src/api/auth.ts",
+        "apps/frontend/src/api/candidateAnalysis.ts",
+        "apps/frontend/src/api/candidateApplications.ts",
+        "apps/frontend/src/api/candidateProfiles.ts",
+        "apps/frontend/src/api/httpClient.ts",
+        "apps/frontend/src/api/typedClient.ts",
+        "apps/frontend/src/app/auth/**",
+        "apps/frontend/src/app/guards/**",
+        "apps/frontend/src/app/router.admin.test.tsx",
+        "apps/frontend/src/app/router.auth.test.tsx",
+        "apps/frontend/src/main.tsx",
+        "apps/frontend/src/pages/AdminEmployeeKeysManagementPage.*",
+        "apps/frontend/src/pages/AdminStaffManagementPage.*",
+        "apps/frontend/src/pages/CandidatePage.*",
+        "apps/frontend/src/pages/LoginPage.*",
+        "docker-compose.yml",
+        "docker-compose.*.yml",
+        "scripts/browser_auth_smoke.py",
+        "scripts/browser_candidate_apply_smoke.py",
+        "scripts/smoke-compose.sh",
+        "scripts/ci/**",
+    ]
+    return _any_match(changed_files, browser_paths)
+
+
+def _any_match(paths: list[str], patterns: tuple[str, ...] | list[str]) -> bool:
+    """Check whether any path matches any glob pattern."""
+    return any(
+        fnmatch.fnmatchcase(path, pattern)
+        for path in paths
+        for pattern in patterns
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a change-aware selector so backend, frontend, and browser-smoke jobs skip unrelated diffs or narrow to targeted tests.
- Document the selective CI policy and add regression coverage for the selector.

## Verification
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend pytest -q apps/backend/tests/unit/test_ci_select_modes.py
- UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend ruff check scripts/ci/select_ci_modes.py apps/backend/tests/unit/test_ci_select_modes.py
- python3 -m py_compile scripts/ci/select_ci_modes.py
- git diff --check