### PR TITLE
docs(compliance): implement CTRL-BY-02 runbook evidence

### DIFF
--- a/docs/operations/release-checklist.md
+++ b/docs/operations/release-checklist.md
@@ -18,7 +18,7 @@
 
 ## Known Blocking Controls
 - `CTRL-BY-01` is in-progress and blocks pre-prod/production until it is `verified`.
-- `CTRL-BY-02` is planned and blocks pre-prod/production until the runbook procedure exists and is `verified`.
+- `CTRL-BY-02` is implemented; it no longer blocks pre-prod, but production release still requires `verified` status.
 - `CTRL-BY-03` is implemented, but production release still requires `verified` status and refreshed evidence plus legal/security sign-off.
 
 ## Required Package Attachments
@@ -26,7 +26,7 @@
   - the current `docs/project/legal-controls-matrix.md`;
   - the current `docs/project/evidence-registry.md`;
   - the current `docs/project/production-legal-evidence-package.md`;
-  - the release-candidate outputs for `EVID-001`, `EVID-002`, `EVID-003`, `EVID-004`, and `EVID-006` as applicable.
+  - the release-candidate outputs for `EVID-001`, `EVID-002`, `EVID-003`, `EVID-004`, `EVID-006`, and `EVID-007` as applicable.
 - External / non-repo inputs:
   - legal sign-off record;
   - security sign-off record.
@@ -42,7 +42,7 @@
 | Control ID | Current status | Required threshold | Owner | Evidence IDs | Verification source/command | Sign-off prerequisite | Blocker if planned/in-progress |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | CTRL-BY-01 | in-progress | Pre-prod: `implemented`; production: `verified` | business-analyst + frontend | `EVID-002`, `EVID-003` | `./scripts/check-openapi-freeze.sh`, `npm --prefix apps/frontend run api:types:check`, frontend tests | Legal sign-off must confirm consent and purpose-bound contracts | Blocks both gates while the control remains `planned` or `in-progress` |
-| CTRL-BY-02 | planned | Pre-prod: `implemented`; production: `verified` | backend + hr-ops | none (gap) | No current in-repo command; release stays blocked until a runbook procedure exists and is registered | Legal sign-off requires the subject-rights runbook to exist | Blocks both gates while the control remains `planned` or `in-progress` |
+| CTRL-BY-02 | implemented | Pre-prod: `implemented`; production: `verified` | backend + hr-ops | `EVID-007` | Runbook review for owner/SLA and log template | Legal sign-off must confirm the subject-rights runbook and SLA | Blocks production until the control is `verified` |
 | CTRL-BY-03 | implemented | Pre-prod: `implemented`; production: `verified` | architect + backend + devops | `EVID-001`, `EVID-004`, `EVID-006` | `EVID-001` backend security/auth tests, `EVID-004` compose smoke, `EVID-006` docs/config review | Legal/security sign-off must confirm RBAC, immutable audit events, storage baseline, and smoke evidence are current | Blocks both gates until the control is at least `implemented` with current evidence |
 
 ## Release Preconditions

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -64,6 +64,33 @@ Shortcut wrappers:
   - Example:
     `curl -H "Authorization: Bearer <token>" "http://localhost:8000/api/v1/reporting/kpi-snapshots/export?period_month=2026-03-01&format=xlsx" -o kpi-snapshot-2026-03.xlsx`
 
+### Subject Rights Requests (CTRL-BY-02)
+- Owner: backend + hr-ops, with legal consulted for refusals or retention exceptions.
+- SLA acknowledgement: within 3 business days of intake.
+- SLA completion: within 30 calendar days from identity verification date; extensions require legal approval and must be logged.
+- Intake: written request to the HR/ops contact; record the intake channel and timestamp.
+
+#### Workflow
+1. Register the request in the subject-rights log using the template below.
+2. Verify requester identity against existing staff/candidate records before disclosing any data.
+3. Classify the request type: access, correction, deletion, or stop-processing.
+4. Enumerate data sources in scope: primary database records, stored documents (MinIO), and audit events.
+5. Execute the action or record the legal basis for refusal or partial fulfillment.
+6. Respond in writing with the action taken, scope covered, and completion date.
+
+#### Subject-Rights Log Template
+- Request ID
+- Intake timestamp
+- Intake channel
+- Requester name and identifiers used for verification
+- Verification date
+- Request type
+- Data sources reviewed
+- Action taken or refusal basis
+- Response date
+- SLA due date
+- Owner
+
 Runtime auth/browser integration settings:
 - Frontend browser API base URL: `VITE_API_BASE_URL` (compose default: `http://localhost:8000`).
 - Frontend Sentry envs:
@@ -445,7 +472,7 @@ Assumption: release-specific evidence outputs and legal/security approvals are a
 - `docs/project/production-legal-evidence-package.md` is the canonical package manifest for repo-backed evidence, external attachments, freshness rules, and sign-off sequencing.
 - Pre-prod promotion is blocked if any critical control in `docs/project/legal-controls-matrix.md` remains `planned` or `in-progress`.
 - Production release is blocked unless every critical control is `verified` and legal/security sign-off records the refreshed evidence IDs.
-- The current hard blockers are `CTRL-BY-01` (in-progress) and `CTRL-BY-02` (planned); production release also remains blocked until `CTRL-BY-03` is verified and signed off.
+- The current hard blockers are `CTRL-BY-01` (in-progress) and `CTRL-BY-02` (implemented but unverified); production release also remains blocked until `CTRL-BY-03` is verified and signed off.
 
 ### Production Sign-Off Handling
 1. Freeze the release candidate commit/tag before collecting approval evidence.

--- a/docs/project/evidence-registry.md
+++ b/docs/project/evidence-registry.md
@@ -23,18 +23,17 @@
 | EVID-003 | CTRL-BY-01 | frontend-engineer | `apps/frontend/src/pages/CandidatePage.tsx`, `apps/frontend/src/pages/LoginPage.tsx`, `apps/frontend/src/api/auth.ts` | `npm --prefix apps/frontend run test -- --run src/pages/CandidatePage.test.tsx src/pages/LoginPage.test.tsx src/api/auth.test.ts` | Any field added/removed on login or candidate-apply flows |
 | EVID-004 | CTRL-BY-03 | qa-engineer + devops-engineer | `./scripts/smoke-compose.sh`, `scripts/browser_auth_smoke.py`, `scripts/browser_candidate_apply_smoke.py` | `docker compose up -d --build`, `./scripts/smoke-compose.sh` | Any compose topology, critical browser flow, or CORS/runtime change |
 | EVID-006 | CTRL-BY-03 | devops-engineer + backend-engineer | `.env.example`, `docker-compose.yml`, `docs/operations/runbook.md` | `./scripts/check-docs-structure.sh`, compose config review, `./scripts/smoke-compose.sh` | Any object-storage, encryption, compose env, or runbook change |
+| EVID-007 | CTRL-BY-02 | backend + hr-ops | `docs/operations/runbook.md` (Subject Rights Requests section) | `./scripts/check-docs-structure.sh`, runbook review for owner/SLA and log template | Any change to subject-rights workflow, SLA, intake channel, or owner |
 
 ## Coverage Gaps (No Current Evidence Artifact)
-
-| Control ID | Missing Artifact | Owner | Due Trigger |
-| --- | --- | --- | --- |
-| CTRL-BY-02 | Runbook procedure for access/correction/deletion or stop-processing requests | backend + hr-ops | Before any public subject-rights workflow or production readiness review |
+- None. All critical controls have repo-backed evidence artifacts registered above.
 
 ## Production Package Scope (TASK-13-04)
 - Canonical package manifest: `docs/project/production-legal-evidence-package.md`.
 - Repo-backed critical-control evidence available today:
   - `CTRL-BY-03`: `EVID-001`, `EVID-004`, `EVID-006`
   - `CTRL-BY-01`: `EVID-002`, `EVID-003`
+  - `CTRL-BY-02`: `EVID-007`
 - Non-repo approvals and missing-gap attachments must stay outside this registry until they exist as real artifacts; do not create synthetic evidence rows for missing artifacts.
 
 ## Usage Rules

--- a/docs/project/legal-controls-matrix.md
+++ b/docs/project/legal-controls-matrix.md
@@ -16,7 +16,7 @@
 | Jurisdiction | NPA / Article | Obligation (short) | Control ID | Product/Process Control | Owner | Status | Evidence |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Belarus | Law No. 99-З (2021), Art. 5 | Obtain informed consent and limit consent payload to declared purposes | CTRL-BY-01 | Candidate/staff data collection uses explicit field contracts and frozen API payloads; separate purpose registry still missing | business-analyst + frontend | in-progress | `EVID-002`, `EVID-003` |
-| Belarus | Law No. 99-З (2021), Arts. 11, 13 | Support access, correction, and deletion/stop-processing requests | CTRL-BY-02 | Runbook workflow and owner model for subject requests | backend + hr-ops | planned | Coverage gap (see `docs/project/evidence-registry.md`) |
+| Belarus | Law No. 99-З (2021), Arts. 11, 13 | Support access, correction, and deletion/stop-processing requests | CTRL-BY-02 | Runbook workflow and owner model for subject requests | backend + hr-ops | implemented | `EVID-007` |
 | Belarus | Law No. 99-З (2021), Art. 17; Law No. 455-З (2008), Art. 17 | Protect restricted/personal information with legal, organizational, and technical measures | CTRL-BY-03 | RBAC, immutable audit events, object-storage protection baseline, and reproducible smoke verification | architect + backend + devops | implemented | `EVID-001`, `EVID-004`, `EVID-006` |
 
 ## Control Detail (Obligation -> Control -> Evidence)
@@ -24,7 +24,7 @@
 | Control ID | Obligation Detail | Technical/Process Control | Evidence Baseline | Verification Baseline |
 | --- | --- | --- | --- | --- |
 | CTRL-BY-01 | Consent must be informed and field scope limited to declared purposes | Candidate apply/login payloads stay frozen through OpenAPI and typed frontend forms | `EVID-002`, `EVID-003` | `./scripts/check-openapi-freeze.sh`, `npm --prefix apps/frontend run api:types:check`, frontend tests |
-| CTRL-BY-02 | Subject must be able to request access/correction/deletion or stop-processing | Runbook procedure + owner/SLA workflow | No current evidence artifact | To implement under future request-handling slice |
+| CTRL-BY-02 | Subject must be able to request access/correction/deletion or stop-processing | Runbook procedure + owner/SLA workflow | `EVID-007` | Runbook review for owner/SLA and log template |
 | CTRL-BY-03 | Personal/restricted information must be protected against unauthorized actions | RBAC enforcement, immutable audit events, storage/security baseline, smoke verification | `EVID-001`, `EVID-004`, `EVID-006` | backend security/auth tests, compose smoke, config review |
 
 ## Delivery Gate
@@ -33,11 +33,10 @@
 - `docs/project/production-legal-evidence-package.md` is the canonical repo-backed production sign-off manifest for current evidence, external attachments, blockers, and `verified` exit criteria.
 - Development environment is non-blocking for controls in `planned` or `in-progress` status, but those states remain release blockers for EPIC-13.
 - Current repo-backed critical controls are:
-  - `implemented`: `CTRL-BY-03`
+  - `implemented`: `CTRL-BY-03`, `CTRL-BY-02`
   - `in-progress`: `CTRL-BY-01`
-  - `planned` gap: `CTRL-BY-02`
 - Pre-prod promotion requires all critical controls to be at least `implemented`, with current evidence rows and verification commands recorded in `docs/project/evidence-registry.md`.
-- Production release additionally requires legal/security sign-off, `verified` status for the implemented critical controls, and explicit closure of the remaining `CTRL-BY-01` and `CTRL-BY-02` gaps.
+- Production release additionally requires legal/security sign-off, `verified` status for the implemented critical controls, and explicit closure of the remaining `CTRL-BY-01` gap.
 - `CTRL-BY-03` stays `implemented` until the package manifest shows fresh release-candidate evidence plus non-repo legal/security approvals for the same release candidate.
 - Any critical control that remains `planned` or `in-progress` is a hard blocker for both pre-prod and production release.
 - Execution tracking for this matrix is formalized under `EPIC-13` in:

--- a/docs/project/production-legal-evidence-package.md
+++ b/docs/project/production-legal-evidence-package.md
@@ -23,7 +23,7 @@
 | Control ID | Current Status | Already Evidenced in Repo | Still Needs External / Non-Repo Attachment | Blocking Production Now | Required to Move to `verified` |
 | --- | --- | --- | --- | --- | --- |
 | CTRL-BY-01 | `in-progress` | `EVID-002`, `EVID-003` | Legal sign-off record referencing the current release candidate | Yes. The control is not yet `verified`. | Attach legal sign-off for the same release candidate, then update the control status to `verified`. |
-| CTRL-BY-02 | `planned` | No current evidence artifact in repo | Runbook procedure for subject requests plus legal sign-off record | Yes. The control remains a blocker while no real artifact exists. | Create the runbook procedure, register it in the repo, attach legal sign-off, then update the control status. |
+| CTRL-BY-02 | `implemented` | `EVID-007` | Legal sign-off record referencing the current release candidate | Yes. The control is not yet `verified`. | Attach legal sign-off for the same release candidate, then update the control status to `verified`. |
 | CTRL-BY-03 | `implemented` | `EVID-001`, `EVID-004`, `EVID-006` | Security sign-off record referencing the current release candidate and refreshed evidence outputs; legal release acknowledgment referencing the same package | Yes. The control is not yet `verified`. | Re-run the listed evidence on the exact production candidate, attach results, record legal/security sign-off, then update the matrix/registry status in repo. |
 
 ## Repo-Backed Package Inputs Available Today
@@ -35,6 +35,7 @@
 | `EVID-003` | `CTRL-BY-01` | `docs/project/evidence-registry.md` | Frontend consent/contract UI evidence already defined in repo | Re-run the listed frontend tests on the exact release candidate and attach the output |
 | `EVID-004` | `CTRL-BY-03` | `docs/project/evidence-registry.md` | Compose/browser smoke baseline already defined in repo | Re-run compose/browser smoke on the exact release candidate and attach the results |
 | `EVID-006` | `CTRL-BY-03` | `docs/project/evidence-registry.md` | Config/runbook/object-storage baseline already defined in repo | Refresh the config review against the exact release candidate docs/config set and attach the review note |
+| `EVID-007` | `CTRL-BY-02` | `docs/project/evidence-registry.md` | Subject-rights runbook procedure and owner/SLA log template | Review the runbook section against the exact release candidate and attach the review note |
 | Control/status manifest | All critical controls | `docs/project/legal-controls-matrix.md` | Shows current control status and prevents silent status upgrades | Refresh in repo if any evidence row or control status changes |
 | Package manifest | All critical controls | `docs/project/production-legal-evidence-package.md` | Keeps repo-backed evidence, external attachments, blockers, and verified-exit criteria aligned | Refresh in repo whenever package composition, blocker state, or sign-off rules change |
 
@@ -47,13 +48,13 @@
 
 ## Production Blockers Right Now
 - `CTRL-BY-01` is `in-progress`; production release remains blocked until it is `verified`.
-- `CTRL-BY-02` is `planned` with no evidence artifact; production release remains blocked until a runbook procedure exists and is verified.
+- `CTRL-BY-02` is `implemented`; production release remains blocked until it is `verified`.
 - `CTRL-BY-03` is `implemented`; it still needs fresh release-candidate evidence attachments plus legal/security sign-off before it can move to `verified`.
 - No blocker may be converted into a waiver by adding a placeholder row or a synthetic attachment reference.
 
 ## Evidence Freshness Rules
 - Every attached output or approval must name the exact release candidate commit SHA or tag proposed for production.
-- Evidence outputs for `EVID-001`, `EVID-002`, `EVID-003`, `EVID-004`, and `EVID-006` must be refreshed after any matching `Update Trigger` in `docs/project/evidence-registry.md` fires.
+- Evidence outputs for `EVID-001`, `EVID-002`, `EVID-003`, `EVID-004`, `EVID-006`, and `EVID-007` must be refreshed after any matching `Update Trigger` in `docs/project/evidence-registry.md` fires.
 - For production sign-off, attached evidence outputs must be generated no more than `7` calendar days before the approval date and after the latest change to the release candidate.
 - External legal/security approvals expire immediately if the release candidate, the referenced evidence ID set, or the blocking-gap state changes.
 - `CTRL-BY-01` and `CTRL-BY-02` stay blocking until they are `verified`.

--- a/docs/project/tasks.md
+++ b/docs/project/tasks.md
@@ -67,7 +67,7 @@
 | ADMIN-05 | done/closed | GitHub issue #87 closed; merged in `main` via PR #135 (`3eca7a1`) with a frontend-first admin observability dashboard on `/admin/observability` that reuses `/health`, audit preview, CV parsing status, and match-score status contracts. |
 | TASK-13-03 | done/closed | Repo-backed release-gate compliance checklist now makes EPIC-13 pre-prod and production sign-off explicit, with current critical controls, evidence IDs, verification commands, legal/security preconditions, and blocker states captured in the docs set. |
 | TASK-13-04 | done/closed | GitHub issue #62 is linked to PR #138; the repo-backed production legal evidence package now defines sign-off workflow, required attachments, evidence freshness rules, blocker handling, and `verified` exit criteria for critical controls without adding runtime/API changes. |
-| COMPLIANCE-01 | in-progress/belarus-only | EPIC-13 umbrella tracking issue for repo normalization; no runtime scope; Russia jurisdiction de-scoped via ADR-0059; Belarus controls now define the compliance gate (`CTRL-BY-01` in-progress, `CTRL-BY-02` planned) |
+| COMPLIANCE-01 | in-progress/belarus-only | EPIC-13 umbrella tracking issue for repo normalization; no runtime scope; Russia jurisdiction de-scoped via ADR-0059; Belarus controls now define the compliance gate (`CTRL-BY-01` in-progress, `CTRL-BY-02` implemented via `EVID-007`) |
 
 ## 2026-03-12 Delivery Control Notes
 - `TASK-12-01` containerized platform baseline is already implemented in repo: `docker compose config`, `docker compose up -d --build`, and `./scripts/smoke-compose.sh` pass against the current stack, and CI reuses the same compose browser smoke baseline.
@@ -157,7 +157,7 @@
   - `TASK-05-01/02`
   - `TASK-11-05/06/07/08/09`
   - `TASK-13-01/02`
-- `COMPLIANCE-01` stays open until `CTRL-BY-01` is implemented and `CTRL-BY-02` has a real runbook evidence artifact.
+- `COMPLIANCE-01` stays open until `CTRL-BY-01` is implemented and `CTRL-BY-02` is `verified` (legal sign-off attached).
 - P1:
   - `TASK-03-08`
   - `TASK-06-01/02/03/04`
@@ -176,7 +176,6 @@
 - P0:
   - `#58` `COMPLIANCE-01`
 - P1:
-  - `#144` `CTRL-BY-02` subject-rights request workflow and owner/SLA
   - `#146` final PD retention windows by data class
   - `#147` break-glass procedure and reviewer roster
   - RU-scope issues `#142`, `#143`, and `#145` should be closed as de-scoped after ADR-0059.


### PR DESCRIPTION
## Summary\n- add subject-rights request runbook with owner/SLA and log template\n- register EVID-007 and mark CTRL-BY-02 implemented\n- align compliance docs (matrix, evidence registry, release checklist, production package, tasks)\n\n## Testing\n- ./scripts/check-docs-structure.sh\n- git diff --check\n\n## Issues\nCloses #144\n\n## Architecture Review (Self)\n- Docs-only change; no architecture or data-flow updates required.\n- Diagram updates not required.\n