### PR TITLE
Finalize PD retention windows policy

### DIFF
--- a/docs/operations/release-checklist.md
+++ b/docs/operations/release-checklist.md
@@ -50,6 +50,7 @@
 - Do not promote to production if any critical control is not `verified`.
 - Do not claim legal/security sign-off unless the evidence IDs above are current and the Belarus controls are verified.
 - Keep this document aligned with `docs/project/legal-controls-matrix.md`, `docs/project/evidence-registry.md`, `docs/operations/runbook.md`, and `docs/testing/strategy.md` in the same change set.
+- Data Retention Policy is approved and current; see `docs/operations/runbook.md` (Data Retention Policy).
 
 ## Sign-Off Workflow
 1. Freeze the production release candidate commit/tag.

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -427,22 +427,27 @@ Runtime auth/browser integration settings:
   5. For register failures with revoked keys, confirm `employee_registration_keys.revoked_at` is not null.
 
 ## Compliance Baseline (Dev Non-Blocking, Prod Blocking)
-This section defines provisional operational controls until final legal/security sign-off.
+This section defines operational controls; the data retention policy below is approved as of 2026-03-23, while remaining controls stay provisional until final legal/security sign-off.
 
 EPIC-13 release gating and sign-off requirements live in `docs/operations/release-checklist.md`.
 The canonical production evidence manifest lives in `docs/project/production-legal-evidence-package.md`.
 Assumption: release-specific evidence outputs and legal/security approvals are attached to the release ticket or PR, while the repo keeps the manifest and blocker logic.
 
-### Data Retention Policy (Provisional)
+### Data Retention Policy (Approved)
+
+- Approval: 2026-03-23 (business-analyst + legal).
 
 | Data Class | Storage | Retention Window | Disposal Strategy | Owner |
 | --- | --- | --- | --- | --- |
 | Auth denylist keys (`jti`, `sid`) | Redis | TTL-bound to token/session validity window | Auto-expire via Redis TTL | backend |
-| Audit events (`audit_events`) | PostgreSQL | 365 days hot storage | Archive then purge by approved retention job | backend + devops |
+| Audit events (`audit_events`) | PostgreSQL | 36 months total (12 months hot + 24 months archive) | Archive then purge by approved retention job | backend + devops |
 | Application logs | Container/log backend | 90 days | Rotation + purge | devops |
-| Candidate CV/documents | Object storage | 24 months after workflow closure (provisional) | Delete object + metadata tombstone | hr-ops + backend |
-
-- TODO(owner: business-analyst + legal, due_trigger: before first production release): approve final retention windows for each PD category.
+| Candidate personal data (profiles, applications, pipeline, parsed CV artifacts) | PostgreSQL | 24 months after workflow closure (non-hire); if hired, follow employee personal data window | Pseudonymize then purge rows after retention expiry | hr-ops + backend |
+| Candidate CV/documents | Object storage | 24 months after workflow closure (non-hire); if hired, follow employee personal data window | Delete object + metadata tombstone | hr-ops + backend |
+| Interview evaluations (`interview_feedback`) | PostgreSQL | 24 months after hiring decision or workflow closure | Purge rows after retention expiry | hr-ops + backend |
+| HR records (vacancies, offers, pipeline transitions, hire conversions) | PostgreSQL | 5 years after vacancy closure or employment termination (whichever is later) | Archive then purge | hr-ops + backend |
+| Employee personal data (employee profiles, onboarding runs/tasks) | PostgreSQL | 7 years after employment termination | Archive then purge | hr-ops + backend |
+| Accounting exports (CSV/XLSX attachments) | Object storage (export attachments) | 10 years after export creation | Delete exported attachments + access logs | finance + devops |
 
 ### Encryption Policy (Provisional)
 - In transit:


### PR DESCRIPTION
## Summary\n- Approve final PD retention windows by data class in the runbook.\n- Remove provisional retention TODOs and mark policy as approved.\n- Link the approved retention policy from the release checklist.\n\n## Testing\n- ./scripts/check-docs-structure.sh\n- git diff --check\n- rg -n "Data Retention Policy|provisional|retention windows|#146" docs/operations/runbook.md docs/operations/release-checklist.md docs/project/tasks.md\n\n## Follow-ups\n- After merge: remove #146 from docs/project/tasks.md (per task requirement to update tasks list post-merge).