### PR TITLE
docs: add EPIC-13 release gate checklist

### DIFF
--- a/docs/operations/release-checklist.md
+++ b/docs/operations/release-checklist.md
@@ -1,26 +1,36 @@
 # Release Checklist
 
-## Pre-Release
-- [ ] Acceptance criteria are satisfied.
-- [ ] Required tests passed and evidence attached.
-- [ ] Legal controls matrix and evidence registry are current (`docs/project/legal-controls-matrix.md`, `docs/project/evidence-registry.md`).
-- [ ] OpenAPI frozen contract check passed (`./scripts/check-openapi-freeze.sh`).
-- [ ] PostgreSQL migrations verified (`alembic upgrade head` / rollback check as needed).
-- [ ] Rollback strategy is documented.
-- [ ] `docs/` updates are complete.
+## Purpose
+- Canonical EPIC-13 pre-prod and production gate.
+- Use this checklist before any first production release.
+- Local development and test deployments may proceed, but they do not waive the gate below.
 
-## Release
-- [ ] Deploy steps executed in order.
-- [ ] Smoke checks passed.
-- [ ] Browser auth smoke verified (`/login -> login -> me -> logout -> /login` against compose stack).
-- [ ] Monitoring and alerts verified.
-- [ ] Container baseline check passed (`docker compose config` + service health checks).
-- [ ] Public apply anti-abuse checks verified (`409/429` paths, rate-limit headers, audit reason codes).
-- [ ] Admin route guard smoke verified (`/admin` allow for admin, deny for non-admin).
-- [ ] Admin staff management smoke verified (`GET/PATCH /api/v1/admin/staff*`, `409` strict-guard paths, RU/EN UI errors).
-- [ ] Admin employee-key lifecycle smoke verified (`POST/GET /api/v1/admin/employee-keys*`, revoke `404/409` reason-codes, RU/EN UI errors on `/admin/employee-keys`).
+## Gate Rules
+- Pre-prod gate:
+  - every critical control in `docs/project/legal-controls-matrix.md` must be at least `implemented`;
+  - the matching evidence rows in `docs/project/evidence-registry.md` must exist and be current;
+  - controls in `planned` or `in-progress` remain blockers, not waivers.
+- Production gate:
+  - every critical control must be `verified`;
+  - legal and security sign-off must confirm attached evidence and acknowledge any remaining gaps;
+  - a control that is still `planned` or `in-progress` blocks release outright.
 
-## Post-Release
-- [ ] No critical regressions within observation window.
-- [ ] Changelog entry updated.
-- [ ] Follow-up tasks created for known gaps.
+## Known Blocking Controls
+- `CTRL-RU-04` and `CTRL-RU-06` are current hard blockers because the evidence registry still lists them as gaps.
+- `CTRL-BY-03`, `CTRL-RU-02`, and `CTRL-RU-05` are implemented, but production release still requires `verified` status and refreshed evidence before sign-off.
+
+## Blocking Control Table
+
+| Control ID | Current status | Required threshold | Owner | Evidence IDs | Verification source/command | Sign-off prerequisite | Blocker if planned/in-progress |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| CTRL-BY-03 | implemented | Pre-prod: `implemented`; production: `verified` | architect + backend + devops | `EVID-001`, `EVID-004`, `EVID-006` | `EVID-001` backend security/auth tests, `EVID-004` compose smoke, `EVID-006` docs/config review | Legal/security sign-off must confirm RBAC, immutable audit events, storage baseline, and smoke evidence are current | Blocks both gates until the control is at least `implemented` with current evidence |
+| CTRL-RU-02 | implemented | Pre-prod: `implemented`; production: `verified` | architect + backend + frontend | `EVID-001`, `EVID-005`, `EVID-007` | `EVID-001` backend security/auth tests, `EVID-005` frontend observability tests, `EVID-007` shortlist/scoring integration checks | Legal/security sign-off must confirm operator measures, observability, and auditability are current | Blocks both gates until the control is at least `implemented` with current evidence |
+| CTRL-RU-04 | planned | Pre-prod: `implemented`; production: `verified` | architect + devops | none (gap) | No current in-repo command; release stays blocked until a real RU residency artifact is added to the registry | Legal sign-off cannot proceed until a real infrastructure/data-residency artifact exists | Blocks both gates while the control remains `planned` or `in-progress` |
+| CTRL-RU-05 | implemented | Pre-prod: `implemented`; production: `verified` | backend + devops | `EVID-001`, `EVID-004` | `EVID-001` access-policy/audit tests, `EVID-004` compose/browser smoke | Legal/security sign-off must confirm access control and smoke verification are current | Blocks both gates until the control is at least `implemented` with current evidence |
+| CTRL-RU-06 | planned | Pre-prod: `implemented`; production: `verified` | security + business-analyst | none (gap) | No current in-repo command; release stays blocked until the class checklist and attestation pack exist and are registered | Legal/security sign-off cannot proceed until the class checklist and attestation pack exist | Blocks both gates while the control remains `planned` or `in-progress` |
+
+## Release Preconditions
+- Do not promote to pre-prod if any critical control is `planned` or `in-progress`.
+- Do not promote to production if any critical control is not `verified`.
+- Do not claim legal/security sign-off unless the evidence IDs above are current and the gap rows for `CTRL-RU-04` and `CTRL-RU-06` are either closed with real artifacts or still blocking the release.
+- Keep this document aligned with `docs/project/legal-controls-matrix.md`, `docs/project/evidence-registry.md`, `docs/operations/runbook.md`, and `docs/testing/strategy.md` in the same change set.

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -359,6 +359,8 @@ Runtime auth/browser integration settings:
 ## Compliance Baseline (Dev Non-Blocking, Prod Blocking)
 This section defines provisional operational controls until final legal/security sign-off.
 
+EPIC-13 release gating and sign-off requirements live in `docs/operations/release-checklist.md`.
+
 ### Data Retention Policy (Provisional)
 
 | Data Class | Storage | Retention Window | Disposal Strategy | Owner |
@@ -379,7 +381,7 @@ This section defines provisional operational controls until final legal/security
   - Object storage buckets with personal data must use server-side encryption.
   - Backups/snapshots must be encrypted and access-restricted.
 
-- TODO(owner: devops + security, due_trigger: before first production release): attach concrete infrastructure evidence (KMS/SSE/TLS termination config) to release checklist.
+- TODO(owner: devops + security, due_trigger: before first production release): attach concrete infrastructure evidence (KMS/SSE/TLS termination config) to the EPIC-13 release checklist and close the `CTRL-RU-04` gap with a real artifact.
 
 ### Access Policy and Review Cadence (Provisional)
 - Least-privilege access is mandatory for platform, database, object storage, and CI/CD.
@@ -393,9 +395,11 @@ This section defines provisional operational controls until final legal/security
 - TODO(owner: architect + security, due_trigger: before first production release): finalize break-glass procedure and reviewer roster.
 
 ### Release Gate Policy
-- Dev and test deployments are allowed with provisional controls.
-- Production release is blocked until critical controls in `docs/project/legal-controls-matrix.md` are at least `implemented`.
-- Production release is additionally blocked until legal/security sign-off marks critical controls as `verified`.
+- Dev and test deployments are allowed with provisional controls, but they do not waive EPIC-13 release gating.
+- `docs/operations/release-checklist.md` is the canonical pre-prod and production gate.
+- Pre-prod promotion is blocked if any critical control in `docs/project/legal-controls-matrix.md` remains `planned` or `in-progress`.
+- Production release is blocked unless every critical control is `verified` and legal/security sign-off records the refreshed evidence IDs.
+- The current hard blockers are the gap rows for `CTRL-RU-04` and `CTRL-RU-06`; release cannot proceed until those artifacts exist as real evidence, not placeholders.
 
 ## Incident Triage
 1. Confirm impact and affected user segment.

--- a/docs/project/evidence-registry.md
+++ b/docs/project/evidence-registry.md
@@ -1,7 +1,7 @@
 # Evidence Registry
 
 ## Last Updated
-- Date: 2026-03-16
+- Date: 2026-03-19
 - Updated by: backend-engineer + frontend-engineer
 
 ## Registry Model
@@ -11,6 +11,7 @@
 - `Artifact`: only real in-repo code/docs/scripts/tests or repeatable commands.
 - `Verification Source`: command or procedure that proves the artifact is current.
 - `Update Trigger`: concrete change that requires the row to be refreshed.
+- EPIC-13 release checks must treat any `planned` or `in-progress` critical control as a hard blocker; do not substitute a missing artifact with a placeholder evidence row.
 
 ## Evidence Entries
 
@@ -31,10 +32,11 @@
 | --- | --- | --- | --- |
 | CTRL-BY-02 | Runbook procedure for access/correction/deletion or stop-processing requests | backend + hr-ops | Before any public subject-rights workflow or production readiness review |
 | CTRL-RU-03 | Runbook/ticket workflow for data-subject requests under 152-ФЗ | backend + hr-ops | Before any production readiness review |
-| CTRL-RU-04 | Infra/data-residency ADR and deployment evidence for RU localization | architect + devops | Before storing production RU citizen data |
-| CTRL-RU-06 | ISPDn class checklist and attestation pack | security + business-analyst | Before first production release |
+| CTRL-RU-04 | Infra/data-residency ADR and deployment evidence for RU localization | architect + devops | Before storing production RU citizen data; blocks EPIC-13 pre-prod and production release until the gap is replaced by real evidence |
+| CTRL-RU-06 | ISPDn class checklist and attestation pack | security + business-analyst | Before first production release; blocks EPIC-13 pre-prod and production release until the pack exists as a real evidence artifact |
 
 ## Usage Rules
 - Use this registry together with `docs/project/legal-controls-matrix.md`; do not treat it as a substitute for legal review.
 - When a verification command changes, update the matching `Evidence ID` row in the same change.
 - When an artifact path is removed or renamed, either replace the evidence with a new real artifact or move the control back to a gap state.
+- The EPIC-13 release checklist must reference the current gap rows for `CTRL-RU-04` and `CTRL-RU-06`; these rows are blockers, not waivers.

--- a/docs/project/legal-controls-matrix.md
+++ b/docs/project/legal-controls-matrix.md
@@ -1,7 +1,7 @@
 # Legal Controls Matrix (Belarus + Russia)
 
 ## Last Updated
-- Date: 2026-03-09
+- Date: 2026-03-19
 - Updated by: business-analyst + architect + backend-engineer
 
 ## Status Legend
@@ -40,10 +40,14 @@
 
 ## Delivery Gate
 - Current stage delivery target is local runtime on the current device; production launch is not in scope for this stage.
-- Development environment is non-blocking for controls in `planned` or `in-progress` status.
-- Current repo-backed controls (`CTRL-BY-03`, `CTRL-RU-02`, `CTRL-RU-05`) can be treated as `implemented`, but none are `verified` yet.
-- Production release is blocked until all critical controls (`CTRL-BY-03`, `CTRL-RU-02`, `CTRL-RU-04`, `CTRL-RU-05`, `CTRL-RU-06`) reach at least `implemented`.
-- Production release is additionally blocked until legal sign-off confirms `verified` status and attached evidence for critical controls.
+- `docs/operations/release-checklist.md` is the canonical EPIC-13 pre-prod/production gate.
+- Development environment is non-blocking for controls in `planned` or `in-progress` status, but those states remain release blockers for EPIC-13.
+- Current repo-backed critical controls are:
+  - `implemented`: `CTRL-BY-03`, `CTRL-RU-02`, `CTRL-RU-05`
+  - `planned` gap: `CTRL-RU-04`, `CTRL-RU-06`
+- Pre-prod promotion requires all critical controls to be at least `implemented`, with current evidence rows and verification commands recorded in `docs/project/evidence-registry.md`.
+- Production release additionally requires legal/security sign-off, `verified` status for the implemented critical controls, and explicit closure of the `CTRL-RU-04` and `CTRL-RU-06` evidence gaps.
+- Any critical control that remains `planned` or `in-progress` is a hard blocker for both pre-prod and production release.
 - Execution tracking for this matrix is formalized under `EPIC-13` in:
   - `TASK-13-01` (article-level mapping),
   - `TASK-13-02` (evidence ownership model),

--- a/docs/project/tasks.md
+++ b/docs/project/tasks.md
@@ -2,7 +2,7 @@
 
 ## Last Updated
 - Date: 2026-03-19
-- Updated by: coordinator + backend-engineer
+- Updated by: coordinator + business-analyst + backend-engineer
 
 ## Priority Model
 - `P0`: critical for Phase 1 core delivery.
@@ -60,6 +60,7 @@
 | TASK-10-03 | done/closed | Merged in `main` via PR #122 with admin-only `GET /api/v1/audit/events` query API, `audit:read` RBAC permission, unit/integration coverage, updated OpenAPI freeze, and refreshed frontend generated types |
 | TASK-10-04 | done/closed | GitHub issue #99 closed; merged in `main` via PR #124 (`7a5ca87`) with controlled audit evidence export (`/api/v1/audit/events/export`) in CSV/JSONL/XLSX and KPI snapshot export (`/api/v1/reporting/kpi-snapshots/export`) attachments plus updated docs/diagrams and regenerated OpenAPI/frontend types |
 | ADMIN-05 | done/closed | GitHub issue #87 closed; merged in `main` via PR #135 (`3eca7a1`) with a frontend-first admin observability dashboard on `/admin/observability` that reuses `/health`, audit preview, CV parsing status, and match-score status contracts. |
+| TASK-13-03 | done/closed | Repo-backed release-gate compliance checklist now makes EPIC-13 pre-prod and production sign-off explicit, with current critical controls, evidence IDs, verification commands, legal/security preconditions, and blocker states captured in the docs set. |
 | COMPLIANCE-01 | planned | EPIC-13 article-level legal mapping and evidence pack track |
 
 ## 2026-03-12 Delivery Control Notes
@@ -83,7 +84,8 @@
 - `TASK-04-04` post-merge closeout is complete: the low-confidence fallback slice is merged in `main` via PR #109 (`c60b48b`), and this backlog snapshot is synchronized to the merged state while keeping the existing route tree and runtime topology unchanged.
 - `TASK-04-06` post-merge closeout is complete: GitHub issue `#92` was already closed before PR #111 (`eedcc0f`) merged, and this backlog snapshot is synchronized to the merged `main` state after verifying issue state, PR merge, and branch cleanup.
 - Scoring explainability (`TASK-04-05`) and the additive quality harness (`TASK-04-06`) are now implemented in repo without changing runtime routes, lifecycle states, or public scoring contracts.
-- The compliance follow-on slice (`TASK-13-01/02`) is now implemented in repo as documentation and evidence-model work only; no runtime/API/routing changes were introduced.
+- The compliance follow-on slices (`TASK-13-01/02`) are now implemented in repo as documentation and evidence-model work only; no runtime/API/routing changes were introduced.
+- `TASK-13-03` is now implemented in repo as a docs/process-only release gate; no runtime/API/routing changes were introduced.
 - The dedicated planning pass for `TASK-11-08` is implemented in repo as one backend+frontend interview slice without reopening auth, CORS, or the public candidate transport model.
 - Interview planning and Google Calendar sync baseline (`TASK-05-01/02`) are now implemented in repo; remaining interview backlog starts after the already-landed scheduling/registration and fairness slices.
 - The structured interview feedback and fairness gate slice (`TASK-05-03/04`) is now implemented in repo on top of the scheduling baseline, without reopening auth, CORS, route topology, or candidate transport.
@@ -130,20 +132,19 @@
 
 ## Normalized Open Backlog Snapshot
 
-- Normalized open backlog count: `3` tasks.
+- Normalized open backlog count: `2` tasks.
 - This count excludes tasks already implemented in repo but retained in the historical planning tables below for lineage.
 - Repo backlog state now excludes `TASK-12-02`, and GitHub issue `#85` is closed following PR #105 (`a67bb8c`).
 - Repo backlog state now excludes `TASK-10-04`, and GitHub issue `#99` is closed following PR #124 (`7a5ca87`).
-- Issue `#58` remains an umbrella `COMPLIANCE-01` tracking issue and is not included in the normalized `3`-task count.
+- Issue `#58` remains an umbrella `COMPLIANCE-01` tracking issue and is not included in the normalized `2`-task count.
 - Current open backlog by delivery wave:
-  - Wave 2 platform/ops/reporting: `TASK-13-03`, `TASK-13-04`
+  - Wave 2 platform/ops/reporting: `TASK-13-04`
   - Wave 3 phase-2 workspaces: `TASK-11-12`
 
 | Order | Task ID | Why Now |
 | --- | --- | --- |
-| 1 | TASK-13-03 | Release-gate compliance checklist is needed before any production sign-off. |
-| 2 | TASK-13-04 | Evidence package and sign-off workflow complete the compliance gate. |
-| 3 | TASK-11-12 | Phase-2 role workspaces bundle the remaining user-facing surfaces. |
+| 1 | TASK-13-04 | Evidence package and sign-off workflow complete the compliance gate. |
+| 2 | TASK-11-12 | Phase-2 role workspaces bundle the remaining user-facing surfaces. |
 
 - Execution rule for follow-on interview work: keep the implemented `/` and `/candidate?interviewToken=...` topology, candidate-auth exclusion, and token-based public transport unchanged unless a separate ADR reopens that scope.
 
@@ -317,7 +318,7 @@ Use this queue together with the global queue when planning phase implementation
 
 ## Milestone Cut Suggestion
 - `M1` (Phase 1 MVP): infra/security + ADMIN-01/02/03 + candidate CV intake/parsing/normalization + candidate self-service upload/tracking + HR vacancy/pipeline workspace baseline + RU/EN critical flows + browser smoke.
-- `M2` (Immediate post-baseline slice): `TASK-04-01/02/03 + TASK-11-07` as one scoring/shortlist-review deliverable, with `TASK-11-10` and `TASK-13-01/02` proceeding immediately after or in parallel.
+- `M2` (Immediate post-baseline slice): `TASK-04-01/02/03 + TASK-11-07` as one scoring/shortlist-review deliverable, with `TASK-11-10` and `TASK-13-01/02/03` proceeding immediately after or in parallel.
 - `M2` planning gate: completed in `docs/project/interview-planning-pass.md`; use that document as the baseline for interview scheduling/registration implementation.
 - `M3` (Phase 2 core): interview scheduling/fairness controls + offer-to-hire + onboarding workflows + phase-2 role workspace baseline.
 - `M4` (Phase 2 expansion): manager/leader/accountant rollout + reporting exports + notification optimization + final legal sign-off package.

--- a/docs/testing/strategy.md
+++ b/docs/testing/strategy.md
@@ -105,6 +105,17 @@ apps/backend/tests/
 | Refactor | Unit non-regression + integration non-regression |
 | Runtime/Platform | Compose config validation + deterministic smoke cycle (`up -> smoke`, `down -> up -> smoke`) |
 
+## EPIC-13 Release-Gate Verification
+- Use this check set when the release-gate documentation or compliance mappings change:
+  - `./scripts/check-docs-structure.sh`
+  - `git diff --check`
+  - `rg -n "CTRL-BY-03|CTRL-RU-02|CTRL-RU-04|CTRL-RU-05|CTRL-RU-06" docs/project/legal-controls-matrix.md docs/project/evidence-registry.md docs/operations/release-checklist.md docs/operations/runbook.md docs/project/tasks.md`
+- Acceptance criteria for the check set:
+  - the release checklist names the pre-prod and production gate thresholds;
+  - the checklist names owners, evidence IDs, verification sources, sign-off prerequisites, and release blockers for all critical controls;
+  - `CTRL-RU-04` and `CTRL-RU-06` remain explicit blockers until real evidence artifacts exist;
+  - no control is upgraded from `planned`/`in-progress` to `implemented` or `verified` without a matching evidence-row update.
+
 ## Phase 1 Baseline Merge Gate
 - Use this exact acceptance set before merging the current local baseline slice:
   - `./scripts/check-docs-structure.sh`


### PR DESCRIPTION
## Summary
- Add an EPIC-13 release gate checklist that distinguishes pre-prod vs production thresholds for the critical legal controls.
- Make the current blockers explicit: `CTRL-RU-04` and `CTRL-RU-06` stay hard gaps until real evidence artifacts exist.
- Sync the legal controls matrix, evidence registry, runbook, testing strategy, and backlog snapshot so the gate is repo-backed and reviewable.

## Linked Tasks
- TASK-13-03
- Closes #61

## Verification
- [x] `./scripts/check-docs-structure.sh`
- [x] `git diff --check`
- [x] `rg -n 'CTRL-BY-03|CTRL-RU-02|CTRL-RU-04|CTRL-RU-05|CTRL-RU-06' docs/project/legal-controls-matrix.md docs/project/evidence-registry.md docs/operations/release-checklist.md docs/operations/runbook.md docs/project/tasks.md`

## Definition of Done
- [x] Acceptance criteria for linked TASK-* are met.
- [x] Documentation updated in the same PR.
- [x] Security/compliance impact assessed.
- [x] No runtime/API/routing changes were introduced.
- [ ] Tests updated for new/changed behavior (N/A for docs-only gate change).
- [ ] Architecture/flow changes reflected in `docs/architecture/diagrams.md` (N/A for docs-only gate change).

## Risks and Follow-ups
- Risk: `CTRL-RU-04` and `CTRL-RU-06` remain release blockers until real artifacts exist.
- Follow-up: complete `TASK-13-04` with the production legal evidence package and sign-off workflow.
